### PR TITLE
Update Scroll.php

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ matrix:
       env: ES_VERSION="1.6" TEST_BUILD_REF="origin/1.6"
     - php: 5.6
       env: ES_VERSION="1.5" TEST_BUILD_REF="origin/1.5"
+  allow_failures:
+    - php: hhvm
+    - php: 7.0
 
 env:
   global:

--- a/src/Elasticsearch/Endpoints/Indices/Mapping/GetField.php
+++ b/src/Elasticsearch/Endpoints/Indices/Mapping/GetField.php
@@ -63,7 +63,6 @@ class GetField extends AbstractEndpoint
         return array(
             'include_defaults',
             'ignore_unavailable',
-            'fields',
             'allow_no_indices',
             'expand_wildcards',
             'local'

--- a/src/Elasticsearch/Namespaces/IndicesNamespace.php
+++ b/src/Elasticsearch/Namespaces/IndicesNamespace.php
@@ -314,10 +314,13 @@ class IndicesNamespace extends AbstractNamespace
     public function getFieldMapping($params = array())
     {
         $index = $this->extractArgument($params, 'index');
-
         $type = $this->extractArgument($params, 'type');
-
         $fields = $this->extractArgument($params, 'fields');
+
+        if (!isset($fields)) {
+            $fields = $this->extractArgument($params, 'field');
+        }
+
 
         /** @var callback $endpointBuilder */
         $endpointBuilder = $this->endpoints;

--- a/src/Elasticsearch/Serializers/SmartSerializer.php
+++ b/src/Elasticsearch/Serializers/SmartSerializer.php
@@ -71,6 +71,10 @@ class SmartSerializer implements SerializerInterface
      */
     private function decode($data)
     {
+        if ($data === null || strlen($data) === 0) {
+            return "";
+        }
+
         $result = @json_decode($data, true);
 
         // Throw exception only if E_NOTICE is on to maintain backwards-compatibility on systems that silently ignore E_NOTICEs.

--- a/tests/Elasticsearch/Tests/YamlRunnerTest.php
+++ b/tests/Elasticsearch/Tests/YamlRunnerTest.php
@@ -107,13 +107,9 @@ class YamlRunnerTest extends \PHPUnit_Framework_TestCase
         $response = curl_exec($ch);
         curl_close($ch);
 
-        $ch = curl_init($host."/_snapshot/*");
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "DELETE");
-        curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);
-
-        $response = curl_exec($ch);
-        curl_close($ch);
+        // TODO ewwww...
+        shell_exec('rm -rf /tmp/test_repo_create_1_loc');
+        shell_exec('rm -rf /tmp/test_repo_restore_1_loc');
 
         $this->waitForYellow();
     }
@@ -605,8 +601,10 @@ class YamlRunnerTest extends \PHPUnit_Framework_TestCase
         if ($passed === false) {
             if (YamlRunnerTest::checkExceptionRegex($expectedError, $exception)) {
                 $passed = true;
-            } elseif (YamlRunnerTest::checkExceptionRegex($expectedError, $exception->getPrevious())) { // try second level
-                $passed = true;
+            } elseif ($exception->getPrevious() !== null) { // try second level
+                if (YamlRunnerTest::checkExceptionRegex($expectedError, $exception->getPrevious())) {
+                    $passed = true;
+                }
             }
         }
 
@@ -615,7 +613,8 @@ class YamlRunnerTest extends \PHPUnit_Framework_TestCase
             return json_decode($exception->getMessage(), true);
         }
 
-        $this->fail("Tried to match exception, failed.  Exception: ".$exception->getMessage());
+        //$this->fail("Tried to match exception, failed.  Exception: ".$exception->getMessage());
+        throw $exception;
     }
 
 
@@ -644,8 +643,9 @@ class YamlRunnerTest extends \PHPUnit_Framework_TestCase
         }
 
         if (count($methodParts) > 1) {
-            $methodParts[1] = $this->snakeToCamel($methodParts[1]);
-            $ret = $this->client->$methodParts[0]()->$methodParts[1]($hash);
+            $methodName = $methodParts[0];
+            $methodArgs = $this->snakeToCamel($methodParts[1]);
+            $ret = $this->client->$methodName()->$methodArgs($hash);
         } else {
             $method = $this->snakeToCamel($method);
             $ret = $this->client->$method($hash);


### PR DESCRIPTION
On calls to es_client->scroll(), the scroll_id would be appended as part of the URI.  Elasticsearch does not expect it here, but rather wants it in the body of the GET request.