### PR TITLE
ClientBuilder fixes for PHP 5.4

### DIFF
--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -95,7 +95,7 @@ class ClientBuilder
         $future = null;
         if (extension_loaded('curl')) {
             $config = array_merge([ 'mh' => curl_multi_init() ], $multiParams);
-            if (function_exists('curl_multi_init')) {
+            if (function_exists('curl_reset')) {
                 $default = new CurlHandler($singleParams);
                 $future = new CurlMultiHandler($config);
             } else {
@@ -127,7 +127,7 @@ class ClientBuilder
      */
     public static function singleHandler()
     {
-        if (function_exists('curl_multi_init')) {
+        if (function_exists('curl_reset')) {
             return new CurlHandler();
         } else {
             throw new \RuntimeException('CurlSingle handler requires cURL.');


### PR DESCRIPTION
Leading on from https://github.com/elastic/elasticsearch-php/issues/201#issuecomment-93821595

- Upstream `GuzzleHttp\Ring\Client\CurlHandler` requires `curl_reset` (available from PHP 5.5) so when using `ClientBuilder::singleHandler()` directly, the check for `curl_reset` should take place or throw the Exception. 
- `ClientBuilder::defaultHandler()` should also perform this check, falling back to `GuzzleHttp\Ring\Client\CurlMultiHandler` in environments where `curl_reset` is not available (the multi handler has no such dependency on `curl_reset`)
- The `ClientBuilder::multiHandler(`) method doesn't require `curl_reset`, but does require `curl_multi_init`, which should be available to those with the curl extension enabled.


Ref:  https://github.com/elastic/elasticsearch-php/issues/201 