### PR TITLE
Ignore 404 for already cleared scroll_ids in SearchResponseIterator

### DIFF
--- a/src/Elasticsearch/Helper/Iterators/SearchResponseIterator.php
+++ b/src/Elasticsearch/Helper/Iterators/SearchResponseIterator.php
@@ -93,7 +93,10 @@ class SearchResponseIterator implements Iterator {
         if (!empty($this->scroll_id)) {
             $this->client->clearScroll(
                 array(
-                    'scroll_id' => $this->scroll_id
+                    'scroll_id' => $this->scroll_id,
+                    'client' => array(
+                        'ignore' => 404
+                    )
                 )
             );
             $this->scroll_id = null;


### PR DESCRIPTION
This pull request addresses #342 by ignoring 404 errors when a scroll has already been automatically cleared.