### PR TITLE
Add support for generators and iterators in bulk endpoint

### DIFF
--- a/src/Elasticsearch/Endpoints/Bulk.php
+++ b/src/Elasticsearch/Endpoints/Bulk.php
@@ -27,25 +27,23 @@ class Bulk extends AbstractEndpoint implements BulkEndpointInterface
     }
 
     /**
-     * @param string|array $body
+     * @param string|array|\Traversable $body
      *
      * @return $this
      */
     public function setBody($body)
     {
-        if (isset($body) !== true) {
+        $this->body = '';
+
+        if (empty($body)) {
             return $this;
         }
 
-        if (is_array($body) === true) {
-            $bulkBody = "";
+        if (is_array($body) === true || $body instanceof \Traversable) {
             foreach ($body as $item) {
-                $bulkBody .= $this->serializer->serialize($item)."\n";
+                $this->body .= $this->serializer->serialize($item) . "\n";
             }
-            $body = $bulkBody;
         }
-
-        $this->body = $body;
 
         return $this;
     }

--- a/src/Elasticsearch/Endpoints/Bulk.php
+++ b/src/Elasticsearch/Endpoints/Bulk.php
@@ -33,8 +33,6 @@ class Bulk extends AbstractEndpoint implements BulkEndpointInterface
      */
     public function setBody($body)
     {
-        $this->body = '';
-
         if (empty($body)) {
             return $this;
         }
@@ -43,6 +41,8 @@ class Bulk extends AbstractEndpoint implements BulkEndpointInterface
             foreach ($body as $item) {
                 $this->body .= $this->serializer->serialize($item) . "\n";
             }
+        } else {
+            $this->body = $body;
         }
 
         return $this;


### PR DESCRIPTION
This add support for generators and iterators in bulk endpoint. Generators can dramatically reduce memory usage and there is no need to work with big arrays.
This also improves variable usage in method bulk(). 