### PR TITLE
Fix on /_search/template endpoint

### DIFF
--- a/src/Elasticsearch/Endpoints/SearchTemplate.php
+++ b/src/Elasticsearch/Endpoints/SearchTemplate.php
@@ -65,7 +65,9 @@ class SearchTemplate extends AbstractEndpoint
             'preference',
             'routing',
             'scroll',
-            'search_type'
+            'search_type',
+            'id',
+            'params'
         );
     }
 

--- a/src/Elasticsearch/Endpoints/Template/Get.php
+++ b/src/Elasticsearch/Endpoints/Template/Get.php
@@ -38,7 +38,7 @@ class Get extends AbstractEndpoint
      */
     protected function getParamWhitelist()
     {
-        return array('params');
+        return array();
     }
 
     /**

--- a/src/Elasticsearch/Endpoints/Template/Get.php
+++ b/src/Elasticsearch/Endpoints/Template/Get.php
@@ -38,7 +38,7 @@ class Get extends AbstractEndpoint
      */
     protected function getParamWhitelist()
     {
-        return array();
+        return array('params');
     }
 
     /**


### PR DESCRIPTION
Whitelist some essential params for the endpoint */_search/template*

It is impossible to query a template without whitelist this two params:
- id
- params

like in the documentation [https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html#pre-registered-templates](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html#pre-registered-templates)
