### PR TITLE
Changed the guzzle requirement to the HTTP component only

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "php": ">=5.3.9",
     "monolog/monolog": "~1.5",
     "pimple/pimple": "~2.0",
-    "guzzle/guzzle": "~3.7",
+    "guzzle/http": "~3.7",
     "psr/log": "~1.0",
     "ext-curl": "*"
   },


### PR DESCRIPTION
Only the HTTP component is needed, not the full Guzzle3 package. This makes the dependency much smaller
