### PR TITLE
Fix Fatal Errors when using ClientBuilder::defaultLogger()

### DIFF
--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -20,6 +20,9 @@ use GuzzleHttp\Ring\Client\Middleware;
 use GuzzleHttp\Ring\Core;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Processor\IntrospectionProcessor;
 
 class ClientBuilder
 {


### PR DESCRIPTION
When enabling the logger as described [in the docs](http://www.elastic.co/guide/en/elasticsearch/client/php-api/2.0/_configuration.html#enabling_logger), Fatal Errors are thrown.

This seems to be due to missing `use` statements for the following classes used within the `ClientBuilder::defaultLogger()` method

-  `Monolog\Logger`
-  `Monolog\Handler\StreamHandler`
-  `Monolog\Processor\IntrospectionProcessor`

This patch adds the missing `use` statements for these classes.