### PR TITLE
Update Scroll.php

### DIFF
--- a/src/Elasticsearch/Endpoints/Scroll.php
+++ b/src/Elasticsearch/Endpoints/Scroll.php
@@ -37,6 +37,14 @@ class Scroll extends AbstractEndpoint
         return $this;
     }
 
+    /**
+     * @return array
+     */
+    protected function getBody()
+    {
+        return $this->scroll_id;
+    }
+
     public function setClearScroll($clear)
     {
         $this->clear = $clear;
@@ -67,10 +75,6 @@ class Scroll extends AbstractEndpoint
     {
         $scroll_id = $this->scroll_id;
         $uri   = "/_search/scroll";
-
-        if (isset($scroll_id) === true) {
-            $uri = "/_search/scroll/$scroll_id";
-        }
 
         return $uri;
     }

--- a/src/Elasticsearch/Endpoints/Scroll.php
+++ b/src/Elasticsearch/Endpoints/Scroll.php
@@ -15,9 +15,6 @@ use Elasticsearch\Common\Exceptions;
  */
 class Scroll extends AbstractEndpoint
 {
-    // The scroll ID
-    private $scroll_id;
-
     private $clear = false;
 
     /**
@@ -42,7 +39,7 @@ class Scroll extends AbstractEndpoint
      */
     protected function getBody()
     {
-        return $this->scroll_id;
+        return $this->body;
     }
 
     public function setClearScroll($clear)
@@ -63,7 +60,7 @@ class Scroll extends AbstractEndpoint
             return $this;
         }
 
-        $this->scroll_id = $scroll_id;
+        $this->body = $scroll_id;
 
         return $this;
     }
@@ -73,9 +70,7 @@ class Scroll extends AbstractEndpoint
      */
     protected function getURI()
     {
-        $scroll_id = $this->scroll_id;
         $uri   = "/_search/scroll";
-
         return $uri;
     }
 
@@ -86,7 +81,6 @@ class Scroll extends AbstractEndpoint
     {
         return array(
             'scroll',
-            'scroll_id',
         );
     }
 


### PR DESCRIPTION
Reference previous request #328.

On calls to es_client->scroll(), the scroll_id would be appended as part of the URI.  This has the side effect of hitting the URL length limit (default 4kb) as scroll IDs can be in the 8kb range.  The other option is to put the scroll ID in the body of the get request, as demonstrated here.