### PR TITLE
Split, refactor and fix some tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ before_script:
 
 script:
   - vendor/bin/phpunit $PHPUNIT_FLAGS
+  - vendor/bin/phpunit -c phpunit-integration.xml $PHPUNIT_FLAGS
 
 after_script:
   - if [ $TRAVIS_PHP_VERSION = '7.0' ]; then php vendor/bin/coveralls; fi

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,11 @@
   "require-dev": {
     "phpunit/phpunit": "~4.7",
     "mockery/mockery": "0.9.4",
-    "symfony/yaml": "2.4.3 as 2.4.2",
+    "symfony/yaml": "^2.8",
+    "symfony/finder": "^2.8",
     "cpliakas/git-wrapper": "~1.0",
-    "sami/sami": "~3.2"
+    "sami/sami": "~3.2",
+    "doctrine/inflector": "^1.1"
   },
   "suggest": {
     "ext-curl": "*",
@@ -34,11 +36,5 @@
     "psr-4": {
       "Elasticsearch\\Tests\\":      "tests/Elasticsearch/Tests/"
     }
-  },
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/polyfractal/Yaml"
-    }
-  ]
+  }
 }

--- a/phpunit-integration.xml
+++ b/phpunit-integration.xml
@@ -12,8 +12,7 @@
     </php>
     <testsuites>
         <testsuite>
-            <directory>tests</directory>
-            <exclude>tests/Elasticsearch/Tests/YamlRunnerTest.php</exclude>
+            <file>tests/Elasticsearch/Tests/YamlRunnerTest.php</file>
         </testsuite>
     </testsuites>
     <filter>

--- a/src/Elasticsearch/Endpoints/Cluster/AllocationExplain.php
+++ b/src/Elasticsearch/Endpoints/Cluster/AllocationExplain.php
@@ -47,7 +47,8 @@ class AllocationExplain extends AbstractEndpoint
     public function getParamWhitelist()
     {
         return array(
-            'include_yes_decisions'
+            'include_yes_decisions',
+            'include_disk_info',
         );
     }
 

--- a/src/Elasticsearch/Endpoints/Cluster/Health.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Health.php
@@ -44,6 +44,7 @@ class Health extends AbstractEndpoint
             'wait_for_nodes',
             'wait_for_relocating_shards',
             'wait_for_status',
+            'wait_for_events',
         );
     }
 

--- a/src/Elasticsearch/Endpoints/Indices/Create.php
+++ b/src/Elasticsearch/Endpoints/Indices/Create.php
@@ -62,7 +62,8 @@ class Create extends AbstractEndpoint
         return array(
             'timeout',
             'master_timeout',
-            'update_all_types'
+            'update_all_types',
+            'wait_for_active_shards'
         );
     }
 

--- a/src/Elasticsearch/Endpoints/Indices/Rollover.php
+++ b/src/Elasticsearch/Endpoints/Indices/Rollover.php
@@ -94,7 +94,8 @@ class Rollover extends AbstractEndpoint
     {
         return array(
             'timeout',
-            'master_timeout'
+            'master_timeout',
+            'wait_for_active_shards',
         );
     }
 

--- a/src/Elasticsearch/Endpoints/Ingest/Pipeline/Get.php
+++ b/src/Elasticsearch/Endpoints/Ingest/Pipeline/Get.php
@@ -23,7 +23,9 @@ class Get extends AbstractEndpoint
     public function getURI()
     {
         if (isset($this->id) !== true) {
-            return '/_ingest/pipeline/*';
+            throw new Exceptions\RuntimeException(
+                'id is required for GetPipeline'
+            );
         }
 
         $id = $this->id;

--- a/src/Elasticsearch/Endpoints/Ingest/Pipeline/Get.php
+++ b/src/Elasticsearch/Endpoints/Ingest/Pipeline/Get.php
@@ -23,10 +23,9 @@ class Get extends AbstractEndpoint
     public function getURI()
     {
         if (isset($this->id) !== true) {
-            throw new Exceptions\RuntimeException(
-                'id is required for GetPipeline'
-            );
+            return '/_ingest/pipeline/*';
         }
+
         $id = $this->id;
         $uri = "/_ingest/pipeline/$id";
 

--- a/tests/Elasticsearch/Tests/YamlRunnerTest.php
+++ b/tests/Elasticsearch/Tests/YamlRunnerTest.php
@@ -26,7 +26,7 @@ use Symfony\Component\Yaml\Yaml;
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link       http://elasticsearch.org
  */
-class YamlRunnerTest2 extends \PHPUnit_Framework_TestCase
+class YamlRunnerTest extends \PHPUnit_Framework_TestCase
 {
     /** @var  Parser */
     private $yaml;

--- a/tests/Elasticsearch/Tests/YamlRunnerTest.php
+++ b/tests/Elasticsearch/Tests/YamlRunnerTest.php
@@ -2,6 +2,7 @@
 
 namespace Elasticsearch\Tests;
 
+use Doctrine\Common\Inflector\Inflector;
 use Elasticsearch;
 use Elasticsearch\Common\Exceptions\BadRequest400Exception;
 use Elasticsearch\Common\Exceptions\Conflict409Exception;
@@ -9,12 +10,8 @@ use Elasticsearch\Common\Exceptions\Forbidden403Exception;
 use Elasticsearch\Common\Exceptions\Missing404Exception;
 use Elasticsearch\Common\Exceptions\RequestTimeout408Exception;
 use Elasticsearch\Common\Exceptions\ServerErrorResponseException;
-use FilesystemIterator;
-use GuzzleHttp\Ring\Future\FutureArrayInterface;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
-use ReflectionClass;
-use Symfony\Component\Process\Exception\RuntimeException;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Parser;
 use Symfony\Component\Yaml\Yaml;
@@ -29,7 +26,7 @@ use Symfony\Component\Yaml\Yaml;
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link       http://elasticsearch.org
  */
-class YamlRunnerTest extends \PHPUnit_Framework_TestCase
+class YamlRunnerTest2 extends \PHPUnit_Framework_TestCase
 {
     /** @var  Parser */
     private $yaml;
@@ -37,35 +34,28 @@ class YamlRunnerTest extends \PHPUnit_Framework_TestCase
     /** @var  Elasticsearch\client */
     private $client;
 
-    /** @var string */
-    private $log = "";
-
-    /** @var  string */
-    public static $esVersion;
-
-    public static $testCounter = 0;
+    /** @var  Es version */
+    private static $esVersion;
 
     /**
-     * @return mixed
+     * Return the elasticsearch host
+     *
+     * @return string
      */
-    public static function getHostEnvVar()
+    public static function getHost()
     {
         if (isset($_SERVER['ES_TEST_HOST']) === true) {
             return $_SERVER['ES_TEST_HOST'];
-        } else {
-            echo 'Environment variable for elasticsearch test cluster (ES_TEST_HOST) not defined. Exiting yaml test';
-            exit;
         }
+
+        echo 'Environment variable for elasticsearch test cluster (ES_TEST_HOST) not defined. Exiting yaml test';
+        exit;
     }
 
-    private function log($text)
-    {
-        $this->log .= $text;
-    }
 
     public static function setUpBeforeClass()
     {
-        $host = YamlRunnerTest::getHostEnvVar();
+        $host = static::getHost();
         echo "Test Host: $host\n";
 
         $ch = curl_init($host);
@@ -77,28 +67,562 @@ class YamlRunnerTest extends \PHPUnit_Framework_TestCase
         curl_close($ch);
 
         $response = json_decode($response, true);
-        YamlRunnerTest::$esVersion = $response['version']['number'];
-        echo "ES Version: ".YamlRunnerTest::$esVersion."\n";
+        static::$esVersion = $response['version']['number'];
+        echo "ES Version: ".static::$esVersion."\n";
     }
 
     public function setUp()
     {
-        $this->yaml = new Parser();
-        $uri = parse_url($host = YamlRunnerTest::getHostEnvVar());
-
-        $params['hosts'] = array($uri['host'].':'.$uri['port']);
-        //$params['connectionParams']['timeout'] = 10000;
-        //$params['logging'] = true;
-        //$params['logLevel'] = \Psr\Log\LogLevel::DEBUG;
-
-        $this->client = Elasticsearch\ClientBuilder::create()->setHosts($params['hosts'])->build();
-        $this->log = "";
+        $this->clean();
+        $this->client = Elasticsearch\ClientBuilder::create()->setHosts([self::getHost()])->build();
     }
 
-    private function clearCluster()
+    /**
+     * @dataProvider provider
+     */
+    public function testIntegration($testProcedure, $skip, $setupProcedure, $fileName)
     {
-        $this->log("\n>>>CLEARING<<<\n");
-        $host = YamlRunnerTest::getHostEnvVar();
+        if ($skip) {
+            static::markTestIncomplete($testProcedure);
+        }
+
+        if (null !== $setupProcedure) {
+            $this->processProcedure(current($setupProcedure), 'setup');
+            $this->waitForYellow();
+        }
+
+        $this->processProcedure(current($testProcedure), key($testProcedure));
+    }
+
+    /**
+     * Process a procedure
+     *
+     * @param $procedure
+     * @param $name
+     */
+    public function processProcedure($procedure, $name)
+    {
+        $lastOperationResult = null;
+        $context = [];
+
+        foreach ($procedure as $operation) {
+            $lastOperationResult = $this->processOperation($operation, $lastOperationResult, $context, $name);
+        }
+    }
+
+    /**
+     * Process an operation
+     *
+     * @param      $operation
+     * @param      $lastOperationResult
+     * @param      $testName
+     * @param array $context 
+     * @param bool $async
+     *
+     * @return mixed
+     */
+    public function processOperation($operation, $lastOperationResult, &$context, $testName, $async = false)
+    {
+        $operationName = array_keys((array)$operation)[0];
+
+        if ('do' === $operationName) {
+            return $this->operationDo($operation->{$operationName}, $lastOperationResult, $context, $testName);
+        }
+
+        if ('is_false' === $operationName) {
+            return $this->operationIsFalse($operation->{$operationName}, $lastOperationResult, $context, $testName);
+        }
+
+        if ('is_true' === $operationName) {
+            return $this->operationIsTrue($operation->{$operationName}, $lastOperationResult, $context, $testName);
+        }
+
+        if ('match' === $operationName) {
+            return $this->operationMatch($operation->{$operationName}, $lastOperationResult, $context, $testName);
+        }
+
+        if ('gte' === $operationName) {
+            return $this->operationGreaterThanOrEqual($operation->{$operationName}, $lastOperationResult, $context, $testName);
+        }
+
+        if ('gt' === $operationName) {
+            return $this->operationGreaterThan($operation->{$operationName}, $lastOperationResult, $context, $testName);
+        }
+
+        if ('length' === $operationName) {
+            return $this->operationLength($operation->{$operationName}, $lastOperationResult, $context, $testName);
+        }
+
+        if ('set' === $operationName) {
+            return $this->operationSet($operation->{$operationName}, $lastOperationResult, $context, $testName);
+        }
+
+        if ('skip' === $operationName) {
+            return $this->operationSkip($operation->{$operationName}, $lastOperationResult, $testName);
+        }
+
+        self::markTestIncomplete(sprintf('Operation %s not supported for test "%s"', $operationName, $testName));
+    }
+
+    /**
+     * Do something on the client
+     *
+     * @param      $operation
+     * @param      $lastOperationResult
+     * @param array $context
+     * @param      $testName
+     * @param bool $async
+     *
+     * @throws \Exception
+     *
+     * @return mixed
+     */
+    public function operationDo($operation, $lastOperationResult, &$context, $testName, $async = false)
+    {
+        $expectedError = null;
+
+        // Check if a error must be catched
+        if ('catch' === key($operation)) {
+            $expectedError = current($operation);
+            next($operation);
+        }
+
+        $endpointInfo = explode('.', key($operation));
+        $endpointParams = $this->replaceWithContext(current($operation), $context);
+        $caller = $this->client;
+        $method = null;
+
+        if (count($endpointInfo) === 1) {
+            $method = Inflector::camelize($endpointInfo[0]);
+        }
+
+        if (count($endpointInfo) === 2) {
+            $namespace = $endpointInfo[0];
+            $method = Inflector::camelize($endpointInfo[1]);
+            $caller = $caller->$namespace();
+        }
+
+        if (property_exists($endpointParams, 'ignore')) {
+            $ignore = $endpointParams->ignore;
+            unset($endpointParams->ignore);
+
+            $endpointParams->client['ignore'] = $ignore;
+        }
+
+        if (null === $method) {
+            self::markTestIncomplete(sprintf('Invalid do operation for test "%s"', $testName));
+        }
+
+        if (!method_exists($caller, $method)) {
+            self::markTestIncomplete(sprintf('Method "%s" not implement in "%s"', $method, get_class($caller)));
+        }
+
+        try {
+            return $caller->$method($endpointParams);
+        } catch (\Exception $exception) {
+            if (null !== $expectedError) {
+                return $this->assertException($exception, $expectedError, $testName);
+            }
+
+            throw $exception;
+        }
+    }
+
+    /**
+     * Check if a field in the last operation is false
+     *
+     * @param $operation
+     * @param $lastOperationResult
+     * @param $testName
+     */
+    public function operationIsFalse($operation, $lastOperationResult, &$context, $testName)
+    {
+        static::assertFalse((bool)$this->resolveValue($lastOperationResult, $operation, $context), 'Failed to assert that a value is false in test ' . $testName);
+
+        return $lastOperationResult;
+    }
+
+    /**
+     * Check if a field in the last operation is true
+     *
+     * @param $operation
+     * @param $lastOperationResult
+     * @param $testName
+     */
+    public function operationIsTrue($operation, $lastOperationResult, &$context, $testName)
+    {
+        $value = $this->resolveValue($lastOperationResult, $operation, $context);
+
+        static::assertNotEquals(0, $value, 'Failed to assert that a value is true in test ' . $testName);
+        static::assertNotFalse($value, 'Failed to assert that a value is true in test ' . $testName);
+        static::assertNotNull($value, 'Failed to assert that a value is true in test ' . $testName);
+        static::assertNotEquals('', 'Failed to assert that a value is true in test ' . $testName);
+
+        return $lastOperationResult;
+    }
+
+    /**
+     * Check if a field in the last operation match an expected value
+     *
+     * @param $operation
+     * @param $lastOperationResult
+     * @param $testName
+     */
+    public function operationMatch($operation, $lastOperationResult, &$context, $testName)
+    {
+        $key = key($operation);
+
+        if ($key === '$body') {
+            $match = $lastOperationResult;
+        } else {
+            $match = $this->resolveValue($lastOperationResult, $key, $context);
+        }
+
+        $expected = $this->replaceWithContext(current($operation), $context);
+
+        if ($expected === '_description') {
+        }
+
+        if ($expected instanceof \stdClass) {
+            // Avoid stdClass / array mismatch
+            $expected = json_decode(json_encode($expected), true);
+            $match = json_decode(json_encode($match), true);
+
+            static::assertEquals($expected, $match, sprintf('Failed to match in test "%s"', $testName));
+        } elseif (is_string($expected) && preg_match('#^/.+?/$#s', $expected)) {
+            static::assertRegExp($this->formatRegex($expected), $match, sprintf('Failed to match in test "%s"', $testName));
+        } else {
+            static::assertEquals($expected, $match, sprintf('Failed to match in test "%s"', $testName));
+        }
+
+        return $lastOperationResult;
+    }
+
+    /**
+     * Check if a field in the last operation is greater than or equal a value
+     *
+     * @param $operation
+     * @param $lastOperationResult
+     * @param $testName
+     */
+    public function operationGreaterThanOrEqual($operation, $lastOperationResult, &$context, $testName)
+    {
+        $value = $this->resolveValue($lastOperationResult, key($operation), $context);
+        $expected = current($operation);
+
+        static::assertGreaterThanOrEqual($expected, $value, 'Failed to gte in test ' . $testName);
+
+        return $lastOperationResult;
+    }
+
+    /**
+     * Check if a field in the last operation is greater than a value
+     *
+     * @param $operation
+     * @param $lastOperationResult
+     * @param $testName
+     */
+    public function operationGreaterThan($operation, $lastOperationResult, &$context, $testName)
+    {
+        $value = $this->resolveValue($lastOperationResult, key($operation), $context);
+        $expected = current($operation);
+
+        static::assertGreaterThan($expected, $value, 'Failed to gt in test ' . $testName);
+
+        return $lastOperationResult;
+    }
+
+    /**
+     * Check if a field in the last operation has length of a value
+     *
+     * @param $operation
+     * @param $lastOperationResult
+     * @param $testName
+     */
+    public function operationLength($operation, $lastOperationResult, &$context, $testName)
+    {
+        $value = $this->resolveValue($lastOperationResult, key($operation), $context);
+        $expected = current($operation);
+
+        static::assertCount($expected, $value, 'Failed to gte in test ' . $testName);
+
+        return $lastOperationResult;
+    }
+
+    /**
+     * Set a variable into context from last operation
+     *
+     * @param $operation
+     * @param $lastOperationResult
+     * @param $context
+     * @param $testName
+     */
+    public function operationSet($operation, $lastOperationResult, &$context, $testName)
+    {
+        $key = key($operation);
+        $value = $this->resolveValue($lastOperationResult, $key, $context);
+        $variable = current($operation);
+
+        $context['$' . $variable] = $value;
+
+        return $lastOperationResult;
+    }
+
+    /**
+     * Skip an operation depending on Elasticsearch Version
+     *
+     * @param $operation
+     * @param $lastOperationResult
+     * @param $testName
+     */
+    public function operationSkip($operation, $lastOperationResult, $testName)
+    {
+        if (property_exists($operation, 'features')) {
+            // No features supported
+            static::markTestSkipped(sprintf('Feature(s) %s not supported in test "%s"', json_encode($operation->features), $testName));
+        }
+
+        if (property_exists($operation, 'version')) {
+            $version = $operation->version;
+            $version = str_replace(" ", "", $version);
+            $version = explode("-", $version);
+
+            if (isset($version[0]) && $version[0] == 'all') {
+                static::markTestSkipped(sprintf('Skip test "%s", as all versions should be skipped (%s)', $testName, $operation->reason));
+            }
+
+            if (!isset($version[0])) {
+                $version[0] = ~PHP_INT_MAX;
+            }
+
+            if (!isset($version[1])) {
+                $version[1] = PHP_INT_MAX;
+            }
+
+            if (version_compare(static::$esVersion, $version[0]) >= 0 && version_compare($version[1], YamlRunnerTest::$esVersion) >= 0) {
+                static::markTestSkipped(sprintf('Skip test "%s", as version %s should be skipped (%s)', $testName, static::$esVersion, $operation->reason));
+            }
+        }
+
+        return $lastOperationResult;
+    }
+
+    /**
+     * Assert an expected error
+     *
+     * @param \Exception $exception
+     * @param            $expectedError
+     * @param            $testName
+     */
+    private function assertException(\Exception $exception, $expectedError, $testName)
+    {
+        if (is_string($expectedError) && preg_match('#^/.+?/$#', $expectedError)) {
+            static::assertRegExp($expectedError, $exception->getMessage(), 'Failed to catch error in test ' . $testName);
+        } elseif ($exception instanceof Missing404Exception && $expectedError === 'missing') {
+            static::assertTrue(true);
+        } elseif ($exception instanceof Conflict409Exception && $expectedError === 'conflict') {
+            static::assertTrue(true);
+        } elseif ($exception instanceof Forbidden403Exception && $expectedError === 'forbidden') {
+            static::assertTrue(true);
+        } elseif ($exception instanceof RequestTimeout408Exception && $expectedError === 'request_timeout') {
+            static::assertTrue(true);
+        } elseif ($exception instanceof BadRequest400Exception && $expectedError === 'request') {
+            static::assertTrue(true);
+        } elseif ($exception instanceof ServerErrorResponseException && $expectedError === 'request') {
+            static::assertTrue(true);
+        } elseif ($exception instanceof \RuntimeException && $expectedError === 'param') {
+            static::assertTrue(true);
+        } else {
+            static::assertContains($expectedError, $exception->getMessage());
+        }
+
+        if ($exception->getPrevious() !== null) {
+            return json_decode($exception->getPrevious()->getMessage(), true);
+        }
+
+        return json_decode($exception->getMessage(), true);
+    }
+
+    /**
+     * Provider list of document to test
+     *
+     * @return array
+     */
+    public function provider()
+    {
+        $this->yaml = new Yaml();
+        $path = __DIR__ . '/../../../util/elasticsearch/rest-api-spec/src/main/resources/rest-api-spec/test';
+        $files = [];
+
+        $finder = new Finder();
+        $finder->in($path);
+        $finder->files();
+        $finder->name('*.yaml');
+
+        $filter = isset($_SERVER['TEST_CASE']) ? $_SERVER['TEST_CASE'] : null;
+
+        /** @var SplFileInfo $file */
+        foreach ($finder as $file) {
+            $files = array_merge($files, $this->splitDocument($file, $path, $filter));
+        }
+
+        return $files;
+    }
+
+    /**
+     * Replace contextual variable into a bunch of data
+     *
+     * @param $data
+     * @param $context
+     *
+     * @return mixed
+     */
+    private function replaceWithContext($data, $context)
+    {
+        if (empty($context)) {
+            return $data;
+        }
+
+        if (is_string($data) && preg_match('/\$.+?$/', $data)) {
+            if (!array_key_exists($data, $context)) {
+                static::fail(sprintf('Cannot find variable %s in context', $data));
+            }
+
+            return $context[$data];
+        }
+
+        if (!is_array($data) && !$data instanceof \stdClass) {
+            return $data;
+        }
+
+        foreach ($data as $key => &$value) {
+            $value = $this->replaceWithContext($value, $context);
+        }
+
+        return $data;
+    }
+
+    /**
+     * Resolve a value into an array given a specific field
+     *
+     * @param $result
+     * @param $field
+     *
+     * @return mixed
+     */
+    private function resolveValue($result, $field, &$context)
+    {
+        if (empty($field)) {
+            return $result;
+        }
+
+        foreach ($context as $key => $value) {
+            $field = preg_replace('/('.preg_quote($key, '/').')/', $value, $field);
+        }
+
+        $operationSplit = explode('.', $field);
+        $value = $result;
+
+        do {
+            $key = array_shift($operationSplit);
+
+            if (substr($key, -1) === '\\') {
+                $key = substr($key, 0, -1) . '.' . array_shift($operationSplit);
+            }
+
+            if (!is_array($value)) {
+                return $value;
+            }
+
+            if (!array_key_exists($key, $value)) {
+                return false;
+            }
+
+            $value = $value[$key];
+        } while (count($operationSplit) > 0);
+
+        return $value;
+    }
+
+    /**
+     * Format a regex for PHP
+     *
+     * @param $regex
+     *
+     * @return string
+     */
+    private function formatRegex($regex)
+    {
+        $regex = trim($regex);
+        $regex = substr($regex, 1, -1);
+        $regex = str_replace('/', '\\/', $regex);
+        $regex = '/' . $regex . '/mx';
+
+        return $regex;
+    }
+
+    /**
+     * Split file content into multiple document
+     *
+     * @param SplFileInfo $file
+     * @param string      $path;
+     *
+     * @return array
+     */
+    private function splitDocument($file, $path, $filter = null)
+    {
+        $fileContent = file_get_contents($file);
+        $documents = explode("---\n", $fileContent);
+        $documents = array_filter($documents, function ($item) {
+            return trim($item) !== '';
+        });
+
+        $documentsParsed = [];
+        $setup = null;
+        $setupSkip = false;
+        $fileName = str_replace($path . '/', '', $file);
+
+        if (null !== $filter && !preg_match('/'.preg_quote($filter, '/').'/', $fileName)) {
+            return [];
+        }
+
+        foreach ($documents as $documentString) {
+            try {
+                if (!$setupSkip) {
+                    $documentParsed = $this->yaml->parse($documentString, false, false, true);
+                    $skip = false;
+                }
+            } catch (ParseException $exception) {
+                $documentParsed = sprintf(
+                    "Cannot run this test as it cannot be parsed (%s) in file %s",
+                    $exception->getMessage(),
+                    $fileName
+                );
+
+                if (preg_match("#\nsetup:#mx", $documentString)) {
+                    $setupSkip = true;
+                }
+
+                $skip = true;
+            }
+
+            if (!$skip && key($documentParsed) === 'setup') {
+                $setup = $documentParsed;
+                $setupSkip = $skip;
+            } else {
+                $documentsParsed[] = [$documentParsed, $skip || $setupSkip, $setup, $fileName];
+            }
+        }
+
+        return $documentsParsed;
+    }
+
+    /**
+     * Clean the cluster
+     */
+    private function clean()
+    {
+        $host = static::getHost();
         $ch = curl_init($host."/*");
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "DELETE");
@@ -108,6 +632,14 @@ class YamlRunnerTest extends \PHPUnit_Framework_TestCase
         curl_close($ch);
 
         $ch = curl_init($host."/_template/*");
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "DELETE");
+        curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);
+
+        $response = curl_exec($ch);
+        curl_close($ch);
+
+        $ch = curl_init($host."/_analyzer/*");
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "DELETE");
         curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);
@@ -125,39 +657,12 @@ class YamlRunnerTest extends \PHPUnit_Framework_TestCase
         $this->waitForYellow();
     }
 
-    private function assertTruthy($value, $settings)
-    {
-        $this->log("\n         |assertTruthy($settings): ".json_encode($value)."\n");
-        if (isset($value) === false || $value === 0 || $value === false || $value === null || $value === '') {
-            $this->fail("Value is not truthy: ".print_r($value, true) . "\n" . $this->log);
-        }
-    }
-
-    private function assertFalsey($value, $settings)
-    {
-        $this->log("\n         |assertFalsey($settings): ".json_encode($value)."\n");
-        if (!(isset($value) === false || $value === 0 || $value === false || $value === null || $value === '' || count($value) === 0)) {
-            $this->fail("Value is not falsey: ".print_r($value, true) . "\n" . $this->log);
-        }
-    }
-
-    private function assertRegex($pattern, $actual)
-    {
-        $pattern = trim($pattern);
-
-        // PHP doesn't like unescaped forward slashes
-        $pattern = substr($pattern, 1, strlen($pattern)-2);
-        $pattern = str_replace('/', '\/', $pattern);
-        $pattern = "/$pattern/mx";
-        $this->log("\n         |> actual: $actual\n");
-        $this->log("\n         |> pattern: $pattern\n");
-        $result = preg_match($pattern, $actual, $matches);
-        $this->assertEquals(1, $result, $this->log);
-    }
-
+    /**
+     * Wait for cluster to be in a "YELLOW" state
+     */
     private function waitForYellow()
     {
-        $host = YamlRunnerTest::getHostEnvVar();
+        $host = static::getHost();
         $ch = curl_init("$host/_cluster/health?wait_for_status=yellow&timeout=50s");
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "GET");
@@ -179,625 +684,4 @@ class YamlRunnerTest extends \PHPUnit_Framework_TestCase
         }
         curl_close($ch);
     }
-
-    public static function provider()
-    {
-        // Dirty workaround for the path change in Core
-        $path = dirname(__FILE__).'/../../../util/elasticsearch/rest-api-spec/test/';
-        if (file_exists($path) !== true) {
-            $path = dirname(__FILE__).'/../../../util/elasticsearch/rest-api-spec/src/main/resources/rest-api-spec/test';
-        }
-
-        $files = array();
-        $objects = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($path),
-            RecursiveIteratorIterator::SELF_FIRST
-        );
-
-        foreach ($objects as $object) {
-            /** @var FilesystemIterator $object */
-            if ($object->isFile() === true && $object->getFilename() !== 'README.asciidoc' && $object->getFilename() !== 'TODO.txt') {
-                $path = $object->getPathInfo()->getRealPath()."/".$object->getBasename();
-                $files[] = array($path);
-            }
-        }
-
-        YamlRunnerTest::recursiveSort($files);
-
-        return $files;
-    }
-
-    private static function recursiveSort(&$array)
-    {
-        foreach ($array as &$value) {
-            if (is_array($value)) {
-                YamlRunnerTest::recursiveSort($value);
-            }
-        }
-
-        return sort($array);
-    }
-
-    /**
-     * @dataProvider provider
-     * @group yaml
-     */
-    public function testYaml()
-    {
-        //* @runInSeparateProcess
-
-        $files = func_get_args();
-
-        foreach ($files as $testFile) {
-            $counter = YamlRunnerTest::$testCounter;
-
-            $this->log("--------------------------------------------------------------------------\n");
-            $this->log("#$counter : $testFile\n");
-            YamlRunnerTest::$testCounter += 1;
-
-            if ($this->skipTest($testFile) === true) {
-                $this->markTestSkipped('Skipped due to skip-list');
-            }
-
-            if (isset($_SERVER['TEST_CASE']) === true && !empty($_SERVER['TEST_CASE'])) {
-                if ($_SERVER['TEST_CASE'] !== $testFile) {
-                    $this->markTestSkipped('Skipping, these are not the tests you\'re looking for...');
-                }
-            }
-
-            $fileData = file_get_contents($testFile);
-            $documents = array_filter(explode("---", $fileData));
-
-            $yamlDocs = array();
-            $setup = null;
-
-            foreach ($documents as $document) {
-                try {
-                    $tDoc = array();
-                    $tDoc['document'] = $this->checkForTimestamp($testFile, $document);
-                    $tDoc['document'] = $this->checkForList($tDoc['document']);
-                    $tDoc['document'] = $this->checkForEmptyProperty($testFile, $tDoc['document']);
-                    $tDoc['values'] = $this->yaml->parse($tDoc['document'], false, false, true);
-
-                    if (key($tDoc['values']) === 'setup') {
-                        $setup = $tDoc['values'];
-                    } else {
-                        $yamlDocs[] = $tDoc;
-                    }
-                } catch (ParseException $e) {
-                    $this->fail(sprintf("Unable to parse the YAML string: %s in file %s", $e->getMessage(), $testFile));
-                }
-            }
-
-            foreach ($yamlDocs as $doc) {
-                $ts = date('c');
-                $this->log("   ".key($doc['values'])." [$ts] - Future: false\n");
-
-                $this->clearCluster();
-
-                if ($setup !== null) {
-                    try {
-                        $this->executeTestCase($setup, $testFile, false);
-                    } catch (SetupSkipException $e) {
-                        break;  //exit this test since we skipped in the setup
-                    }
-                }
-                $this->executeTestCase($doc['values'], $testFile, false);
-
-                $this->log("Success\n\n");
-            }
-        }
-    }
-
-    /**
-     * @dataProvider provider
-     * @group yaml
-     */
-    public function testFutureModeYaml()
-    {
-        //* @runInSeparateProcess
-
-        $files = func_get_args();
-
-        foreach ($files as $testFile) {
-            $this->log("$testFile\n");
-
-            if ($this->skipTest($testFile) === true) {
-                $this->markTestSkipped('Skipped due to skip-list');
-            }
-
-            if (isset($_SERVER['TEST_CASE']) === true && !empty($_SERVER['TEST_CASE'])) {
-                if ($_SERVER['TEST_CASE'] !== $testFile) {
-                    $this->markTestSkipped('Skipping, these are not the tests you\'re looking for...');
-                }
-            }
-
-            $fileData = file_get_contents($testFile);
-            $containsExist = strpos($fileData, "exists");
-            $documents = array_filter(explode("---", $fileData));
-
-            $yamlDocs = array();
-            $setup = null;
-            foreach ($documents as $document) {
-                try {
-                    $tDoc = array();
-                    $tDoc['document'] = $this->checkForTimestamp($testFile, $document);
-                    $tDoc['document'] = $this->checkForList($tDoc['document']);
-                    $tDoc['document'] = $this->checkForEmptyProperty($testFile, $tDoc['document']);
-                    $tDoc['values'] = $this->yaml->parse($tDoc['document'], false, false, true);
-
-                    if (key($tDoc['values']) === 'setup') {
-                        $setup = $tDoc['values'];
-                    } else {
-                        $yamlDocs[] = $tDoc;
-                    }
-                } catch (ParseException $e) {
-                    $this->fail(sprintf("Unable to parse the YAML string: %s in file %s", $e->getMessage(), $testFile));
-                }
-            }
-
-            foreach ($yamlDocs as $doc) {
-                $ts = date('c');
-                $this->log("   ".key($doc['values'])." [$ts] - Future: true\n");
-
-                if ($containsExist !== false) {
-                    $this->markTestSkipped('Test contains `exist`, not easily tested in async. Skipping.');
-                }
-
-                $this->clearCluster();
-
-                if ($setup !== null) {
-                    try {
-                        $this->executeTestCase($setup, $testFile, false);
-                    } catch (SetupSkipException $e) {
-                        break;  //exit this test since we skipped in the setup
-                    }
-                }
-                $this->executeTestCase($doc['values'], $testFile, true);
-            }
-        }
-    }
-
-    public static function replaceWithStash($values, $stash)
-    {
-        if (count($stash) === 0) {
-            return $values;
-        }
-
-        if (is_array($values) === true) {
-            array_walk_recursive($values, function (&$item, $key) use ($stash) {
-                if (is_string($item) === true) {
-                    if (array_key_exists($item, $stash) == true) {
-                        $item = $stash[$item];
-                    }
-                } elseif (is_object($item) === true) {
-                    $tItem = json_decode(json_encode($item), true);
-
-                    // Have to make sure we don't convert empty objects ( {} ) into arrays
-                    if (count($tItem) > 0) {
-                        $item = YamlRunnerTest::replaceWithStash($item, $stash);
-                    }
-                }
-
-            });
-        } elseif (is_string($values) || is_numeric($values)) {
-            if (array_key_exists($values, $stash) == true) {
-                $values = $stash[$values];
-            } else {
-                // Couldn't find the entire value, try a substring replace
-                foreach ($stash as $k => $v) {
-                    $values = str_replace($k, $v, $values);
-                }
-            }
-        } elseif (is_object($values) === true) {
-            $values = json_decode(json_encode($values), true);
-            $values = YamlRunnerTest::replaceWithStash($values, $stash);
-        }
-
-        return $values;
-    }
-
-    private function executeTestCase($test, $testFile, $future)
-    {
-        $stash = array();
-        $response = array();
-        reset($test);
-        $key = key($test);
-
-        foreach ($test[$key] as $operators) {
-            foreach ($operators as $operator => $settings) {
-                $this->log("      > $operator: ");
-                if ($operator === 'do') {
-                    if (key($settings) === 'catch') {
-                        $catch = $this->getValue($settings, 'catch');
-                        $expectedError = str_replace("/", "", $catch);
-                        next($settings);
-
-                        $this->log("(catch: $expectedError) ");
-                    } else {
-                        $expectedError = null;
-                    }
-
-                    $method = key($settings);
-                    $hash = $this->getValue($settings, $method);
-
-                    $this->log("\n         |$method\n");
-
-
-                    $hash = YamlRunnerTest::replaceWithStash($hash, $stash);
-
-
-                    try {
-                        $this->log("         |".json_encode($hash)."\n");
-                        ob_flush();
-                        $response = $this->callMethod($method, $hash, $future);
-                        $this->log("         |".json_encode($response)."\n");
-
-                        //$this->waitForYellow();
-
-                        if (isset($expectedError) === true) {
-                            $this->fail("Expected Exception not thrown: $expectedError");
-                        }
-                    } catch (\Exception $exception) {
-                        if ($expectedError === null) {
-                            $this->fail($exception->getMessage());
-                        }
-
-                        $response = $this->handleCaughtException($exception, $expectedError);
-                    }
-                } elseif ($operator === 'match') {
-                    $expected = $this->getValue($settings, key($settings));
-                    if (key($settings) === '') {
-                        $actual = $response;
-                    } elseif (key($settings) === '$body') {
-                        $actual = $response;
-                    } else {
-                        $path = YamlRunnerTest::replaceWithStash(key($settings), $stash);
-                        $actual = $this->getNestedVar($response, $path);
-                    }
-
-                    $expected = YamlRunnerTest::replaceWithStash($expected, $stash);
-                    $actual = YamlRunnerTest::replaceWithStash($actual, $stash);
-                    if ($actual != $expected) {
-                        //Holy janky batman
-                        if (is_array($actual) && count($actual) == 0) {
-                            $actual = (object) $actual;
-                        } else {
-                            $actual = json_decode(json_encode($actual));
-                        }
-
-                        $expected = json_decode(json_encode($expected));
-                    }
-
-                    if ($this->checkForRegex($expected) === true) {
-                        $this->assertRegex($expected, $actual);
-                    } else {
-                        $this->assertEquals($expected, $actual, $this->log);
-                    }
-
-                    //$this->assertSame()
-
-                    $this->log("\n");
-                } elseif ($operator === "is_true") {
-                    if (empty($settings) === true) {
-                        $response = YamlRunnerTest::replaceWithStash($response, $stash);
-                        $this->assertTruthy($response, $settings);
-                    } else {
-                        $settings = YamlRunnerTest::replaceWithStash($settings, $stash);
-                        $this->log("settings after replace: ");
-                        //print_r($settings);
-                        $this->log("\n");
-                        $actual = $this->getNestedVar($response, $settings);
-                        $actual = YamlRunnerTest::replaceWithStash($actual, $stash);
-                        $this->assertTruthy($actual, $settings);
-                    }
-
-                    $this->log("\n");
-                } elseif ($operator === "is_false") {
-                    if (empty($settings) === true) {
-                        $response = YamlRunnerTest::replaceWithStash($response, $stash);
-                        $this->assertFalsey($response, $settings);
-                    } else {
-                        $actual = $this->getNestedVar($response, $settings);
-                        $actual = YamlRunnerTest::replaceWithStash($actual, $stash);
-                        $this->assertFalsey($actual, $settings);
-                    }
-
-                    $this->log("\n");
-                } elseif ($operator === 'set') {
-                    $stashKey = $this->getValue($settings, key($settings));
-                    $this->log(" $stashKey\n");
-                    $stash["$$stashKey"] = $this->getNestedVar($response, key($settings));
-                    $this->log("Stash updated.  Total stash now: \n");
-                    //print_r($stash);
-                    $this->log("\n");
-                } elseif ($operator === "length") {
-                    $expectedCount = $this->getValue($settings, key($settings));
-                    $this->assertCount($expectedCount, $this->getNestedVar($response, key($settings)), $this->log);
-                    $this->log("\n");
-                } elseif ($operator === "lt") {
-                    $expectedCount = $this->getValue($settings, key($settings));
-                    $this->assertLessThan($expectedCount, $this->getNestedVar($response, key($settings)), $this->log);
-                    $this->log("\n");
-                } elseif ($operator === "gt") {
-                    $expectedCount = $this->getValue($settings, key($settings));
-                    $this->assertGreaterThan($expectedCount, $this->getNestedVar($response, key($settings)), $this->log);
-                    $this->log("\n");
-                } elseif ($operator === "skip") {
-                    if (isset($settings['version']) === true) {
-                        $version = $settings['version'];
-                        $version = str_replace(" ", "", $version);
-                        $version = explode("-", $version);
-
-                        if (isset($version[0]) && $version[0] == 'all') {
-                            $this->log("Skipping: all\n");
-                            if ($key == 'setup') {
-                                throw new SetupSkipException();
-                            }
-                            return;
-                        }
-                        if (!isset($version[0])) {
-                            $version[0] = ~PHP_INT_MAX;
-                        }
-                        if (!isset($version[1])) {
-                            $version[1] = PHP_INT_MAX;
-                        }
-                        if (version_compare(YamlRunnerTest::$esVersion, $version[0]) >= 0
-                            && version_compare($version[1], YamlRunnerTest::$esVersion) >= 0) {
-                            $this->log("Skipping: ".$settings['reason']."\n");
-
-                            if ($key == 'setup') {
-                                throw new SetupSkipException();
-                            }
-
-                            return;
-                        }
-                    } elseif (isset($settings['features']) === true) {
-                        $feature = $settings['features'];
-                        $whitelist = array();
-
-                        if (array_search($feature, $whitelist) === false) {
-                            $this->log("Unsupported optional feature: " . print_r($feature, true) . "\n");
-
-                            return;
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    private function handleCaughtException(\Exception $exception, $expectedError)
-    {
-        $reflect = new ReflectionClass($exception);
-        $caught = $reflect->getShortName();
-        $passed = false;
-
-
-        if ($caught === 'Missing404Exception' && $expectedError === 'missing') {
-            $passed = true;
-        } elseif ($caught === 'Conflict409Exception' && $expectedError === 'conflict') {
-            $passed = true;
-        } elseif ($caught === 'Missing404Exception' && $expectedError === 'missing') {
-            $passed = true;
-        } elseif ($caught === 'Forbidden403Exception' && $expectedError === 'forbidden') {
-            $passed = true;
-        } elseif ($caught === 'RequestTimeout408Exception' && $expectedError === 'request_timeout') {
-            $passed = true;
-        } elseif ($caught === 'BadRequest400Exception' && $expectedError === 'request') {
-            $passed = true;
-        } elseif ($caught === 'ServerErrorResponseException' && $expectedError === 'request') {
-            $passed = true;
-        } elseif ($caught === 'RuntimeException' && $expectedError === 'param') {
-            $passed = true;
-        } elseif ($caught === 'Missing404Exception' && $expectedError === 'missing') {
-            $passed = true;
-        }
-
-        if ($passed === false) {
-            if (YamlRunnerTest::checkExceptionRegex($expectedError, $exception)) {
-                $passed = true;
-            } elseif ($exception->getPrevious() !== null) { // try second level
-                if (YamlRunnerTest::checkExceptionRegex($expectedError, $exception->getPrevious())) {
-                    $passed = true;
-                }
-            }
-        }
-
-        if ($passed === true) {
-            $this->assertTrue(true, $this->log);
-            if ($exception->getPrevious() !== null) {
-                return json_decode($exception->getPrevious()->getMessage(), true);
-            }
-            return json_decode($exception->getMessage(), true);
-        }
-
-        //$this->fail("Tried to match exception, failed.  Exception: ".$exception->getMessage());
-        throw $exception;
-    }
-
-
-    private static function checkExceptionRegex($expectedError, \Exception $exception)
-    {
-        return isset($expectedError) === true && preg_match("/$expectedError/", $exception->getMessage()) === 1;
-    }
-
-    private function callMethod($method, $hash, $future)
-    {
-        $ret = array();
-
-        $methodParts = explode(".", $method);
-
-        if (is_object($hash)) {
-            $hash = json_decode(json_encode($hash), true);
-        }
-
-        if ($future === true) {
-            $hash['client'] = [];
-            $hash['client']['future'] = true;
-        }
-
-        if (isset($hash['ignore']) === true) {
-            $hash['client']['ignore'] = $hash['ignore'];
-            unset($hash['ignore']);
-        }
-
-        if (count($methodParts) > 1) {
-            $methodName = $methodParts[0];
-            $methodArgs = $this->snakeToCamel($methodParts[1]);
-            $ret = $this->client->$methodName()->$methodArgs($hash);
-        } else {
-            $method = $this->snakeToCamel($method);
-            $ret = $this->client->$method($hash);
-        }
-
-        if ($future && $ret instanceof FutureArrayInterface) {
-            $ret = $ret->wait();
-        }
-
-        return $ret;
-    }
-
-    private function getValue($a, $key)
-    {
-        if (is_array($a)) {
-            return $a[$key];
-        } elseif (is_object($a)) {
-            return $a->$key;
-        } else {
-            die('non-array, non-object in getValue()');
-        }
-    }
-
-    private function snakeToCamel($val)
-    {
-        return str_replace(' ', '', lcfirst(ucwords(str_replace('_', ' ', $val))));
-    }
-
-    private function getNestedVar(&$context, $name)
-    {
-        $pieces = preg_split('/(?<!\\\\)\./', $name);
-        foreach ($pieces as $piece) {
-            $piece = str_replace('\.', '.', $piece);
-            if (!is_array($context) || !array_key_exists($piece, $context)) {
-                // error occurred
-                $this->log("Could not find nested property [$piece] in context");//.print_r($context, true);
-                $this->log("\nReturning null...");
-                return null;
-            }
-            $context = &$context[$piece];
-        }
-
-        return $context;
-    }
-
-    /**
-     * Really ugly hack until upstream Yaml date parsing is fixed
-     * See: https://github.com/symfony/symfony/issues/8580
-     * TODO
-     *
-     * @param $file
-     * @param $document
-     *
-     * @return mixed
-     */
-    private function checkForTimestamp($file, $document)
-    {
-        $isMatch = preg_match($this->getTimestampRegex(), $document, $matches);
-        if ($isMatch) {
-            $newTime = new \DateTime($matches[0].'GMT');
-            $document = preg_replace($this->getTimestampRegex(), $newTime->format('U') * 1000, $document);
-        }
-
-        return $document;
-    }
-
-    /**
-     * Hack to rewrite the command `task.list` into `task.get`, since list is a reserved
-     * word in PHP. :/
-     *
-     * @param $file
-     * @return mixed
-     */
-    private function checkForList($document)
-    {
-        return str_replace("tasks.list", "tasks.get", $document);
-    }
-
-    private function checkForEmptyProperty($file, $document)
-    {
-        $pattern = "/{.*?('').*?:.*?{/";
-
-        $document = preg_replace($pattern, '{ $body: {', $document);
-
-        return $document;
-    }
-
-    private function checkForRegex($value)
-    {
-        if (is_string($value) !== true) {
-            return false;
-        }
-
-        $value = trim($value);
-        if (substr($value, 0, 1) === '/' && substr($value, strlen($value) - 1, 1) === '/') {
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    private function getTimestampRegex()
-    {
-        return <<<EOF
-        ~[^"]
-        (?P<year>[0-9][0-9][0-9][0-9])
-        -(?P<month>[0-9][0-9]?)
-        -(?P<day>[0-9][0-9]?)
-        (?:(?:[Tt]|[ \t]+)
-        (?P<hour>[0-9][0-9]?)
-        :(?P<minute>[0-9][0-9])
-        :(?P<second>[0-9][0-9])
-        (?:\.(?P<fraction>[0-9]*))?
-        (?:[ \t]*(?P<tz>Z|(?P<tz_sign>[-+])(?P<tz_hour>[0-9][0-9]?)
-        (?::(?P<tz_minute>[0-9][0-9]))?))?)?
-        [^"]~x
-EOF;
-    }
-
-    private function skipTest($path)
-    {
-        //all_path_options
-        $skipList = array(
-            'cat.nodeattrs/10_basic.yaml',
-            'cat.repositories/10_basic.yaml'
-        );
-
-        foreach ($skipList as $skip) {
-            if (strpos($path, $skip) !== false) {
-                return true;
-            }
-        }
-
-        //TODO make this more generic
-        if (version_compare(YamlRunnerTest::$esVersion, "1.4.0", "<")) {
-            // Breaking changes in null alias
-            $skipList = array(
-                'indices.delete_alias/all_path_options.yaml',
-                'indices.put_alias/all_path_options.yaml'
-            );
-
-            foreach ($skipList as $skip) {
-                if (strpos($path, $skip) !== false) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-}
-
-class SetupSkipException extends \Exception
-{
 }


### PR DESCRIPTION
Hello,

I was curious how integration test was working so i rewrite the test class, IMO it is more readbable and debuggable (but that's subjective) , also i start from scratch by looking as few as possible as the existing one.

I also split into 2 phpunit files, now by default integrations tests are not run, but you can use the phpunit-integration.xml file to run integrations tests (i add it to travis).

I also try to fix tests / code, but from what i have seen, most of the remaining tests that are failing are yaml files not updated with the current contract of elasticsearch.

Also there is no more run in async as, IMO, it does not add value to do that in integration.