### PR TITLE
Add JSON_FORCE_OBJECT

### DIFF
--- a/src/Elasticsearch/Serializers/AbstractJsonSerializer.php
+++ b/src/Elasticsearch/Serializers/AbstractJsonSerializer.php
@@ -23,7 +23,7 @@ abstract class AbstractJsonSerializer implements SerializerInterface
      */
     protected static function jsonEncode($value)
     {
-        $result = json_encode($value);
+        $result = json_encode($value, JSON_FORCE_OBJECT);
 
         if (static::hasJsonError()) {
             throw new JsonSerializationError(json_last_error(), $value, $result);


### PR DESCRIPTION
Sometimes ES API doesnt accept [] but only {}. For instance, in aggregation to use global scope.

JSON_FORCE_OBJECT is available from Php 5.3.0

Maybe this should be a parameter?