### PR TITLE
travis: recent PHP added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,17 @@
 language: php
+
 php:
-  - "5.5"
-  - "5.4"
-  - "5.3"
+  - 7.0
+  - 5.6
+  - 5.5
+  - 5.4
+  - 5.3
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: 7.0
+
 env:
   - ES_VERSION=0.90.0 ES_TEST_HOST=http://localhost:9200
   - ES_VERSION=0.90.1 ES_TEST_HOST=http://localhost:9200
@@ -12,7 +21,7 @@ env:
   - ES_VERSION=0.90.5 ES_TEST_HOST=http://localhost:9200
 
 before_script:
-  - composer install --dev
+  - composer install
   - mkdir -p build/logs
 
 script: ./run_travis_test.sh


### PR DESCRIPTION
- `--dev` is by default for almost a year

Further, I have some suggestions to improve build process.
No need to test matrix every PHP version x every ES_VERSION. Same for coverage.