### PR TITLE
Update README to link to Composer site for how to install Composer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,7 @@ The recommended method to install _Elasticsearch-PHP_ is through [Composer](http
         }
     ```
 
-2. Download and install Composer:
-
-    ```bash
-        curl -s http://getcomposer.org/installer | php
-    ```
+2. Download and install Composer for [Linux/Unix/OSX](https://getcomposer.org/doc/00-intro.md#installation-linux-unix-osx) or [Windows](https://getcomposer.org/doc/00-intro.md#installation-windows).
 
 3. Install your dependencies:
 


### PR DESCRIPTION
Super simple documentation patch to refer users to the Composer website for how to install Composer.  This means that if Composer changes their installation method in the future, our documentation does not need to be changed (assuming the URLs stay the same). This also fixes #251 in a way.