### PR TITLE
Removed explicit use of $client->clearScroll(...)

### DIFF
--- a/src/Elasticsearch/Helper/Iterators/SearchResponseIterator.php
+++ b/src/Elasticsearch/Helper/Iterators/SearchResponseIterator.php
@@ -65,13 +65,6 @@ class SearchResponseIterator implements Iterator {
     }
 
     /**
-     * Destructor
-     */
-    public function __destruct() {
-        $this->clearScroll();
-    }
-
-    /**
      * Sets the time to live duration of a scroll window
      *
      * @param  string $time_to_live
@@ -88,7 +81,7 @@ class SearchResponseIterator implements Iterator {
      *
      * @return void
      */
-    private function clearScroll()
+    public function clearScroll()
     {
         if (!empty($this->scroll_id)) {
             $this->client->clearScroll(


### PR DESCRIPTION
This pull request addresses #342 

The `SearchResponseIterator` tries to redundantly clear a scroll that Elasticsearch clears on its own. This pull request removes the explicit call to `$client->clearScroll()`.