### PR TITLE
Remove usage of Pimple class with new Pimple\Container class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "php": ">=5.3.9",
     "monolog/monolog": "~1.5",
-    "pimple/pimple": "~2.0",
+    "pimple/pimple": "~2.1",
     "guzzle/http": "~3.7",
     "psr/log": "~1.0",
     "ext-curl": "*"

--- a/src/Elasticsearch/Client.php
+++ b/src/Elasticsearch/Client.php
@@ -41,7 +41,7 @@ class Client
     public $transport;
 
     /**
-     * @var \Pimple
+     * @var \Pimple\Container
      */
     protected $params;
 

--- a/src/Elasticsearch/Common/AbstractFactory.php
+++ b/src/Elasticsearch/Common/AbstractFactory.php
@@ -8,7 +8,7 @@
 namespace Elasticsearch\Common;
 
 
-use Pimple;
+use Pimple\Container as Pimple;
 
 abstract class AbstractFactory
 {

--- a/src/Elasticsearch/Common/DICBuilder.php
+++ b/src/Elasticsearch/Common/DICBuilder.php
@@ -16,12 +16,12 @@ use Elasticsearch\Namespaces\NodesNamespace;
 use Elasticsearch\Namespaces\SnapshotNamespace;
 use Elasticsearch\Transport;
 use Psr\Log;
-use Pimple;
+use Pimple\Container as Pimple;
 
 class DICBuilder
 {
     /**
-     * @var \Pimple
+     * @var Pimple
      */
     private $dic;
 

--- a/src/Elasticsearch/Transport.php
+++ b/src/Elasticsearch/Transport.php
@@ -27,7 +27,7 @@ use Psr\Log\LoggerInterface;
 class Transport
 {
     /**
-     * @var \Pimple
+     * @var \Pimple\Container
      */
     private $params;
 
@@ -63,7 +63,7 @@ class Transport
      * underlying cluster connections
      *
      * @param array                    $hosts  Array of hosts in cluster
-     * @param \Pimple                  $params DIC containing dependencies
+     * @param \Pimple\Container        $params DIC containing dependencies
      * @param \Psr\Log\LoggerInterface $log    Monolog logger object
      *
      * @throws Common\Exceptions\InvalidArgumentException


### PR DESCRIPTION
Pimple 2 has a php-ext available, and if you use that instead of php version, then you get an exception in 
`class_alias('Pimple\Container', 'Pimple');` since Container is no longer a user defined class. 
any usage of \Pimple is removed (Replaced with \Pimple\Container) in this PR. 
