### PR TITLE
Remove monolog dependency 

### DIFF
--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -136,7 +136,7 @@ class ClientBuilder
     }
 
     /**
-     * @param \Elasticsearch\Connections\ConnectionFactoryInterface $connectionFactory
+     * @param ConnectionFactoryInterface $connectionFactory
      * @return $this
      */
     public function setConnectionFactory(ConnectionFactoryInterface $connectionFactory)
@@ -200,10 +200,10 @@ class ClientBuilder
     }
 
     /**
-     * @param \Psr\Log\LoggerInterface $logger
+     * @param LoggerInterface $logger
      * @return $this
      */
-    public function setLogger(\Psr\Log\LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger)
     {
         $this->logger = $logger;
 
@@ -211,10 +211,10 @@ class ClientBuilder
     }
 
     /**
-     * @param \Psr\Log\LoggerInterface $tracer
+     * @param LoggerInterface $tracer
      * @return $this
      */
-    public function setTracer(\Psr\Log\LoggerInterface $tracer)
+    public function setTracer(LoggerInterface $tracer)
     {
         $this->tracer = $tracer;
 

--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -17,9 +17,6 @@ use GuzzleHttp\Ring\Client\CurlMultiHandler;
 use GuzzleHttp\Ring\Client\Middleware;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use Monolog\Logger;
-use Monolog\Handler\StreamHandler;
-use Monolog\Processor\IntrospectionProcessor;
 
 /**
  * Class ClientBuilder
@@ -139,21 +136,6 @@ class ClientBuilder
     }
 
     /**
-     * @param $path string
-     * @return \Monolog\Logger\Logger
-     */
-    public static function defaultLogger($path, $level = Logger::WARNING)
-    {
-        $log       = new Logger('log');
-        $handler   = new StreamHandler($path, $level);
-        $processor = new IntrospectionProcessor();
-        $log->pushHandler($handler);
-        $log->pushProcessor($processor);
-
-        return $log;
-    }
-
-    /**
      * @param \Elasticsearch\Connections\ConnectionFactoryInterface $connectionFactory
      * @return $this
      */
@@ -221,7 +203,7 @@ class ClientBuilder
      * @param \Psr\Log\LoggerInterface $logger
      * @return $this
      */
-    public function setLogger($logger)
+    public function setLogger(\Psr\Log\LoggerInterface $logger)
     {
         $this->logger = $logger;
 
@@ -232,7 +214,7 @@ class ClientBuilder
      * @param \Psr\Log\LoggerInterface $tracer
      * @return $this
      */
-    public function setTracer($tracer)
+    public function setTracer(\Psr\Log\LoggerInterface $tracer)
     {
         $this->tracer = $tracer;
 


### PR DESCRIPTION
Know about a specific object logger isn't responsability of ClientBuilder.
Then this PR removes this dependency and add the type hinting.

The example below will result in fatal error:

``` php
$logger = new stdClass();
$client = \Elasticsearch\ClientBuilder::create()
    ->setLogger($logger)
    ->build();

// ... code
```

> Catchable fatal error: Argument 1 passed to Elasticsearch\ClientBuilder::setLogger() must be an instance of Psr\Log\LoggerInterface.

If we use a logger compatible with PSR-3:

``` php
$logger = new Monolog\Logger('log');
$logger->pushHandler(new Monolog\Handler\StreamHandler('logfile.log'));
$client = \Elasticsearch\ClientBuilder::create()
    ->setLogger($logger)
    ->build();

// ... code
```
