### PR TITLE
[WIP] Transport decoupling and PSR7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
   "require": {
     "php": ">=5.4",
     "psr/log": "~1.0",
-    "guzzlehttp/ringphp" : "~1.0"
+    "guzzlehttp/ringphp" : "~1.0",
+    "php-http/message-factory": "^1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.7",
@@ -20,7 +21,9 @@
     "athletic/athletic": "~0.1",
     "symfony/yaml": "2.4.3 as 2.4.2",
     "twig/twig": "1.*",
-    "cpliakas/git-wrapper": "~1.0"
+    "cpliakas/git-wrapper": "~1.0",
+    "guzzlehttp/psr7": "^1.2",
+    "php-http/message": "^1.0"
   },
   "suggest": {
     "ext-curl": "*",

--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -431,11 +431,10 @@ class ClientBuilder
 
             $this->endpoint = function ($class) use ($transport, $serializer) {
                 $fullPath = '\\Elasticsearch\\Endpoints\\' . $class;
-                if ($class === 'Bulk' || $class === 'Msearch' || $class === 'MPercolate') {
-                    return new $fullPath($transport, $serializer);
-                } else {
-                    return new $fullPath($transport);
-                }
+                $endpoint = new $fullPath($transport);
+                $endpoint->setSerializer($serializer);
+
+                return $endpoint;
             };
         }
 

--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -23,6 +23,7 @@ use Elasticsearch\Transport;
 use GuzzleHttp\Ring\Core;
 use GuzzleHttp\Ring\Exception\ConnectException;
 use GuzzleHttp\Ring\Exception\RingException;
+use Psr\Http\Message\RequestInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -155,6 +156,23 @@ class Connection implements ConnectionInterface
         $request = array_merge_recursive($request, $this->connectionParams, $options);
 
 
+        $handler = $this->handler;
+        $future = $handler($request, $this, $transport, $options);
+
+        return $future;
+    }
+
+    public function sendRequest(RequestInterface $request, $options = [], Transport $transport = null)
+    {
+        $request = [
+            'http_method' => $request->getMethod(),
+            'scheme'      => $this->transportSchema,
+            'uri'         => $request->getRequestTarget(),
+            'body'        => $request->getBody()->getContents(),
+            'headers'     => array_merge(['host' => $this->host], $request->getHeaders())
+        ];
+
+        $request = array_merge_recursive($request, $this->connectionParams, $options);
         $handler = $this->handler;
         $future = $handler($request, $this, $transport, $options);
 

--- a/src/Elasticsearch/Endpoints/Bulk.php
+++ b/src/Elasticsearch/Endpoints/Bulk.php
@@ -17,16 +17,6 @@ use Elasticsearch\Transport;
 class Bulk extends AbstractEndpoint implements BulkEndpointInterface
 {
     /**
-     * @param Transport           $transport
-     * @param SerializerInterface $serializer
-     */
-    public function __construct(Transport $transport, SerializerInterface $serializer)
-    {
-        $this->serializer = $serializer;
-        parent::__construct($transport);
-    }
-
-    /**
      * @param string|array|\Traversable $body
      *
      * @return $this

--- a/src/Elasticsearch/Endpoints/BulkEndpointInterface.php
+++ b/src/Elasticsearch/Endpoints/BulkEndpointInterface.php
@@ -16,11 +16,4 @@ use Elasticsearch\Transport;
  */
 interface BulkEndpointInterface
 {
-    /**
-     * Constructor
-     *
-     * @param Transport           $transport  Transport instance
-     * @param SerializerInterface $serializer A serializer
-     */
-    public function __construct(Transport $transport, SerializerInterface $serializer);
 }

--- a/src/Elasticsearch/Endpoints/MPercolate.php
+++ b/src/Elasticsearch/Endpoints/MPercolate.php
@@ -17,16 +17,6 @@ use Elasticsearch\Transport;
 class MPercolate extends AbstractEndpoint implements BulkEndpointInterface
 {
     /**
-     * @param Transport           $transport
-     * @param SerializerInterface $serializer
-     */
-    public function __construct(Transport $transport, SerializerInterface $serializer)
-    {
-        $this->serializer = $serializer;
-        parent::__construct($transport);
-    }
-
-    /**
      * @param string|array $body
      *
      * @return $this

--- a/src/Elasticsearch/Endpoints/Msearch.php
+++ b/src/Elasticsearch/Endpoints/Msearch.php
@@ -18,16 +18,6 @@ use Elasticsearch\Transport;
 class Msearch extends AbstractEndpoint
 {
     /**
-     * @param Transport           $transport
-     * @param SerializerInterface $serializer
-     */
-    public function __construct(Transport $transport, SerializerInterface $serializer)
-    {
-        $this->serializer = $serializer;
-        parent::__construct($transport);
-    }
-
-    /**
      * @param array|string $body
      *
      * @throws \Elasticsearch\Common\Exceptions\InvalidArgumentException

--- a/src/Elasticsearch/Namespaces/NodesNamespace.php
+++ b/src/Elasticsearch/Namespaces/NodesNamespace.php
@@ -51,7 +51,9 @@ class NodesNamespace extends AbstractNamespace
                  ->setMetric($metric)
                  ->setIndexMetric($index_metric)
                  ->setParams($params);
-        $response = $endpoint->performRequest();
+
+        $request = $endpoint->createRequest();
+        $response = $this->transport->sendRequest($request, []);
 
         return $endpoint->resultOrFuture($response);
     }
@@ -79,7 +81,9 @@ class NodesNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Cluster\Nodes\Info');
         $endpoint->setNodeID($nodeID)->setMetric($metric);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
+
+        $request = $endpoint->createRequest();
+        $response = $this->transport->sendRequest($request, []);
 
         return $endpoint->resultOrFuture($response);
     }
@@ -106,7 +110,9 @@ class NodesNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Cluster\Nodes\HotThreads');
         $endpoint->setNodeID($nodeID);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
+
+        $request = $endpoint->createRequest();
+        $response = $this->transport->sendRequest($request, []);
 
         return $endpoint->resultOrFuture($response);
     }
@@ -131,7 +137,9 @@ class NodesNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Cluster\Nodes\Shutdown');
         $endpoint->setNodeID($nodeID);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
+
+        $request = $endpoint->createRequest();
+        $response = $this->transport->sendRequest($request, []);
 
         return $endpoint->resultOrFuture($response);
     }

--- a/tests/Elasticsearch/Tests/Endpoint/AbstractEndpointTest.php
+++ b/tests/Elasticsearch/Tests/Endpoint/AbstractEndpointTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Elasticsearch\Tests\Endpoint;
+
+use Elasticsearch\Endpoints\AbstractEndpoint;
+use Http\Message\MessageFactory\GuzzleMessageFactory;
+
+class AbstractEndpointTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCreateRequest()
+    {
+        $endpoint = new AbstractEndpointStub('GET', '/test', []);
+        $request = $endpoint->createRequest();
+
+        $this->assertInstanceOf('Psr\Http\Message\RequestInterface', $request);
+        $this->assertEquals('GET', $request->getMethod());
+        $this->assertEquals('/test', $request->getRequestTarget());
+    }
+}
+
+class AbstractEndpointStub extends AbstractEndpoint
+{
+    private $requestMethod;
+    private $uri;
+    private $paramsWhiteList;
+
+    public function __construct($method, $uri, $paramsWhiteList)
+    {
+        parent::__construct(null, new GuzzleMessageFactory());
+
+        $this->requestMethod = $method;
+        $this->uri = $uri;
+        $this->paramsWhiteList = $paramsWhiteList;
+    }
+
+    protected function getParamWhitelist()
+    {
+        return $this->paramsWhiteList;
+    }
+
+    protected function getURI()
+    {
+        return $this->uri;
+    }
+
+    protected function getMethod()
+    {
+        return $this->requestMethod;
+    }
+}


### PR DESCRIPTION
This is a attempt to #350 and #291, and also a first step for this : https://github.com/ruflin/Elastica/pull/845

The goal here is to decouple endpoint from transport by using PSR7. Each endpoint can be transformed into a RequestInterface which then can be used by any client using this interface.

It use https://github.com/php-http/message-factory to allow people to choose the implementation for PSR7.

I made this in a none BC break but also added a deprecated flag to inform user that this will change in 3.0

Not sure if this is complete, anyway it's just a small step to bring discussion about this.