### PR TITLE
Only show log when test fails

### DIFF
--- a/tests/Elasticsearch/Tests/YamlRunnerTest.php
+++ b/tests/Elasticsearch/Tests/YamlRunnerTest.php
@@ -265,7 +265,7 @@ class YamlRunnerTest extends \PHPUnit_Framework_TestCase
                         $yamlDocs[] = $tDoc;
                     }
                 } catch (ParseException $e) {
-                    printf("Unable to parse the YAML string: %s", $e->getMessage());
+                    $this->fail(sprintf("Unable to parse the YAML string: %s in file %s", $e->getMessage(), $testFile));
                 }
             }
 
@@ -332,7 +332,7 @@ class YamlRunnerTest extends \PHPUnit_Framework_TestCase
                         $yamlDocs[] = $tDoc;
                     }
                 } catch (ParseException $e) {
-                    printf("Unable to parse the YAML string: %s", $e->getMessage());
+                    $this->fail(sprintf("Unable to parse the YAML string: %s in file %s", $e->getMessage(), $testFile));
                 }
             }
 


### PR DESCRIPTION
This is mainly to show full log of elasticsearch integration test only when a test fail, also this better track which integration test fail with the source code (as it show the output just above the exception)