### PR TITLE
whitelist search per-request cache parameters

### DIFF
--- a/src/Elasticsearch/Client.php
+++ b/src/Elasticsearch/Client.php
@@ -890,6 +890,8 @@ class Client
      *        ['lowercase_expanded_terms'] = (boolean) Specify whether query terms should be lowercased
      *        ['preference']               = (string) Specify the node or shard the operation should be performed on (default: random)
      *        ['q']                        = (string) Query in the Lucene query string syntax
+     *        ['query_cache']              = (boolean) Enable query cache for this request
+     *        ['request_cache']            = (boolean) Enable request cache for this request
      *        ['routing']                  = (list) A comma-separated list of specific routing values
      *        ['scroll']                   = (duration) Specify how long a consistent view of the index should be maintained for scrolled search
      *        ['search_type']              = (enum) Search operation type

--- a/src/Elasticsearch/Endpoints/Search.php
+++ b/src/Elasticsearch/Endpoints/Search.php
@@ -74,6 +74,8 @@ class Search extends AbstractEndpoint
             'lowercase_expanded_terms',
             'preference',
             'q',
+            'query_cache',
+            'request_cache',
             'routing',
             'scroll',
             'search_type',


### PR DESCRIPTION
This was already solved in #276, but I think it was then lost when merging the 2.0 branch here https://github.com/elastic/elasticsearch-php/commit/333b84898f5a96f31025022790f3b3aff222e539 .

I also added the params to the docs, so that people can find it ;)