### PR TITLE
Added log permission and bubble to settings

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -113,13 +113,14 @@ $client = new Elasticsearch\Client($params);
 This will enable logging to a file called `elasticsearch.log` inside your project directory.  The default logging level is `WARN`.  This is a logging level
 that only describes important events that should probably require action from you.
 
-Often, you'll want to change the logging location.  To change this location, simply do the following:
+Often, you'll want to change the logging location or set the logs file permissions to group writeable. To change these things, simply do the following:
 
 [source,php]
 ----
 $params = array();
 $params['logging'] = true;
 $params['logPath'] = '/var/logs/elasticsearch/elasticsearch.log';
+$params['logPermission'] = 0664;
 $client = new Elasticsearch\Client($params);
 ----
 {zwsp} +

--- a/src/Elasticsearch/Client.php
+++ b/src/Elasticsearch/Client.php
@@ -1454,7 +1454,9 @@ class Client
         $log       = new Logger('log');
         $handler   = new StreamHandler(
             $this->params['logPath'],
-            $this->params['logLevel']
+            $this->params['logLevel'],
+            $this->params['logBubble'],
+            $this->params['logPermission']
         );
         $processor = new IntrospectionProcessor();
 
@@ -1469,7 +1471,9 @@ class Client
         $trace        = new Logger('trace');
         $traceHandler = new StreamHandler(
             $this->params['tracePath'],
-            $this->params['traceLevel']
+            $this->params['traceLevel'],
+            $this->params['traceBubble'],
+            $this->params['tracePermission']
         );
 
         $trace->pushHandler($traceHandler);

--- a/src/Elasticsearch/Common/DICBuilder.php
+++ b/src/Elasticsearch/Common/DICBuilder.php
@@ -40,9 +40,13 @@ class DICBuilder
         'logObject'             => null,
         'logPath'               => 'elasticsearch.log',
         'logLevel'              => Log\LogLevel::WARNING,
+        'logBubble'             => true,
+        'logPermission'         => null,
         'traceObject'           => null,
         'tracePath'             => 'elasticsearch.log',
         'traceLevel'            => Log\LogLevel::WARNING,
+        'traceBubble'           => true,
+        'tracePermission'       => null,
         'guzzleOptions'         => array(),
         'connectionPoolParams'  => array(
             'randomizeHosts' => true


### PR DESCRIPTION
Simply added `logBubble`, `logPermission`,`traceBubble` and `tracePermission` as configuration setting parameters using the same defaults as `StreamHandler` uses. Updated the documentation a little so usage is clear. 
