### PR TITLE
Add support for "update_all_types" parameter

### DIFF
--- a/src/Elasticsearch/Endpoints/Indices/Create.php
+++ b/src/Elasticsearch/Endpoints/Indices/Create.php
@@ -62,6 +62,7 @@ class Create extends AbstractEndpoint
         return array(
             'timeout',
             'master_timeout',
+            'update_all_types'
         );
     }
 

--- a/src/Elasticsearch/Endpoints/Indices/Mapping/Put.php
+++ b/src/Elasticsearch/Endpoints/Indices/Mapping/Put.php
@@ -69,6 +69,7 @@ class Put extends AbstractEndpoint
             'ignore_unavailable',
             'allow_no_indices',
             'expand_wildcards',
+            'update_all_types'
         );
     }
 


### PR DESCRIPTION
Right now this setting can't be set with elasticsearch-php

See https://github.com/elastic/elasticsearch/issues/12840, https://github.com/elastic/elasticsearch/commit/a254b2da2919ba5e82f19bc890eb7e32c39cb037 and https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-put-mapping.html#merging-conflicts