### PR TITLE
Fixed the bulk indexed with batches example

### DIFF
--- a/docs/crud.asciidoc
+++ b/docs/crud.asciidoc
@@ -93,16 +93,16 @@ to batch up the requests and periodically send them:
 .Bulk indexing with batches
 [source,php]
 ----
-$params = [];
+$params = ['body' => []];
 
-for ($i = 0; $i <= 100000; $i++) {
-    $params['body'][] = array(
-        'index' => array(
+for ($i = 1; $i <= 1234567; $i++) {
+    $params['body'][] = [
+        'index' => [
             '_index' => 'my_index',
             '_type' => 'my_type',
             '_id' => $i
-        )
-    );
+        ]
+    ];
 
     $params['body'][] = [
         'my_field' => 'my_value',
@@ -110,15 +110,20 @@ for ($i = 0; $i <= 100000; $i++) {
     ];
 
     // Every 1000 documents stop and send the bulk request
-    if ($i % 1000) {
+    if ($i % 1000 == 0) {
         $responses = $client->bulk($params);
 
         // erase the old bulk request
-        $params = [];
+        $params = ['body' => []];
 
         // unset the bulk response when you are done to save memory
         unset($responses);
     }
+}
+
+// Send the last batch if it exists
+if (!empty($params['body'])) {
+    $responses = $client->bulk($params);
 }
 ----
 


### PR DESCRIPTION
Was bogus and sending the batch at every loop (except when $i % 1000 was evaluated to 0, every 1000 loop)
Also changed the number of documents to index to show how to make sure the remaining docs after the loop is done are indeed indexed