### PR TITLE
Documentation error on bulk indexing.

### DIFF
--- a/docs/indexing-operations.asciidoc
+++ b/docs/indexing-operations.asciidoc
@@ -72,10 +72,8 @@ for($i = 0; $i < 100; $i++) {
     );
 
     $params['body'][] = array(
-        'doc' => array(
-            'my_field' => 'my_value',
-            'second_field' => 'some more values'
-        )
+        'my_field' => 'my_value',
+        'second_field' => 'some more values'
     );
 }
 


### PR DESCRIPTION
The example uses the 'doc' parameter on bulk indexing, which is inconsistent with how the bulk API expects JSON documents to be passed in, and is thus incorrect. It essentially puts all the data under a 'doc' property. Only the update action supports the 'doc' parameter.

I struggled with this for quite some time before realizing the problem :)
