### PR TITLE
Added 'percolate_format' parameter to endpoints MPercolate and Percolate

### DIFF
--- a/src/Elasticsearch/Endpoints/MPercolate.php
+++ b/src/Elasticsearch/Endpoints/MPercolate.php
@@ -71,6 +71,7 @@ class MPercolate extends AbstractEndpoint implements BulkEndpointInterface
             'ignore_unavailable',
             'allow_no_indices',
             'expand_wildcards',
+            'percolate_format'
         );
     }
 

--- a/src/Elasticsearch/Endpoints/Percolate.php
+++ b/src/Elasticsearch/Endpoints/Percolate.php
@@ -83,6 +83,7 @@ class Percolate extends AbstractEndpoint
             'expand_wildcards',
             'percolate_index',
             'percolate_type',
+            'percolate_format',
             'version',
             'version_type',
         );


### PR DESCRIPTION
Added the 'percolate_format' parameter for '_percolate' and '_mpercolate' requests. 
The option allows you to return a response that will contain a string array of the matching ids instead of an array of objects.

see also https://www.elastic.co/guide/en/elasticsearch/reference/current/search-percolate.html#_percolate_api 