### PR TITLE
Minor fix to wrong documentation

### DIFF
--- a/src/Elasticsearch/Client.php
+++ b/src/Elasticsearch/Client.php
@@ -717,8 +717,8 @@ class Client
      *        ['consistency'] = (enum) Explicit write consistency setting for the operation
      *        ['refresh']     = (boolean) Refresh the index after performing the operation
      *        ['replication'] = (enum) Explicitly set the replication type
-     *        ['body']        = (string) Default document type for items which don't provide one
      *        ['fields']      = (list) Default comma-separated list of fields to return in the response for updates
+     *        ['body']        = (array) The document
      *
      * @param $params array Associative array of parameters
      *


### PR DESCRIPTION
The "body" parameter for bulk queries has a copy of the documentation from the type parameter.