### PR TITLE
Fixes #398: Switch method to POST if request has a body

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ composer.phar
 
 #editor related
 .idea
+/.settings/
+/.buildpath
+/.project
 
 # OS generated files
 .DS_Store

--- a/src/Elasticsearch/Endpoints/Search.php
+++ b/src/Elasticsearch/Endpoints/Search.php
@@ -16,6 +16,8 @@ use Elasticsearch\Common\Exceptions;
  */
 class Search extends AbstractEndpoint
 {
+    protected $method = 'GET';
+
     /**
      * @param array $body
      *
@@ -29,6 +31,7 @@ class Search extends AbstractEndpoint
         }
 
         $this->body = $body;
+        $this->method = 'POST';
 
         return $this;
     }
@@ -102,6 +105,6 @@ class Search extends AbstractEndpoint
      */
     public function getMethod()
     {
-        return 'GET';
+        return $this->method;
     }
 }


### PR DESCRIPTION
This PR will set the http-method to `POST` on search queries, if a data-body has been supplied (else it will default to `GET`).

(also adding ZendStudio files to the `.gitignore`)
