### PR TITLE
Actually loosen the version requirement for monolog.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "php": ">=5.3.9",
-    "monolog/monolog": "~1.5.0",
+    "monolog/monolog": "~1.5",
     "pimple/pimple": "v1.0.2",
     "guzzle/guzzle": "~3.7"
   },


### PR DESCRIPTION
This fulfills the intention behind 2e2596c7aef56bb07644a73f49814e9d828ae222.
