### PR TITLE
fix coding standards in DICBuilder

### DIFF
--- a/src/Elasticsearch/Common/DICBuilder.php
+++ b/src/Elasticsearch/Common/DICBuilder.php
@@ -149,7 +149,7 @@ class DICBuilder
     private function setNonSharedDICObjects()
     {
         $this->setConnectionObj();
-        $this-> setConnectionFactoryObj();
+        $this->setConnectionFactoryObj();
         $this->setSelectorObj();
         $this->setSerializerObj();
         $this->setConnectionPoolObj();


### PR DESCRIPTION
IDE was moaning about the trailing space. :thumbsup: 
