### PR TITLE
Match function call with function signature

### DIFF
--- a/src/Elasticsearch/Endpoints/Index.php
+++ b/src/Elasticsearch/Endpoints/Index.php
@@ -76,7 +76,7 @@ class Index extends AbstractEndpoint
         }
 
         if ($this->createIfAbsent === true) {
-            $uri .= $this->addCreateFlag($uri);
+            $uri .= $this->addCreateFlag();
         }
 
         return $uri;


### PR DESCRIPTION
Looks like its calling a function that doesn't take a parameter with a parameter.

Commit that added this:
https://github.com/elasticsearch/elasticsearch-php/commit/3dbc951dae6431a13c6792fe82c79557da0bdb8d
