### PR TITLE
Decouple endpoint from transport

### DIFF
--- a/src/Elasticsearch/Client.php
+++ b/src/Elasticsearch/Client.php
@@ -89,9 +89,9 @@ class Client
 
         /** @var \Elasticsearch\Endpoints\Info $endpoint */
         $endpoint = $endpointBuilder('Info');
-        $response = $endpoint->setParams($params)->performRequest();
+        $endpoint->setParams($params);
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -108,8 +108,7 @@ class Client
         $endpoint = $endpointBuilder('Ping');
 
         try {
-            $response = $endpoint->setParams($params)->performRequest();
-            $endpoint->resultOrFuture($response);
+            $response = $this->transport->performEndpoint($endpoint);
         } catch (Missing404Exception $exception) {
             return false;
         } catch (TransportException $exception) {
@@ -155,9 +154,8 @@ class Client
                  ->setIndex($index)
                  ->setType($type);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -193,9 +191,8 @@ class Client
                  ->setType($type)
                  ->returnOnlySource();
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -233,9 +230,8 @@ class Client
                  ->setIndex($index)
                  ->setType($type);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -266,9 +262,8 @@ class Client
                 ->setType($type)
                 ->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -304,9 +299,8 @@ class Client
                  ->setType($type)
                  ->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -345,9 +339,8 @@ class Client
                  ->setID($id)
                  ->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -377,9 +370,8 @@ class Client
                  ->setID($id)
                  ->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -408,9 +400,8 @@ class Client
                  ->setType($type)
                  ->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -448,9 +439,8 @@ class Client
                  ->setID($id)
                  ->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -495,9 +485,8 @@ class Client
                  ->setType($type)
                  ->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -535,7 +524,7 @@ class Client
                  ->setType($type);
         $endpoint->setParams($params);
 
-        return BooleanRequestWrapper::performRequest($endpoint);
+        return BooleanRequestWrapper::performRequest($endpoint, $this->transport);
     }
 
     /**
@@ -587,9 +576,8 @@ class Client
                  ->setType($type)
                  ->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -627,9 +615,8 @@ class Client
                  ->setType($type)
                  ->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -659,9 +646,8 @@ class Client
                  ->setType($type)
                  ->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -706,9 +692,8 @@ class Client
                  ->setBody($body)
                  ->createIfAbsent();
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -741,9 +726,8 @@ class Client
                  ->setType($type)
                  ->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -788,9 +772,8 @@ class Client
                  ->setType($type)
                  ->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -819,9 +802,8 @@ class Client
         $endpoint->setIndex($index)
                  ->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -869,9 +851,8 @@ class Client
                  ->setType($type)
                  ->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -927,9 +908,8 @@ class Client
                  ->setType($type)
                  ->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -985,9 +965,8 @@ class Client
                  ->setType($type)
                  ->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -1017,9 +996,8 @@ class Client
         $endpoint->setIndex($index)
                  ->setType($type);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -1045,9 +1023,8 @@ class Client
                  ->setType($type)
                  ->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -1073,9 +1050,8 @@ class Client
         $endpoint->setScrollID($scrollID)
                  ->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -1102,9 +1078,8 @@ class Client
                  ->setBody($body)
                  ->setClearScroll(true);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -1151,9 +1126,8 @@ class Client
                  ->setType($type)
                  ->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -1177,9 +1151,8 @@ class Client
         $endpoint->setID($id)
                  ->setLang($lang);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -1203,9 +1176,8 @@ class Client
         $endpoint->setID($id)
                  ->setLang($lang);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -1231,9 +1203,8 @@ class Client
                  ->setLang($lang)
                  ->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -1254,9 +1225,8 @@ class Client
         $endpoint = $endpointBuilder('Template\Get');
         $endpoint->setID($id);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -1277,9 +1247,8 @@ class Client
         $endpoint = $endpointBuilder('Template\Delete');
         $endpoint->setID($id);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -1302,9 +1271,8 @@ class Client
         $endpoint->setID($id)
                  ->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -1332,9 +1300,8 @@ class Client
         $endpoint->setIndex($index)
             ->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -1357,8 +1324,8 @@ class Client
         $endpoint->setBody($body)
             ->setID($id);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
-        return $endpoint->resultOrFuture($response);
+
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**

--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -426,15 +426,14 @@ class ClientBuilder
         $this->buildTransport();
 
         if (is_null($this->endpoint)) {
-            $transport = $this->transport;
             $serializer = $this->serializer;
 
-            $this->endpoint = function ($class) use ($transport, $serializer) {
+            $this->endpoint = function ($class) use ($serializer) {
                 $fullPath = '\\Elasticsearch\\Endpoints\\' . $class;
                 if ($class === 'Bulk' || $class === 'Msearch' || $class === 'MPercolate') {
-                    return new $fullPath($transport, $serializer);
+                    return new $fullPath($serializer);
                 } else {
-                    return new $fullPath($transport);
+                    return new $fullPath();
                 }
             };
         }

--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -152,8 +152,8 @@ class Connection implements ConnectionInterface
             ]
 
         ];
-        $request = array_merge_recursive($request, $this->connectionParams, $options);
 
+        $request = array_merge_recursive($request, $this->connectionParams, $options);
 
         $handler = $this->handler;
         $future = $handler($request, $this, $transport, $options);

--- a/src/Elasticsearch/Endpoints/AbstractEndpoint.php
+++ b/src/Elasticsearch/Endpoints/AbstractEndpoint.php
@@ -50,13 +50,27 @@ abstract class AbstractEndpoint
      */
     public function getURI()
     {
-        
+        $uri = $this->getEndpointURI();
+
+        if (!empty($this->params)) {
+            $uri .= '?'.http_build_query($this->params);
+        }
+
+        return $uri;
     }
 
     /**
      * @return string
      */
     abstract public function getMethod();
+
+    /**
+     * @return array
+     */
+    public function getParams()
+    {
+        return $this->params;
+    }
 
     /**
      * Set the parameters for this endpoint
@@ -138,7 +152,7 @@ abstract class AbstractEndpoint
     /**
      * @return array
      */
-    protected function getBody()
+    public function getBody()
     {
         return $this->body;
     }

--- a/src/Elasticsearch/Endpoints/Bulk.php
+++ b/src/Elasticsearch/Endpoints/Bulk.php
@@ -51,7 +51,7 @@ class Bulk extends AbstractEndpoint implements BulkEndpointInterface
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         return $this->getOptionalURI('_bulk');
     }
@@ -73,7 +73,7 @@ class Bulk extends AbstractEndpoint implements BulkEndpointInterface
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Bulk.php
+++ b/src/Elasticsearch/Endpoints/Bulk.php
@@ -16,14 +16,14 @@ use Elasticsearch\Transport;
  */
 class Bulk extends AbstractEndpoint implements BulkEndpointInterface
 {
+    protected $serializer;
+
     /**
-     * @param Transport           $transport
      * @param SerializerInterface $serializer
      */
-    public function __construct(Transport $transport, SerializerInterface $serializer)
+    public function __construct(SerializerInterface $serializer)
     {
         $this->serializer = $serializer;
-        parent::__construct($transport);
     }
 
     /**

--- a/src/Elasticsearch/Endpoints/BulkEndpointInterface.php
+++ b/src/Elasticsearch/Endpoints/BulkEndpointInterface.php
@@ -19,8 +19,7 @@ interface BulkEndpointInterface
     /**
      * Constructor
      *
-     * @param Transport           $transport  Transport instance
      * @param SerializerInterface $serializer A serializer
      */
-    public function __construct(Transport $transport, SerializerInterface $serializer);
+    public function __construct(SerializerInterface $serializer);
 }

--- a/src/Elasticsearch/Endpoints/Cat/Aliases.php
+++ b/src/Elasticsearch/Endpoints/Cat/Aliases.php
@@ -37,7 +37,7 @@ class Aliases extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $name = $this->name;
         $uri   = "/_cat/aliases";
@@ -66,7 +66,7 @@ class Aliases extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/Allocation.php
+++ b/src/Elasticsearch/Endpoints/Cat/Allocation.php
@@ -37,7 +37,7 @@ class Allocation extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $node_id = $this->node_id;
         $uri   = "/_cat/allocation";
@@ -67,7 +67,7 @@ class Allocation extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/Count.php
+++ b/src/Elasticsearch/Endpoints/Cat/Count.php
@@ -18,7 +18,7 @@ class Count extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $uri   = "/_cat/count";
@@ -47,7 +47,7 @@ class Count extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/Fielddata.php
+++ b/src/Elasticsearch/Endpoints/Cat/Fielddata.php
@@ -36,7 +36,7 @@ class Fielddata extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $fields = $this->fields;
         $uri   = "/_cat/fielddata";
@@ -65,7 +65,7 @@ class Fielddata extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/Health.php
+++ b/src/Elasticsearch/Endpoints/Cat/Health.php
@@ -18,7 +18,7 @@ class Health extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $uri   = "/_cat/health";
 
@@ -43,7 +43,7 @@ class Health extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/Help.php
+++ b/src/Elasticsearch/Endpoints/Cat/Help.php
@@ -18,7 +18,7 @@ class Help extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $uri   = "/_cat";
 
@@ -38,7 +38,7 @@ class Help extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/Indices.php
+++ b/src/Elasticsearch/Endpoints/Cat/Indices.php
@@ -19,7 +19,7 @@ class Indices extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $uri   = "/_cat/indices";
@@ -50,7 +50,7 @@ class Indices extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/Master.php
+++ b/src/Elasticsearch/Endpoints/Cat/Master.php
@@ -18,7 +18,7 @@ class Master extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $uri   = "/_cat/master";
 
@@ -42,7 +42,7 @@ class Master extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/NodeAttrs.php
+++ b/src/Elasticsearch/Endpoints/Cat/NodeAttrs.php
@@ -18,7 +18,7 @@ class NodeAttrs extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $uri   = "/_cat/nodeattrs";
 
@@ -42,7 +42,7 @@ class NodeAttrs extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/Nodes.php
+++ b/src/Elasticsearch/Endpoints/Cat/Nodes.php
@@ -18,7 +18,7 @@ class Nodes extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $uri   = "/_cat/nodes";
 
@@ -42,7 +42,7 @@ class Nodes extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/PendingTasks.php
+++ b/src/Elasticsearch/Endpoints/Cat/PendingTasks.php
@@ -18,7 +18,7 @@ class PendingTasks extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $uri   = "/_cat/pending_tasks";
 
@@ -42,7 +42,7 @@ class PendingTasks extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/Plugins.php
+++ b/src/Elasticsearch/Endpoints/Cat/Plugins.php
@@ -18,7 +18,7 @@ class Plugins extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $uri   = "/_cat/plugins";
 
@@ -42,7 +42,7 @@ class Plugins extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/Recovery.php
+++ b/src/Elasticsearch/Endpoints/Cat/Recovery.php
@@ -18,7 +18,7 @@ class Recovery extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $uri   = "/_cat/recovery";
@@ -48,7 +48,7 @@ class Recovery extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/Repositories.php
+++ b/src/Elasticsearch/Endpoints/Cat/Repositories.php
@@ -18,7 +18,7 @@ class Repositories extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $uri   = "/_cat/repositories";
 
@@ -42,7 +42,7 @@ class Repositories extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/Segments.php
+++ b/src/Elasticsearch/Endpoints/Cat/Segments.php
@@ -25,7 +25,7 @@ class Segments extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $uri   = "/_cat/segments";
@@ -54,7 +54,7 @@ class Segments extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/Shards.php
+++ b/src/Elasticsearch/Endpoints/Cat/Shards.php
@@ -18,7 +18,7 @@ class Shards extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $uri   = "/_cat/shards";
@@ -48,7 +48,7 @@ class Shards extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/Snapshots.php
+++ b/src/Elasticsearch/Endpoints/Cat/Snapshots.php
@@ -36,7 +36,7 @@ class Snapshots extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->repository) !== true) {
             throw new Exceptions\RuntimeException(
@@ -65,7 +65,7 @@ class Snapshots extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/ThreadPool.php
+++ b/src/Elasticsearch/Endpoints/Cat/ThreadPool.php
@@ -19,7 +19,7 @@ class ThreadPool extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $uri   = "/_cat/thread_pool";
 
@@ -44,7 +44,7 @@ class ThreadPool extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/ClearScroll.php
+++ b/src/Elasticsearch/Endpoints/ClearScroll.php
@@ -38,7 +38,7 @@ class ClearScroll extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->scroll_id) !== true) {
             throw new Exceptions\RuntimeException(
@@ -67,7 +67,7 @@ class ClearScroll extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'DELETE';
     }

--- a/src/Elasticsearch/Endpoints/Cluster/Health.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Health.php
@@ -18,7 +18,7 @@ class Health extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $uri   = "/_cluster/health";
@@ -50,7 +50,7 @@ class Health extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cluster/Nodes/HotThreads.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Nodes/HotThreads.php
@@ -16,7 +16,7 @@ class HotThreads extends AbstractNodesEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $node_id = $this->nodeID;
         $uri   = "/_cluster/nodes/hotthreads";
@@ -44,7 +44,7 @@ class HotThreads extends AbstractNodesEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cluster/Nodes/Info.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Nodes/Info.php
@@ -39,7 +39,7 @@ class Info extends AbstractNodesEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $node_id = $this->nodeID;
         $metric = $this->metric;
@@ -70,7 +70,7 @@ class Info extends AbstractNodesEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cluster/Nodes/Shutdown.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Nodes/Shutdown.php
@@ -16,7 +16,7 @@ class Shutdown extends AbstractNodesEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $node_id = $this->nodeID;
         $uri   = "/_shutdown";
@@ -42,7 +42,7 @@ class Shutdown extends AbstractNodesEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Cluster/Nodes/Stats.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Nodes/Stats.php
@@ -62,7 +62,7 @@ class Stats extends AbstractNodesEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $metric = $this->metric;
         $index_metric = $this->indexMetric;
@@ -103,7 +103,7 @@ class Stats extends AbstractNodesEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cluster/PendingTasks.php
+++ b/src/Elasticsearch/Endpoints/Cluster/PendingTasks.php
@@ -18,7 +18,7 @@ class PendingTasks extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $uri   = "/_cluster/pending_tasks";
 
@@ -39,7 +39,7 @@ class PendingTasks extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cluster/Reroute.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Reroute.php
@@ -36,7 +36,7 @@ class Reroute extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $uri   = "/_cluster/reroute";
 
@@ -61,7 +61,7 @@ class Reroute extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Cluster/Settings/Get.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Settings/Get.php
@@ -19,7 +19,7 @@ class Get extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $uri   = "/_cluster/settings";
 
@@ -41,7 +41,7 @@ class Get extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cluster/Settings/Put.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Settings/Put.php
@@ -36,7 +36,7 @@ class Put extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $uri   = "/_cluster/settings";
 
@@ -56,7 +56,7 @@ class Put extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'PUT';
     }

--- a/src/Elasticsearch/Endpoints/Cluster/State.php
+++ b/src/Elasticsearch/Endpoints/Cluster/State.php
@@ -41,7 +41,7 @@ class State extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $metric = $this->metric;
@@ -75,7 +75,7 @@ class State extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cluster/Stats.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Stats.php
@@ -37,7 +37,7 @@ class Stats extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $node_id = $this->nodeID;
         $uri   = "/_cluster/stats";
@@ -63,7 +63,7 @@ class Stats extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Count.php
+++ b/src/Elasticsearch/Endpoints/Count.php
@@ -35,7 +35,7 @@ class Count extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $type = $this->type;
@@ -79,7 +79,7 @@ class Count extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/CountPercolate.php
+++ b/src/Elasticsearch/Endpoints/CountPercolate.php
@@ -36,7 +36,7 @@ class CountPercolate extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->index) !== true) {
             throw new Exceptions\RuntimeException(
@@ -83,7 +83,7 @@ class CountPercolate extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Delete.php
+++ b/src/Elasticsearch/Endpoints/Delete.php
@@ -19,7 +19,7 @@ class Delete extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->id) !== true) {
             throw new Exceptions\RuntimeException(
@@ -68,7 +68,7 @@ class Delete extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'DELETE';
     }

--- a/src/Elasticsearch/Endpoints/DeleteByQuery.php
+++ b/src/Elasticsearch/Endpoints/DeleteByQuery.php
@@ -36,7 +36,7 @@ class DeleteByQuery extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->index) !== true) {
             throw new Exceptions\RuntimeException(
@@ -80,7 +80,7 @@ class DeleteByQuery extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'DELETE';
     }

--- a/src/Elasticsearch/Endpoints/Exists.php
+++ b/src/Elasticsearch/Endpoints/Exists.php
@@ -19,7 +19,7 @@ class Exists extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->id) !== true) {
             throw new Exceptions\RuntimeException(
@@ -65,7 +65,7 @@ class Exists extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'HEAD';
     }

--- a/src/Elasticsearch/Endpoints/Explain.php
+++ b/src/Elasticsearch/Endpoints/Explain.php
@@ -36,7 +36,7 @@ class Explain extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->id) !== true) {
             throw new Exceptions\RuntimeException(
@@ -92,7 +92,7 @@ class Explain extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/FieldStats.php
+++ b/src/Elasticsearch/Endpoints/FieldStats.php
@@ -36,7 +36,7 @@ class FieldStats extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $uri   = "/_field_stats";
@@ -66,7 +66,7 @@ class FieldStats extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Get.php
+++ b/src/Elasticsearch/Endpoints/Get.php
@@ -45,7 +45,7 @@ class Get extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->id) !== true) {
             throw new Exceptions\RuntimeException(
@@ -101,7 +101,7 @@ class Get extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         if ($this->checkOnlyExistance === true) {
             return 'HEAD';

--- a/src/Elasticsearch/Endpoints/Index.php
+++ b/src/Elasticsearch/Endpoints/Index.php
@@ -116,7 +116,7 @@ class Index extends AbstractEndpoint
      * @return array
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      */
-    protected function getBody()
+    public function getBody()
     {
         if (isset($this->body) !== true) {
             throw new Exceptions\RuntimeException('Document body must be set for index request');

--- a/src/Elasticsearch/Endpoints/Index.php
+++ b/src/Elasticsearch/Endpoints/Index.php
@@ -49,7 +49,7 @@ class Index extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->index) !== true) {
             throw new Exceptions\RuntimeException(
@@ -103,7 +103,7 @@ class Index extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         if (isset($this->id) === true) {
             return 'PUT';

--- a/src/Elasticsearch/Endpoints/Indices/Alias/Delete.php
+++ b/src/Elasticsearch/Endpoints/Indices/Alias/Delete.php
@@ -39,7 +39,7 @@ class Delete extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->index) !== true) {
             throw new Exceptions\RuntimeException(
@@ -76,7 +76,7 @@ class Delete extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'DELETE';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Alias/Exists.php
+++ b/src/Elasticsearch/Endpoints/Indices/Alias/Exists.php
@@ -37,7 +37,7 @@ class Exists extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $name = $this->name;
@@ -70,7 +70,7 @@ class Exists extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'HEAD';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Alias/Get.php
+++ b/src/Elasticsearch/Endpoints/Indices/Alias/Get.php
@@ -37,7 +37,7 @@ class Get extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $name = $this->name;
@@ -70,7 +70,7 @@ class Get extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Alias/Put.php
+++ b/src/Elasticsearch/Endpoints/Indices/Alias/Put.php
@@ -56,7 +56,7 @@ class Put extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->name) !== true) {
             throw new Exceptions\RuntimeException(
@@ -90,7 +90,7 @@ class Put extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'PUT';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Aliases/Get.php
+++ b/src/Elasticsearch/Endpoints/Indices/Aliases/Get.php
@@ -37,7 +37,7 @@ class Get extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $name = $this->name;
@@ -68,7 +68,7 @@ class Get extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Aliases/Update.php
+++ b/src/Elasticsearch/Endpoints/Indices/Aliases/Update.php
@@ -36,7 +36,7 @@ class Update extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $uri   = "/_aliases";
 
@@ -70,7 +70,7 @@ class Update extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Aliases/Update.php
+++ b/src/Elasticsearch/Endpoints/Indices/Aliases/Update.php
@@ -58,7 +58,7 @@ class Update extends AbstractEndpoint
      * @return array
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      */
-    protected function getBody()
+    public function getBody()
     {
         if (isset($this->body) !== true) {
             throw new Exceptions\RuntimeException('Body is required for Update Aliases');

--- a/src/Elasticsearch/Endpoints/Indices/Analyze.php
+++ b/src/Elasticsearch/Endpoints/Indices/Analyze.php
@@ -36,7 +36,7 @@ class Analyze extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $uri   = "/_analyze";
@@ -68,7 +68,7 @@ class Analyze extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Cache/Clear.php
+++ b/src/Elasticsearch/Endpoints/Indices/Cache/Clear.php
@@ -18,7 +18,7 @@ class Clear extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $uri   = "/_cache/clear";
@@ -55,7 +55,7 @@ class Clear extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Indices/ClearCache.php
+++ b/src/Elasticsearch/Endpoints/Indices/ClearCache.php
@@ -18,7 +18,7 @@ class ClearCache extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $uri   = "/_cache/clear";
@@ -55,7 +55,7 @@ class ClearCache extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Close.php
+++ b/src/Elasticsearch/Endpoints/Indices/Close.php
@@ -20,7 +20,7 @@ class Close extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->index) !== true) {
             throw new Exceptions\RuntimeException(
@@ -54,7 +54,7 @@ class Close extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Create.php
+++ b/src/Elasticsearch/Endpoints/Indices/Create.php
@@ -37,7 +37,7 @@ class Create extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->index) !== true) {
             throw new Exceptions\RuntimeException(
@@ -69,7 +69,7 @@ class Create extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         if (isset($this->body['mappings']) === true) {
             return 'POST';

--- a/src/Elasticsearch/Endpoints/Indices/Delete.php
+++ b/src/Elasticsearch/Endpoints/Indices/Delete.php
@@ -18,7 +18,7 @@ class Delete extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $uri   = "/$index";
@@ -44,7 +44,7 @@ class Delete extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'DELETE';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Exists.php
+++ b/src/Elasticsearch/Endpoints/Indices/Exists.php
@@ -20,7 +20,7 @@ class Exists extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->index) !== true) {
             throw new Exceptions\RuntimeException(
@@ -53,7 +53,7 @@ class Exists extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'HEAD';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Exists/Types.php
+++ b/src/Elasticsearch/Endpoints/Indices/Exists/Types.php
@@ -20,7 +20,7 @@ class Types extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->index) !== true) {
             throw new Exceptions\RuntimeException(
@@ -56,7 +56,7 @@ class Types extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'HEAD';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Field/Get.php
+++ b/src/Elasticsearch/Endpoints/Indices/Field/Get.php
@@ -39,7 +39,7 @@ class Get extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->field) !== true) {
             throw new Exceptions\RuntimeException(
@@ -81,7 +81,7 @@ class Get extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Flush.php
+++ b/src/Elasticsearch/Endpoints/Indices/Flush.php
@@ -24,7 +24,7 @@ class Flush extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $uri   = "/_flush";
@@ -58,7 +58,7 @@ class Flush extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/ForceMerge.php
+++ b/src/Elasticsearch/Endpoints/Indices/ForceMerge.php
@@ -18,7 +18,7 @@ class ForceMerge extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $uri   = "/_forcemerge";
@@ -50,7 +50,7 @@ class ForceMerge extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Gateway/Snapshot.php
+++ b/src/Elasticsearch/Endpoints/Indices/Gateway/Snapshot.php
@@ -18,7 +18,7 @@ class Snapshot extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $uri   = "/_gateway/snapshot";
@@ -45,7 +45,7 @@ class Snapshot extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Get.php
+++ b/src/Elasticsearch/Endpoints/Indices/Get.php
@@ -22,7 +22,7 @@ class Get extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->index) !== true) {
             throw new Exceptions\RuntimeException(
@@ -72,7 +72,7 @@ class Get extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Mapping/Delete.php
+++ b/src/Elasticsearch/Endpoints/Indices/Mapping/Delete.php
@@ -20,7 +20,7 @@ class Delete extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->index) !== true) {
             throw new Exceptions\RuntimeException(
@@ -56,7 +56,7 @@ class Delete extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'DELETE';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Mapping/Get.php
+++ b/src/Elasticsearch/Endpoints/Indices/Mapping/Get.php
@@ -18,7 +18,7 @@ class Get extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $type = $this->type;
@@ -52,7 +52,7 @@ class Get extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Mapping/GetField.php
+++ b/src/Elasticsearch/Endpoints/Indices/Mapping/GetField.php
@@ -43,7 +43,7 @@ class GetField extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->fields) !== true) {
             throw new Exceptions\RuntimeException(
@@ -72,7 +72,7 @@ class GetField extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Mapping/Put.php
+++ b/src/Elasticsearch/Endpoints/Indices/Mapping/Put.php
@@ -77,7 +77,7 @@ class Put extends AbstractEndpoint
      * @return array
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      */
-    protected function getBody()
+    public function getBody()
     {
         if (isset($this->body) !== true) {
             throw new Exceptions\RuntimeException('Body is required for Put Mapping');

--- a/src/Elasticsearch/Endpoints/Indices/Mapping/Put.php
+++ b/src/Elasticsearch/Endpoints/Indices/Mapping/Put.php
@@ -37,7 +37,7 @@ class Put extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->type) !== true) {
             throw new Exceptions\RuntimeException(
@@ -89,7 +89,7 @@ class Put extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'PUT';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Open.php
+++ b/src/Elasticsearch/Endpoints/Indices/Open.php
@@ -20,7 +20,7 @@ class Open extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->index) !== true) {
             throw new Exceptions\RuntimeException(
@@ -54,7 +54,7 @@ class Open extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Optimize.php
+++ b/src/Elasticsearch/Endpoints/Indices/Optimize.php
@@ -18,7 +18,7 @@ class Optimize extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $uri   = "/_optimize";
@@ -50,7 +50,7 @@ class Optimize extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Recovery.php
+++ b/src/Elasticsearch/Endpoints/Indices/Recovery.php
@@ -18,7 +18,7 @@ class Recovery extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $uri   = "/_recovery";
@@ -45,7 +45,7 @@ class Recovery extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Refresh.php
+++ b/src/Elasticsearch/Endpoints/Indices/Refresh.php
@@ -18,7 +18,7 @@ class Refresh extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $uri   = "/_refresh";
@@ -47,7 +47,7 @@ class Refresh extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Seal.php
+++ b/src/Elasticsearch/Endpoints/Indices/Seal.php
@@ -20,7 +20,7 @@ class Seal extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $uri   = "/_seal";
@@ -43,7 +43,7 @@ class Seal extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Segments.php
+++ b/src/Elasticsearch/Endpoints/Indices/Segments.php
@@ -18,7 +18,7 @@ class Segments extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $uri   = "/_segments";
@@ -47,7 +47,7 @@ class Segments extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Settings/Get.php
+++ b/src/Elasticsearch/Endpoints/Indices/Settings/Get.php
@@ -37,7 +37,7 @@ class Get extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $name = $this->name;
@@ -71,7 +71,7 @@ class Get extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Settings/Put.php
+++ b/src/Elasticsearch/Endpoints/Indices/Settings/Put.php
@@ -66,7 +66,7 @@ class Put extends AbstractEndpoint
      * @return array
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      */
-    protected function getBody()
+    public function getBody()
     {
         if (isset($this->body) !== true) {
             throw new Exceptions\RuntimeException('Body is required for Put Settings');

--- a/src/Elasticsearch/Endpoints/Indices/Settings/Put.php
+++ b/src/Elasticsearch/Endpoints/Indices/Settings/Put.php
@@ -36,7 +36,7 @@ class Put extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $uri   = "/_settings";
@@ -78,7 +78,7 @@ class Put extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'PUT';
     }

--- a/src/Elasticsearch/Endpoints/Indices/ShardStores.php
+++ b/src/Elasticsearch/Endpoints/Indices/ShardStores.php
@@ -21,7 +21,7 @@ class ShardStores extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $uri   = "/_shard_stores";
@@ -52,7 +52,7 @@ class ShardStores extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Snapshotindex.php
+++ b/src/Elasticsearch/Endpoints/Indices/Snapshotindex.php
@@ -18,7 +18,7 @@ class Snapshotindex extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $uri   = "/_gateway/snapshot";
@@ -45,7 +45,7 @@ class Snapshotindex extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Stats.php
+++ b/src/Elasticsearch/Endpoints/Indices/Stats.php
@@ -41,7 +41,7 @@ class Stats extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $metric = $this->metric;
@@ -78,7 +78,7 @@ class Stats extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Status.php
+++ b/src/Elasticsearch/Endpoints/Indices/Status.php
@@ -18,7 +18,7 @@ class Status extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $uri   = "/_status";
@@ -49,7 +49,7 @@ class Status extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Template/Delete.php
+++ b/src/Elasticsearch/Endpoints/Indices/Template/Delete.php
@@ -40,7 +40,7 @@ class Delete extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->name) !== true) {
             throw new Exceptions\RuntimeException(
@@ -71,7 +71,7 @@ class Delete extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'DELETE';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Template/Exists.php
+++ b/src/Elasticsearch/Endpoints/Indices/Template/Exists.php
@@ -39,7 +39,7 @@ class Exists extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->name) !== true) {
             throw new Exceptions\RuntimeException(
@@ -70,7 +70,7 @@ class Exists extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'HEAD';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Template/Get.php
+++ b/src/Elasticsearch/Endpoints/Indices/Template/Get.php
@@ -39,7 +39,7 @@ class Get extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $name = $this->name;
         $uri   = "/_template";
@@ -66,7 +66,7 @@ class Get extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Template/Put.php
+++ b/src/Elasticsearch/Endpoints/Indices/Template/Put.php
@@ -91,7 +91,7 @@ class Put extends AbstractEndpoint
      * @return array
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      */
-    protected function getBody()
+    public function getBody()
     {
         if (isset($this->body) !== true) {
             throw new Exceptions\RuntimeException('Body is required for Put Template');

--- a/src/Elasticsearch/Endpoints/Indices/Template/Put.php
+++ b/src/Elasticsearch/Endpoints/Indices/Template/Put.php
@@ -56,7 +56,7 @@ class Put extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->name) !== true) {
             throw new Exceptions\RuntimeException(
@@ -103,7 +103,7 @@ class Put extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'PUT';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Type/Exists.php
+++ b/src/Elasticsearch/Endpoints/Indices/Type/Exists.php
@@ -20,7 +20,7 @@ class Exists extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->index) !== true) {
             throw new Exceptions\RuntimeException(
@@ -59,7 +59,7 @@ class Exists extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'HEAD';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Upgrade/Get.php
+++ b/src/Elasticsearch/Endpoints/Indices/Upgrade/Get.php
@@ -26,7 +26,7 @@ class Get extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $uri   = "/_upgrade";
@@ -58,7 +58,7 @@ class Get extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Upgrade/Post.php
+++ b/src/Elasticsearch/Endpoints/Indices/Upgrade/Post.php
@@ -26,7 +26,7 @@ class Post extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $uri   = "/_upgrade";
@@ -58,7 +58,7 @@ class Post extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Validate/Query.php
+++ b/src/Elasticsearch/Endpoints/Indices/Validate/Query.php
@@ -36,7 +36,7 @@ class Query extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         return $this->getOptionalURI('_validate/query');
     }
@@ -64,7 +64,7 @@ class Query extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/ValidateQuery.php
+++ b/src/Elasticsearch/Endpoints/Indices/ValidateQuery.php
@@ -36,7 +36,7 @@ class ValidateQuery extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $type = $this->type;
@@ -70,7 +70,7 @@ class ValidateQuery extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Warmer/Delete.php
+++ b/src/Elasticsearch/Endpoints/Indices/Warmer/Delete.php
@@ -39,7 +39,7 @@ class Delete extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->index) !== true) {
             throw new Exceptions\RuntimeException(
@@ -76,7 +76,7 @@ class Delete extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'DELETE';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Warmer/Get.php
+++ b/src/Elasticsearch/Endpoints/Indices/Warmer/Get.php
@@ -39,7 +39,7 @@ class Get extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $name = $this->name;
@@ -77,7 +77,7 @@ class Get extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Warmer/Put.php
+++ b/src/Elasticsearch/Endpoints/Indices/Warmer/Put.php
@@ -96,7 +96,7 @@ class Put extends AbstractEndpoint
      * @return array
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      */
-    protected function getBody()
+    public function getBody()
     {
         if (isset($this->body) !== true) {
             throw new Exceptions\RuntimeException('Body is required for Put Warmer');

--- a/src/Elasticsearch/Endpoints/Indices/Warmer/Put.php
+++ b/src/Elasticsearch/Endpoints/Indices/Warmer/Put.php
@@ -56,7 +56,7 @@ class Put extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->name) !== true) {
             throw new Exceptions\RuntimeException(
@@ -108,7 +108,7 @@ class Put extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'PUT';
     }

--- a/src/Elasticsearch/Endpoints/Info.php
+++ b/src/Elasticsearch/Endpoints/Info.php
@@ -16,7 +16,7 @@ class Info extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $uri   = "/";
 
@@ -35,7 +35,7 @@ class Info extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/MPercolate.php
+++ b/src/Elasticsearch/Endpoints/MPercolate.php
@@ -53,7 +53,7 @@ class MPercolate extends AbstractEndpoint implements BulkEndpointInterface
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         return $this->getOptionalURI('_mpercolate');
     }
@@ -73,7 +73,7 @@ class MPercolate extends AbstractEndpoint implements BulkEndpointInterface
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/MPercolate.php
+++ b/src/Elasticsearch/Endpoints/MPercolate.php
@@ -17,13 +17,11 @@ use Elasticsearch\Transport;
 class MPercolate extends AbstractEndpoint implements BulkEndpointInterface
 {
     /**
-     * @param Transport           $transport
      * @param SerializerInterface $serializer
      */
-    public function __construct(Transport $transport, SerializerInterface $serializer)
+    public function __construct(SerializerInterface $serializer)
     {
         $this->serializer = $serializer;
-        parent::__construct($transport);
     }
 
     /**

--- a/src/Elasticsearch/Endpoints/MTermVectors.php
+++ b/src/Elasticsearch/Endpoints/MTermVectors.php
@@ -35,7 +35,7 @@ class MTermVectors extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         return $this->getOptionalURI('_mtermvectors');
     }
@@ -63,7 +63,7 @@ class MTermVectors extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Mget.php
+++ b/src/Elasticsearch/Endpoints/Mget.php
@@ -35,7 +35,7 @@ class Mget extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $type = $this->type;
@@ -84,7 +84,7 @@ class Mget extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Mget.php
+++ b/src/Elasticsearch/Endpoints/Mget.php
@@ -72,7 +72,7 @@ class Mget extends AbstractEndpoint
      * @return array
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      */
-    protected function getBody()
+    public function getBody()
     {
         if (isset($this->body) !== true) {
             throw new Exceptions\RuntimeException('Body is required for MGet');

--- a/src/Elasticsearch/Endpoints/Mlt.php
+++ b/src/Elasticsearch/Endpoints/Mlt.php
@@ -36,7 +36,7 @@ class Mlt extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->id) !== true) {
             throw new Exceptions\RuntimeException(
@@ -96,7 +96,7 @@ class Mlt extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Msearch.php
+++ b/src/Elasticsearch/Endpoints/Msearch.php
@@ -17,14 +17,14 @@ use Elasticsearch\Transport;
  */
 class Msearch extends AbstractEndpoint
 {
+    protected $serializer;
+
     /**
-     * @param Transport           $transport
      * @param SerializerInterface $serializer
      */
-    public function __construct(Transport $transport, SerializerInterface $serializer)
+    public function __construct(SerializerInterface $serializer)
     {
         $this->serializer = $serializer;
-        parent::__construct($transport);
     }
 
     /**
@@ -86,7 +86,7 @@ class Msearch extends AbstractEndpoint
      * @return array
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      */
-    protected function getBody()
+    public function getBody()
     {
         if (isset($this->body) !== true) {
             throw new Exceptions\RuntimeException('Body is required for MSearch');

--- a/src/Elasticsearch/Endpoints/Msearch.php
+++ b/src/Elasticsearch/Endpoints/Msearch.php
@@ -55,7 +55,7 @@ class Msearch extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $type = $this->type;
@@ -98,7 +98,7 @@ class Msearch extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Percolate.php
+++ b/src/Elasticsearch/Endpoints/Percolate.php
@@ -36,7 +36,7 @@ class Percolate extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->index) !== true) {
             throw new Exceptions\RuntimeException(
@@ -90,7 +90,7 @@ class Percolate extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Percolate.php
+++ b/src/Elasticsearch/Endpoints/Percolate.php
@@ -82,7 +82,7 @@ class Percolate extends AbstractEndpoint
      * @return array
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      */
-    protected function getBody()
+    public function getBody()
     {
         return $this->body;
     }

--- a/src/Elasticsearch/Endpoints/Ping.php
+++ b/src/Elasticsearch/Endpoints/Ping.php
@@ -16,7 +16,7 @@ class Ping extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $uri   = "/";
 
@@ -35,7 +35,7 @@ class Ping extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'HEAD';
     }

--- a/src/Elasticsearch/Endpoints/RenderSearchTemplate.php
+++ b/src/Elasticsearch/Endpoints/RenderSearchTemplate.php
@@ -62,7 +62,7 @@ class RenderSearchTemplate extends AbstractEndpoint
      * @return array
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      */
-    protected function getBody()
+    public function getBody()
     {
         return $this->body;
     }

--- a/src/Elasticsearch/Endpoints/RenderSearchTemplate.php
+++ b/src/Elasticsearch/Endpoints/RenderSearchTemplate.php
@@ -37,7 +37,7 @@ class RenderSearchTemplate extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $id = $this->id;
 
@@ -70,7 +70,7 @@ class RenderSearchTemplate extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Script/Delete.php
+++ b/src/Elasticsearch/Endpoints/Script/Delete.php
@@ -39,7 +39,7 @@ class Delete extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->lang) !== true) {
             throw new Exceptions\RuntimeException(
@@ -72,7 +72,7 @@ class Delete extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'DELETE';
     }

--- a/src/Elasticsearch/Endpoints/Script/Get.php
+++ b/src/Elasticsearch/Endpoints/Script/Get.php
@@ -39,7 +39,7 @@ class Get extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->lang) !== true) {
             throw new Exceptions\RuntimeException(
@@ -72,7 +72,7 @@ class Get extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Script/Put.php
+++ b/src/Elasticsearch/Endpoints/Script/Put.php
@@ -55,7 +55,7 @@ class Put extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->lang) !== true) {
             throw new Exceptions\RuntimeException(
@@ -89,7 +89,7 @@ class Put extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'PUT';
     }

--- a/src/Elasticsearch/Endpoints/Scroll.php
+++ b/src/Elasticsearch/Endpoints/Scroll.php
@@ -37,7 +37,7 @@ class Scroll extends AbstractEndpoint
     /**
      * @return array
      */
-    protected function getBody()
+    public function getBody()
     {
         return $this->body;
     }

--- a/src/Elasticsearch/Endpoints/Scroll.php
+++ b/src/Elasticsearch/Endpoints/Scroll.php
@@ -68,7 +68,7 @@ class Scroll extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $uri   = "/_search/scroll";
         return $uri;
@@ -87,7 +87,7 @@ class Scroll extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         if ($this->clear == true) {
             return 'DELETE';

--- a/src/Elasticsearch/Endpoints/Search.php
+++ b/src/Elasticsearch/Endpoints/Search.php
@@ -36,7 +36,7 @@ class Search extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $type = $this->type;
@@ -98,7 +98,7 @@ class Search extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/SearchExists.php
+++ b/src/Elasticsearch/Endpoints/SearchExists.php
@@ -36,7 +36,7 @@ class SearchExists extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $type = $this->type;
@@ -96,7 +96,7 @@ class SearchExists extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/SearchShards.php
+++ b/src/Elasticsearch/Endpoints/SearchShards.php
@@ -16,7 +16,7 @@ class SearchShards extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $type = $this->type;
@@ -51,7 +51,7 @@ class SearchShards extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/SearchTemplate.php
+++ b/src/Elasticsearch/Endpoints/SearchTemplate.php
@@ -36,7 +36,7 @@ class SearchTemplate extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $type = $this->type;
@@ -72,7 +72,7 @@ class SearchTemplate extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Snapshot/Create.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Create.php
@@ -75,7 +75,7 @@ class Create extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->repository) !== true) {
             throw new Exceptions\RuntimeException(
@@ -112,7 +112,7 @@ class Create extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'PUT';
     }

--- a/src/Elasticsearch/Endpoints/Snapshot/Delete.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Delete.php
@@ -58,7 +58,7 @@ class Delete extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->repository) !== true) {
             throw new Exceptions\RuntimeException(
@@ -94,7 +94,7 @@ class Delete extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'DELETE';
     }

--- a/src/Elasticsearch/Endpoints/Snapshot/Get.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Get.php
@@ -58,7 +58,7 @@ class Get extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->repository) !== true) {
             throw new Exceptions\RuntimeException(
@@ -94,7 +94,7 @@ class Get extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Snapshot/Repository/Create.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Repository/Create.php
@@ -56,7 +56,7 @@ class Create extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->repository) !== true) {
             throw new Exceptions\RuntimeException(
@@ -100,7 +100,7 @@ class Create extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'PUT';
     }

--- a/src/Elasticsearch/Endpoints/Snapshot/Repository/Create.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Repository/Create.php
@@ -88,7 +88,7 @@ class Create extends AbstractEndpoint
      * @return array
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      */
-    protected function getBody()
+    public function getBody()
     {
         if (isset($this->body) !== true) {
             throw new Exceptions\RuntimeException('Body is required for Create Repository');

--- a/src/Elasticsearch/Endpoints/Snapshot/Repository/Delete.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Repository/Delete.php
@@ -39,7 +39,7 @@ class Delete extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->repository) !== true) {
             throw new Exceptions\RuntimeException(
@@ -70,7 +70,7 @@ class Delete extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'DELETE';
     }

--- a/src/Elasticsearch/Endpoints/Snapshot/Repository/Get.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Repository/Get.php
@@ -37,7 +37,7 @@ class Get extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $repository = $this->repository;
         $uri   = "/_snapshot";
@@ -63,7 +63,7 @@ class Get extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Snapshot/Repository/Verify.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Repository/Verify.php
@@ -39,7 +39,7 @@ class Verify extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $repository = $this->repository;
         if (isset($this->repository) !== true) {
@@ -67,7 +67,7 @@ class Verify extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Snapshot/Restore.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Restore.php
@@ -75,7 +75,7 @@ class Restore extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->repository) !== true) {
             throw new Exceptions\RuntimeException(
@@ -112,7 +112,7 @@ class Restore extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Snapshot/Status.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Status.php
@@ -58,7 +58,7 @@ class Status extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->snapshot) === true && isset($this->repository) !== true) {
             throw new Exceptions\RuntimeException(
@@ -92,7 +92,7 @@ class Status extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Source/Get.php
+++ b/src/Elasticsearch/Endpoints/Source/Get.php
@@ -20,7 +20,7 @@ class Get extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->id) !== true) {
             throw new Exceptions\RuntimeException(
@@ -71,7 +71,7 @@ class Get extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Suggest.php
+++ b/src/Elasticsearch/Endpoints/Suggest.php
@@ -66,7 +66,7 @@ class Suggest extends AbstractEndpoint
      * @return array
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      */
-    protected function getBody()
+    public function getBody()
     {
         if (isset($this->body) !== true) {
             throw new Exceptions\RuntimeException('Body is required for Suggest');

--- a/src/Elasticsearch/Endpoints/Suggest.php
+++ b/src/Elasticsearch/Endpoints/Suggest.php
@@ -35,7 +35,7 @@ class Suggest extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         $index = $this->index;
         $uri   = "/_suggest";
@@ -78,7 +78,7 @@ class Suggest extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Template/Delete.php
+++ b/src/Elasticsearch/Endpoints/Template/Delete.php
@@ -20,7 +20,7 @@ class Delete extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->id) !== true) {
             throw new Exceptions\RuntimeException(
@@ -44,7 +44,7 @@ class Delete extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'DELETE';
     }

--- a/src/Elasticsearch/Endpoints/Template/Get.php
+++ b/src/Elasticsearch/Endpoints/Template/Get.php
@@ -20,7 +20,7 @@ class Get extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->id) !== true) {
             throw new Exceptions\RuntimeException(
@@ -44,7 +44,7 @@ class Get extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Template/Put.php
+++ b/src/Elasticsearch/Endpoints/Template/Put.php
@@ -36,7 +36,7 @@ class Put extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->id) !== true) {
             throw new Exceptions\RuntimeException(
@@ -61,7 +61,7 @@ class Put extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'PUT';
     }

--- a/src/Elasticsearch/Endpoints/TermVector.php
+++ b/src/Elasticsearch/Endpoints/TermVector.php
@@ -36,7 +36,7 @@ class TermVector extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->index) !== true) {
             throw new Exceptions\RuntimeException(
@@ -84,7 +84,7 @@ class TermVector extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Update.php
+++ b/src/Elasticsearch/Endpoints/Update.php
@@ -36,7 +36,7 @@ class Update extends AbstractEndpoint
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string
      */
-    protected function getURI()
+    protected function getEndpointURI()
     {
         if (isset($this->id) !== true) {
             throw new Exceptions\RuntimeException(
@@ -91,7 +91,7 @@ class Update extends AbstractEndpoint
     /**
      * @return string
      */
-    protected function getMethod()
+    public function getMethod()
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Namespaces/BooleanRequestWrapper.php
+++ b/src/Elasticsearch/Namespaces/BooleanRequestWrapper.php
@@ -5,6 +5,7 @@ namespace Elasticsearch\Namespaces;
 use Elasticsearch\Common\Exceptions\Missing404Exception;
 use Elasticsearch\Common\Exceptions\RoutingMissingException;
 use Elasticsearch\Endpoints\AbstractEndpoint;
+use Elasticsearch\Transport;
 use GuzzleHttp\Ring\Future\FutureArrayInterface;
 
 /**
@@ -21,16 +22,19 @@ trait BooleanRequestWrapper
     /**
      * Perform Request
      *
-     * @param  AbstractEndpoint $endpoint The Endpoint to perform this request against
+     * @param  AbstractEndpoint $endpoint  The Endpoint to perform this request against
+     * @param  Transport        $transport Transport to execute the request
      *
      * @throws Missing404Exception
      * @throws RoutingMissingException
+     *
+     * @return bool|array
      */
-    public static function performRequest(AbstractEndpoint $endpoint)
+    public static function performRequest(AbstractEndpoint $endpoint, Transport $transport)
     {
         try {
-            $response = $endpoint->performRequest();
-            $response = $endpoint->resultOrFuture($response);
+            $response = $transport->performEndpoint($endpoint);
+
             if (!($response instanceof FutureArrayInterface)) {
                 if ($response['status'] === 200) {
                     return true;

--- a/src/Elasticsearch/Namespaces/CatNamespace.php
+++ b/src/Elasticsearch/Namespaces/CatNamespace.php
@@ -35,9 +35,8 @@ class CatNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Cat\Aliases');
         $endpoint->setName($name);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -63,9 +62,8 @@ class CatNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Cat\Allocation');
         $endpoint->setNodeID($nodeID);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -90,9 +88,8 @@ class CatNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Cat\Count');
         $endpoint->setIndex($index);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -115,9 +112,8 @@ class CatNamespace extends AbstractNamespace
         /** @var \Elasticsearch\Endpoints\Cat\Health $endpoint */
         $endpoint = $endpointBuilder('Cat\Health');
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -135,9 +131,8 @@ class CatNamespace extends AbstractNamespace
         /** @var \Elasticsearch\Endpoints\Cat\Help $endpoint */
         $endpoint = $endpointBuilder('Cat\Help');
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -164,9 +159,8 @@ class CatNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Cat\Indices');
         $endpoint->setIndex($index);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -188,9 +182,8 @@ class CatNamespace extends AbstractNamespace
         /** @var \Elasticsearch\Endpoints\Cat\Master $endpoint */
         $endpoint = $endpointBuilder('Cat\Master');
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -212,9 +205,8 @@ class CatNamespace extends AbstractNamespace
         /** @var \Elasticsearch\Endpoints\Cat\Nodes $endpoint */
         $endpoint = $endpointBuilder('Cat\Nodes');
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -236,9 +228,8 @@ class CatNamespace extends AbstractNamespace
         /** @var \Elasticsearch\Endpoints\Cat\NodeAttrs $endpoint */
         $endpoint = $endpointBuilder('Cat\NodeAttrs');
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -260,9 +251,8 @@ class CatNamespace extends AbstractNamespace
         /** @var \Elasticsearch\Endpoints\Cat\PendingTasks $endpoint */
         $endpoint = $endpointBuilder('Cat\PendingTasks');
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -288,9 +278,8 @@ class CatNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Cat\Recovery');
         $endpoint->setIndex($index);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -312,9 +301,8 @@ class CatNamespace extends AbstractNamespace
         /** @var \Elasticsearch\Endpoints\Cat\Repositories $endpoint */
         $endpoint = $endpointBuilder('Cat\Repositories');
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -340,9 +328,8 @@ class CatNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Cat\Shards');
         $endpoint->setIndex($index);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -369,9 +356,8 @@ class CatNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Cat\Snapshots');
         $endpoint->setRepository($repository);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -397,9 +383,8 @@ class CatNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Cat\ThreadPool');
         $endpoint->setIndex($index);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -426,9 +411,8 @@ class CatNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Cat\Fielddata');
         $endpoint->setFields($fields);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -450,9 +434,8 @@ class CatNamespace extends AbstractNamespace
         /** @var \Elasticsearch\Endpoints\Cat\Plugins $endpoint */
         $endpoint = $endpointBuilder('Cat\Plugins');
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -475,8 +458,7 @@ class CatNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Cat\Segments');
         $endpoint->setIndex($index);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 }

--- a/src/Elasticsearch/Namespaces/ClusterNamespace.php
+++ b/src/Elasticsearch/Namespaces/ClusterNamespace.php
@@ -39,9 +39,8 @@ class ClusterNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Cluster\Health');
         $endpoint->setIndex($index);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -65,9 +64,8 @@ class ClusterNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Cluster\Reroute');
         $endpoint->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -97,9 +95,8 @@ class ClusterNamespace extends AbstractNamespace
         $endpoint->setParams($params)
                  ->setIndex($index)
                  ->setMetric($metric);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -121,9 +118,8 @@ class ClusterNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Cluster\Stats');
         $endpoint->setNodeID($nodeID)
                  ->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -144,9 +140,8 @@ class ClusterNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Cluster\Settings\Put');
         $endpoint->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -162,9 +157,8 @@ class ClusterNamespace extends AbstractNamespace
         /** @var \Elasticsearch\Endpoints\Cluster\Settings\Put $endpoint */
         $endpoint = $endpointBuilder('Cluster\Settings\Get');
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -183,8 +177,7 @@ class ClusterNamespace extends AbstractNamespace
         /** @var \Elasticsearch\Endpoints\Cluster\PendingTasks $endpoint */
         $endpoint = $endpointBuilder('Cluster\PendingTasks');
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 }

--- a/src/Elasticsearch/Namespaces/IndicesNamespace.php
+++ b/src/Elasticsearch/Namespaces/IndicesNamespace.php
@@ -35,7 +35,7 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint->setIndex($index);
         $endpoint->setParams($params);
 
-        return BooleanRequestWrapper::performRequest($endpoint);
+        return BooleanRequestWrapper::performRequest($endpoint, $this->transport);
     }
 
     /**
@@ -64,9 +64,7 @@ class IndicesNamespace extends AbstractNamespace
                  ->setFeature($feature)
                  ->setParams($params);
 
-        $response = $endpoint->performRequest();
-
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -91,9 +89,8 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Indices\Segments');
         $endpoint->setIndex($index);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -115,9 +112,8 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Indices\Template\Delete');
         $endpoint->setName($name);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -146,9 +142,8 @@ class IndicesNamespace extends AbstractNamespace
                  ->setName($name)
                  ->setType($type);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -170,9 +165,8 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Indices\Delete');
         $endpoint->setIndex($index);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -216,9 +210,8 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint->setIndex($index)
                  ->setMetric($metric);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -243,9 +236,8 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint->setIndex($index)
                  ->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -269,9 +261,8 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Indices\Gateway\Snapshot');
         $endpoint->setIndex($index);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -296,9 +287,8 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint->setIndex($index)
                  ->setType($type);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -332,9 +322,8 @@ class IndicesNamespace extends AbstractNamespace
                  ->setFields($fields);
 
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -361,9 +350,8 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Indices\Flush');
         $endpoint->setIndex($index);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -391,8 +379,8 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint->setIndex($index);
         $endpoint->setParams($params);
         $endpoint->setSynced(true);
-        $response = $endpoint->performRequest();
-        return $endpoint->resultOrFuture($response);
+
+        return $this->transport->performEndpoint($endpoint);
     }
 
 
@@ -418,9 +406,8 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Indices\Refresh');
         $endpoint->setIndex($index);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -444,9 +431,8 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Indices\Recovery');
         $endpoint->setIndex($index);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -478,7 +464,7 @@ class IndicesNamespace extends AbstractNamespace
                  ->setType($type);
         $endpoint->setParams($params);
 
-        return BooleanRequestWrapper::performRequest($endpoint);
+        return BooleanRequestWrapper::performRequest($endpoint, $this->transport);
     }
 
     /**
@@ -508,9 +494,8 @@ class IndicesNamespace extends AbstractNamespace
                  ->setName($name)
                  ->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -539,9 +524,8 @@ class IndicesNamespace extends AbstractNamespace
                  ->setName($name)
                  ->setType($type);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -574,9 +558,8 @@ class IndicesNamespace extends AbstractNamespace
                  ->setType($type)
                  ->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -604,9 +587,8 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint->setName($name)
                  ->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -639,9 +621,8 @@ class IndicesNamespace extends AbstractNamespace
                  ->setType($type)
                  ->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -668,9 +649,8 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint->setIndex($index)
                  ->setName($name);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -701,9 +681,8 @@ class IndicesNamespace extends AbstractNamespace
                  ->setType($type)
                  ->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -728,9 +707,8 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint->setIndex($index)
                  ->setType($type);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -751,9 +729,8 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Indices\Template\Get');
         $endpoint->setName($name);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -778,7 +755,7 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint->setName($name);
         $endpoint->setParams($params);
 
-        return BooleanRequestWrapper::performRequest($endpoint);
+        return BooleanRequestWrapper::performRequest($endpoint, $this->transport);
     }
 
     /**
@@ -804,9 +781,8 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint->setIndex($index)
                  ->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -836,9 +812,8 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Indices\Optimize');
         $endpoint->setIndex($index);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -868,9 +843,8 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Indices\ForceMerge');
         $endpoint->setIndex($index);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -896,9 +870,8 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint->setIndex($index)
                  ->setName($name);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -920,9 +893,8 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Indices\Open');
         $endpoint->setIndex($index);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -954,9 +926,8 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint->setIndex($index)
                  ->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -989,9 +960,8 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Indices\Cache\Clear');
         $endpoint->setIndex($index);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -1017,9 +987,8 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint->setIndex($index)
                  ->setBody($body);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -1044,9 +1013,8 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint->setIndex($index)
                  ->setName($name);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -1078,7 +1046,7 @@ class IndicesNamespace extends AbstractNamespace
                  ->setName($name);
         $endpoint->setParams($params);
 
-        return BooleanRequestWrapper::performRequest($endpoint);
+        return BooleanRequestWrapper::performRequest($endpoint, $this->transport);
     }
 
     /**
@@ -1103,9 +1071,8 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Indices\Status');
         $endpoint->setIndex($index);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -1129,9 +1096,8 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint->setIndex($index)
                  ->setName($name);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -1153,9 +1119,8 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Indices\Close');
         $endpoint->setIndex($index);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -1176,9 +1141,8 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Indices\Seal');
         $endpoint->setIndex($index);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -1205,8 +1169,8 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Indices\Upgrade\Post');
         $endpoint->setIndex($index);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
-        return $endpoint->resultOrFuture($response);
+
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -1233,9 +1197,8 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Indices\Upgrade\Get');
         $endpoint->setIndex($index);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -1261,8 +1224,7 @@ class IndicesNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Indices\ShardStores');
         $endpoint->setIndex($index);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 }

--- a/src/Elasticsearch/Namespaces/NodesNamespace.php
+++ b/src/Elasticsearch/Namespaces/NodesNamespace.php
@@ -51,9 +51,8 @@ class NodesNamespace extends AbstractNamespace
                  ->setMetric($metric)
                  ->setIndexMetric($index_metric)
                  ->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -79,9 +78,8 @@ class NodesNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Cluster\Nodes\Info');
         $endpoint->setNodeID($nodeID)->setMetric($metric);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -106,9 +104,8 @@ class NodesNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Cluster\Nodes\HotThreads');
         $endpoint->setNodeID($nodeID);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -131,8 +128,7 @@ class NodesNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Cluster\Nodes\Shutdown');
         $endpoint->setNodeID($nodeID);
         $endpoint->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 }

--- a/src/Elasticsearch/Namespaces/SnapshotNamespace.php
+++ b/src/Elasticsearch/Namespaces/SnapshotNamespace.php
@@ -36,9 +36,8 @@ class SnapshotNamespace extends AbstractNamespace
                  ->setSnapshot($snapshot)
                  ->setParams($params)
                  ->setBody($body);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -62,9 +61,8 @@ class SnapshotNamespace extends AbstractNamespace
         $endpoint->setRepository($repository)
                  ->setBody($body)
                  ->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -87,9 +85,8 @@ class SnapshotNamespace extends AbstractNamespace
         $endpoint->setRepository($repository)
                  ->setSnapshot($snapshot)
                  ->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -111,9 +108,8 @@ class SnapshotNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Snapshot\Repository\Delete');
         $endpoint->setRepository($repository)
                  ->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -136,9 +132,8 @@ class SnapshotNamespace extends AbstractNamespace
         $endpoint->setRepository($repository)
                  ->setSnapshot($snapshot)
                  ->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -160,9 +155,8 @@ class SnapshotNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Snapshot\Repository\Get');
         $endpoint->setRepository($repository)
                  ->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -188,9 +182,8 @@ class SnapshotNamespace extends AbstractNamespace
                  ->setSnapshot($snapshot)
                  ->setParams($params)
                  ->setBody($body);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -213,9 +206,8 @@ class SnapshotNamespace extends AbstractNamespace
         $endpoint->setRepository($repository)
                  ->setSnapshot($snapshot)
                  ->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 
     /**
@@ -237,8 +229,7 @@ class SnapshotNamespace extends AbstractNamespace
         $endpoint = $endpointBuilder('Snapshot\Repository\Verify');
         $endpoint->setRepository($repository)
                  ->setParams($params);
-        $response = $endpoint->performRequest();
 
-        return $endpoint->resultOrFuture($response);
+        return $this->transport->performEndpoint($endpoint);
     }
 }

--- a/src/Elasticsearch/Transport.php
+++ b/src/Elasticsearch/Transport.php
@@ -6,6 +6,8 @@ use Elasticsearch\Common\Exceptions;
 use Elasticsearch\ConnectionPool\AbstractConnectionPool;
 use Elasticsearch\Connections\Connection;
 use Elasticsearch\Connections\ConnectionInterface;
+use Elasticsearch\Endpoints\AbstractEndpoint;
+use GuzzleHttp\Ring\Future\FutureArrayInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -69,6 +71,34 @@ class Transport
     public function getConnection()
     {
         return $this->connectionPool->nextConnection();
+    }
+
+    /**
+     * Perform a endpoint to the Cluster
+     *
+     * @param AbstractEndpoint $endpoint Endpoint to execute
+     * @param array            $options  Options when executing the request
+     *
+     * @throws Common\Exceptions\NoNodesAvailableException|\Exception
+     * @return array
+     */
+    public function performEndpoint(AbstractEndpoint $endpoint, $options = [])
+    {
+        $options = array_merge($endpoint->getParams(), $options);
+        $options = $this->extractOptions($options);
+
+        $result = $this->performRequest($endpoint->getMethod(), $endpoint->getURI(), null, $endpoint->getBody(), $options);
+        $response = null;
+        $async = isset($options['client']['future']) ? $options['client']['future'] : null;
+        if (is_null($async) || $async === false) {
+            do {
+                $result = $result->wait();
+            } while ($result instanceof FutureArrayInterface);
+
+            return $result;
+        } elseif ($async === true || $async === 'lazy') {
+            return $result;
+        }
     }
 
     /**
@@ -146,5 +176,34 @@ class Transport
     public function getLastConnection()
     {
         return $this->lastConnection;
+    }
+
+    /**
+     * @param array $params
+     *
+     * @return array
+     */
+    private function extractOptions($params)
+    {
+        $options = ['client' => []];
+
+        // Extract out client options, then start transforming
+        if (isset($params['client']) === true) {
+            $options['client'] = $params['client'];
+        }
+
+        $ignore = isset($options['client']['ignore']) ? $options['client']['ignore'] : null;
+
+        if (isset($ignore) === true) {
+            if (is_string($ignore)) {
+                $options['client']['ignore'] = explode(",", $ignore);
+            } elseif (is_array($ignore)) {
+                $options['client']['ignore'] = $ignore;
+            } else {
+                $options['client']['ignore'] = [$ignore];
+            }
+        }
+
+        return $options;
     }
 }


### PR DESCRIPTION
This PR replace #383 and is a first step for #350 

I decided to do small steps as #383 was too big of a change (there will be others PR if this one is merged, to use PSR7 and other stuffs), and also this one has less "politics"

Purpose of this change it's to decouple entirely transport from the endpoint, so endpoint will never have to know about a transport.

The transport, now, has the responsability to transform an endpoint to a request.

Doing this will allow for better reusability of the endpoint (i.e. create a PSR7 request from it).

This change is BC and add new method to the endpoint contract (getUri, getMethod, getParams, getBody are now public method instead of protected / only propriety)

For the BC part this may be possible to have a deprecation layer, however the maintenance will be harder and IMO es 5.0 will certainly have BC so this might be the right time to do this ?

