### PR TITLE
Update Pimple dependency to 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "php": ">=5.3.9",
     "monolog/monolog": "~1.5",
-    "pimple/pimple": "~1.0",
+    "pimple/pimple": "~2.0",
     "guzzle/guzzle": "~3.7",
     "psr/log": "~1.0",
     "ext-curl": "*"


### PR DESCRIPTION
This PR updates Pimple to 2.0 as per #84.

Seen as this is just a code change the tests should pass unchanged as far as I can tell, though I'm getting one error!

```
1) SniffingConnectionPoolIntegrationTest::testSniff
Elasticsearch\Common\Exceptions\NoNodesAvailableException: No alive nodes found in your cluster

/Users/mif08/git-projects/elasticsearch-php/src/Elasticsearch/ConnectionPool/SniffingConnectionPool.php:54
/Users/mif08/git-projects/elasticsearch-php/src/Elasticsearch/ConnectionPool/SniffingConnectionPool.php:57
/Users/mif08/git-projects/elasticsearch-php/src/Elasticsearch/Transport.php:126
/Users/mif08/git-projects/elasticsearch-php/src/Elasticsearch/Transport.php:146
/Users/mif08/git-projects/elasticsearch-php/src/Elasticsearch/Endpoints/AbstractEndpoint.php:86
/Users/mif08/git-projects/elasticsearch-php/src/Elasticsearch/Client.php:124
/Users/mif08/git-projects/elasticsearch-php/tests/Elasticsearch/Tests/ConnectionPool/SniffingConnectionPoolIntegrationTest.php:24
/Users/mif08/.composer/vendor/phpunit/phpunit/PHPUnit/TextUI/Command.php:176
/Users/mif08/.composer/vendor/phpunit/phpunit/PHPUnit/TextUI/Command.php:129

FAILURES!
Tests: 443, Assertions: 1065, Errors: 1, Skipped: 5.
```

Any suggestions?

M
