### PR TITLE
Head request warning

### DIFF
--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -199,7 +199,9 @@ class Connection implements ConnectionInterface
                 } else {
                     $connection->markAlive();
 
-                    $response['body'] = stream_get_contents($response['body']);
+                    if ($response['body']) {
+                        $response['body'] = stream_get_contents($response['body']);
+                    }
 
                     if ($response['status'] >= 400 && $response['status'] < 500) {
                         $ignore = isset($request['client']['ignore']) ? $request['client']['ignore'] : [];

--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -199,7 +199,7 @@ class Connection implements ConnectionInterface
                 } else {
                     $connection->markAlive();
 
-                    if ($response['body']) {
+                    if (isset($response['body']) === true) {
                         $response['body'] = stream_get_contents($response['body']);
                     }
 


### PR DESCRIPTION
Hi,

When preforming HEAD request there is a warrning because there is no body in the response so it's null and 

Warning: stream_get_contents() expects parameter 1 to be resource, null given in ../vendor/elasticsearch/elasticsearch/src/Elasticsearch/Connections/Connection.php on line 202

Example code:
```php
$client->indices()->exists([
    'index' => 'index_name'
]);
```