### PR TITLE
fixed client builder due to outdated class methods

### DIFF
--- a/benchmarks/Elasticsearch/Benchmarks/AsyncVsSyncIndexingEvent.php
+++ b/benchmarks/Elasticsearch/Benchmarks/AsyncVsSyncIndexingEvent.php
@@ -3,7 +3,7 @@
 namespace Elasticsearch\Benchmarks;
 
 use Athletic\AthleticEvent;
-use Elasticsearch\Client;
+use Elasticsearch\ClientBuilder;
 
 class AsyncVsSyncIndexingEvent extends AthleticEvent
 {
@@ -19,9 +19,9 @@ class AsyncVsSyncIndexingEvent extends AthleticEvent
 
     protected function classSetUp()
     {
-        $this->client = $client = Client::newBuilder()->setHosts(['127.0.0.1:9200'])->build();
+        $this->client = $client = ClientBuilder::create()->setHosts(['127.0.0.1:9200'])->build();
 
-        $this->setupClient = $client = Client::newBuilder()->setHosts(['127.0.0.1:9200'])->build();
+        $this->setupClient = $client = ClientBuilder::create()->setHosts(['127.0.0.1:9200'])->build();
         $indexParams['index']  = 'benchmarking_index';
         $indexParams['body']['test']['_all']['enabled'] = false;
         $indexParams['body']['test']['properties']['testField'] = array(

--- a/benchmarks/Elasticsearch/Benchmarks/SequentialIndexingEvent.php
+++ b/benchmarks/Elasticsearch/Benchmarks/SequentialIndexingEvent.php
@@ -3,7 +3,7 @@
 namespace Elasticsearch\Benchmarks;
 
 use Athletic\AthleticEvent;
-use Elasticsearch\Client;
+use Elasticsearch\ClientBuilder;
 
 class SequentialIndexingEvent extends AthleticEvent
 {
@@ -19,9 +19,9 @@ class SequentialIndexingEvent extends AthleticEvent
 
     protected function classSetUp()
     {
-        $this->client = $client = Client::newBuilder()->setHosts(['127.0.0.1:9200'])->build();
+        $this->client = $client = ClientBuilder::create()->setHosts(['127.0.0.1:9200'])->build();
 
-        $this->setupClient = $client = Client::newBuilder()->setHosts(['127.0.0.1:9200'])->build();
+        $this->setupClient = $client = ClientBuilder::create()->setHosts(['127.0.0.1:9200'])->build();
         $indexParams['index']  = 'benchmarking_index';
         $indexParams['body']['test']['_all']['enabled'] = false;
         $indexParams['body']['test']['properties']['testField'] = array(


### PR DESCRIPTION
The Athletic benchmarks can't be executed without adjusting the client builder. With the changes the benchmarks work as expected.