### PR TITLE
Loosen version requirement on monolog dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "php": ">=5.3.9",
-    "monolog/monolog": "1.5.0",
+    "monolog/monolog": "~1.5.0",
     "pimple/pimple": "v1.0.2",
     "guzzle/guzzle": "~3.7"
   },


### PR DESCRIPTION
I want to use a handler that was added to Monolog in version 1.6.0, but this project requires 1.5.0 and only 1.5.0. Can we loosen that up with a \* or a ~?
