### PR TITLE
Loosen the Pimple dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "php": ">=5.3.9",
     "monolog/monolog": "~1.5",
-    "pimple/pimple": "v1.0.2",
+    "pimple/pimple": "~1.0",
     "guzzle/guzzle": "~3.7"
   },
   "require-dev": {


### PR DESCRIPTION
Shared libraries should avoid exact match requirements as it would forbid users to use newer version of Pimple (fixing a bug or adding a new feature) until you release a new version changing the constraint
