### PR TITLE
Drop standard port (443 for HTTPS, 80 for HTTP) from host header

### DIFF
--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -105,7 +105,10 @@ class Connection implements ConnectionInterface
             $connectionParams['client']['curl'][CURLOPT_USERPWD] = $hostDetails['user'].':'.$hostDetails['pass'];
         }
 
-        $host = $hostDetails['host'].':'.$hostDetails['port'];
+        $host = $hostDetails['host'];
+        if (!$this->isStandardPort($hostDetails['scheme'], $hostDetails['port'])) {
+            $host .= ':' . $hostDetails['port'];
+        }
         if (isset($hostDetails['path']) === true) {
             $host .= $hostDetails['path'];
         }
@@ -466,6 +469,12 @@ class Connection implements ConnectionInterface
         );
 
         throw $exception;
+    }
+
+    private function isStandardPort($scheme, $port)
+    {
+        return ('https' === strtolower($scheme) && 443 === $port)
+            || ('http' === strtolower($scheme) && 80 === $port);
     }
 
     /**

--- a/tests/Elasticsearch/Tests/Connections/ConnectionTest.php
+++ b/tests/Elasticsearch/Tests/Connections/ConnectionTest.php
@@ -1,0 +1,93 @@
+<?php
+namespace Elasticsearch\Tests\Connections;
+
+
+use Elasticsearch\Connections\Connection;
+use Elasticsearch\Serializers\SerializerInterface;
+use GuzzleHttp\Ring\Future\CompletedFutureArray;
+use Psr\Log\LoggerInterface;
+
+class ConnectionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider hostPartProvider
+     *
+     * @param array $hostParts
+     */
+    public function testStandardPortsAreNotSpecifiedOnHosts(array $hostParts, $isStandard)
+    {
+        $connection = new Connection(
+            function (array $request) use ($isStandard, $hostParts) {
+                $expectedHost = $hostParts['host'];
+                if (!$isStandard) {
+                    $expectedHost .= ":{$hostParts['port']}";
+                }
+
+                $this->assertSame($expectedHost, $request['headers']['host'][0]);
+
+                return new CompletedFutureArray([]);
+            },
+            $hostParts,
+            [],
+            $this->getMock(SerializerInterface::class),
+            $this->getMock(LoggerInterface::class),
+            $this->getMock(LoggerInterface::class)
+        );
+
+        $connection->performRequest('GET', '/');
+    }
+
+    public function hostPartProvider()
+    {
+        return [
+            [
+                [
+                    'scheme' => 'http',
+                    'host' => 'example.com',
+                    'port' => 80,
+                ],
+                true,
+            ],
+            [
+                [
+                    'scheme' => 'https',
+                    'host' => 'example.com',
+                    'port' => 443,
+                ],
+                true,
+            ],
+            [
+                [
+                    'scheme' => 'http',
+                    'host' => 'example.com',
+                    'port' => 443,
+                ],
+                false,
+            ],
+            [
+                [
+                    'scheme' => 'https',
+                    'host' => 'example.com',
+                    'port' => 80,
+                ],
+                false,
+            ],
+            [
+                [
+                    'scheme' => 'http',
+                    'host' => 'example.com',
+                    'port' => 9200,
+                ],
+                false,
+            ],
+            [
+                [
+                    'scheme' => 'https',
+                    'host' => 'example.com',
+                    'port' => 9200,
+                ],
+                false,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Including the port can complicate certain authentication schemes (such as AWS authentication) that expect only non-standard ports to be included in the host header.
