### PR TITLE
Add error and status parsing from ES exception

### DIFF
--- a/src/Elasticsearch/Common/Exceptions/BadRequest400Exception.php
+++ b/src/Elasticsearch/Common/Exceptions/BadRequest400Exception.php
@@ -13,4 +13,18 @@ namespace Elasticsearch\Common\Exceptions;
  */
 class BadRequest400Exception extends \Exception implements ElasticsearchException
 {
+    public $status = 400;
+
+    public function __construct($message = "", $code = 0, \Exception $previous = null)
+    {
+        $buffer = json_decode($message, true);
+
+        if (!empty($buffer) && is_array($buffer) && isset($buffer['error']) && isset($buffer['status']))
+        {
+            $this->status   = (int) $buffer['status'];
+            $message        = $buffer['error'];
+        }
+
+        parent::__construct($message, $code, $previous);
+    }
 }


### PR DESCRIPTION
Since ElasticSearch throws JSON encoded exceptions, I think it's a good idea to expose the real error and status instead of the raw message. We could also consider to have a ElasticsearchException class that all exceptions could override.