### PR TITLE
Avoid Pimple 2.1 which has some backward compatibility breaks.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "php": ">=5.3.9",
     "monolog/monolog": "~1.5",
-    "pimple/pimple": "~2.0",
+    "pimple/pimple": ">=2.0,<2.1",
     "guzzle/guzzle": "~3.7",
     "psr/log": "~1.0",
     "ext-curl": "*"


### PR DESCRIPTION
The current version constraint allows Pimple 2.1 to be downloaded, which uses namespaces and different class names. Although there is a `class_alias` call which should maintain backward compatibility, it did not work for me, and https://github.com/fabpot/Pimple/issues/127 shows that there are other conditions where it doesn't work.

Upgrading to 2.1 is probably a good idea, but this is simpler for the immediate need.
