### PR TITLE
Allow to get multiple pipelines without id

### DIFF
--- a/src/Elasticsearch/Endpoints/Ingest/Pipeline/Get.php
+++ b/src/Elasticsearch/Endpoints/Ingest/Pipeline/Get.php
@@ -23,14 +23,12 @@ class Get extends AbstractEndpoint
     public function getURI()
     {
         if (isset($this->id) !== true) {
-            throw new Exceptions\RuntimeException(
-                'id is required for GetPipeline'
-            );
+            return '/_ingest/pipeline/*';
         }
-        $id = $this->id;
-        $uri = "/_ingest/pipeline/$id";
 
-        return $uri;
+        $id = $this->id;
+
+        return "/_ingest/pipeline/$id";
     }
 
     /**


### PR DESCRIPTION
Ref this https://github.com/elastic/elasticsearch-php/pull/447/commits/bd00e228ded2583fb0ef2b03e4053bc9613edcc6#diff-aefcee0e9e5740f9f538f702a848a6c1L26
