### PR TITLE
Allow ConnectionFactory to be override

### DIFF
--- a/src/Elasticsearch/ConnectionPool/AbstractConnectionPool.php
+++ b/src/Elasticsearch/ConnectionPool/AbstractConnectionPool.php
@@ -5,7 +5,8 @@ namespace Elasticsearch\ConnectionPool;
 use Elasticsearch\Common\Exceptions\InvalidArgumentException;
 use Elasticsearch\ConnectionPool\Selectors\SelectorInterface;
 use Elasticsearch\Connections\Connection;
-use Elasticsearch\Connections\ConnectionFactory;
+use Elasticsearch\Connections\ConnectionFactoryInterface;
+use Elasticsearch\Connections\ConnectionInterface;
 
 /**
  * Class AbstractConnectionPool
@@ -39,18 +40,21 @@ abstract class AbstractConnectionPool implements ConnectionPoolInterface
      */
     protected $selector;
 
+    /** @var array */
+    protected $connectionPoolParams;
+
     /** @var \Elasticsearch\Connections\ConnectionFactory  */
     protected $connectionFactory;
 
     /**
      * Constructor
      *
-     * @param ConnectionInterface[] $connections          The Connections to choose from
-     * @param SelectorInterface     $selector             A Selector instance to perform the selection logic for the available connections
-     * @param ConnectionFactory     $factory              ConnectionFactory instance
-     * @param array                 $connectionPoolParams
+     * @param ConnectionInterface[]          $connections          The Connections to choose from
+     * @param SelectorInterface              $selector             A Selector instance to perform the selection logic for the available connections
+     * @param ConnectionFactoryInterface     $factory              ConnectionFactory instance
+     * @param array                          $connectionPoolParams
      */
-    public function __construct($connections, SelectorInterface $selector, ConnectionFactory $factory, $connectionPoolParams)
+    public function __construct($connections, SelectorInterface $selector, ConnectionFactoryInterface $factory, $connectionPoolParams)
     {
         $paramList = array('connections', 'selector', 'connectionPoolParams');
         foreach ($paramList as $param) {

--- a/src/Elasticsearch/ConnectionPool/SimpleConnectionPool.php
+++ b/src/Elasticsearch/ConnectionPool/SimpleConnectionPool.php
@@ -2,10 +2,9 @@
 
 namespace Elasticsearch\ConnectionPool;
 
-use Elasticsearch\Common\Exceptions\NoNodesAvailableException;
 use Elasticsearch\ConnectionPool\Selectors\SelectorInterface;
 use Elasticsearch\Connections\Connection;
-use Elasticsearch\Connections\ConnectionFactory;
+use Elasticsearch\Connections\ConnectionFactoryInterface;
 
 class SimpleConnectionPool extends AbstractConnectionPool implements ConnectionPoolInterface
 {
@@ -13,7 +12,7 @@ class SimpleConnectionPool extends AbstractConnectionPool implements ConnectionP
     /**
      * {@inheritdoc}
      */
-    public function __construct($connections, SelectorInterface $selector, ConnectionFactory $factory, $connectionPoolParams)
+    public function __construct($connections, SelectorInterface $selector, ConnectionFactoryInterface $factory, $connectionPoolParams)
     {
         parent::__construct($connections, $selector, $factory, $connectionPoolParams);
     }

--- a/src/Elasticsearch/ConnectionPool/SniffingConnectionPool.php
+++ b/src/Elasticsearch/ConnectionPool/SniffingConnectionPool.php
@@ -6,7 +6,7 @@ use Elasticsearch\Common\Exceptions\Curl\OperationTimeoutException;
 use Elasticsearch\Common\Exceptions\NoNodesAvailableException;
 use Elasticsearch\ConnectionPool\Selectors\SelectorInterface;
 use Elasticsearch\Connections\Connection;
-use Elasticsearch\Connections\ConnectionFactory;
+use Elasticsearch\Connections\ConnectionFactoryInterface;
 
 class SniffingConnectionPool extends AbstractConnectionPool implements ConnectionPoolInterface
 {
@@ -16,7 +16,10 @@ class SniffingConnectionPool extends AbstractConnectionPool implements Connectio
     /** @var  int */
     private $nextSniff = -1;
 
-    public function __construct($connections, SelectorInterface $selector, ConnectionFactory $factory, $connectionPoolParams)
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct($connections, SelectorInterface $selector, ConnectionFactoryInterface $factory, $connectionPoolParams)
     {
         parent::__construct($connections, $selector, $factory, $connectionPoolParams);
 

--- a/src/Elasticsearch/ConnectionPool/StaticConnectionPool.php
+++ b/src/Elasticsearch/ConnectionPool/StaticConnectionPool.php
@@ -5,7 +5,7 @@ namespace Elasticsearch\ConnectionPool;
 use Elasticsearch\Common\Exceptions\NoNodesAvailableException;
 use Elasticsearch\ConnectionPool\Selectors\SelectorInterface;
 use Elasticsearch\Connections\Connection;
-use Elasticsearch\Connections\ConnectionFactory;
+use Elasticsearch\Connections\ConnectionFactoryInterface;
 
 class StaticConnectionPool extends AbstractConnectionPool implements ConnectionPoolInterface
 {
@@ -22,7 +22,7 @@ class StaticConnectionPool extends AbstractConnectionPool implements ConnectionP
     /**
      * {@inheritdoc}
      */
-    public function __construct($connections, SelectorInterface $selector, ConnectionFactory $factory, $connectionPoolParams)
+    public function __construct($connections, SelectorInterface $selector, ConnectionFactoryInterface $factory, $connectionPoolParams)
     {
         parent::__construct($connections, $selector, $factory, $connectionPoolParams);
         $this->scheduleCheck();

--- a/src/Elasticsearch/ConnectionPool/StaticNoPingConnectionPool.php
+++ b/src/Elasticsearch/ConnectionPool/StaticNoPingConnectionPool.php
@@ -5,7 +5,7 @@ namespace Elasticsearch\ConnectionPool;
 use Elasticsearch\Common\Exceptions\NoNodesAvailableException;
 use Elasticsearch\ConnectionPool\Selectors\SelectorInterface;
 use Elasticsearch\Connections\Connection;
-use Elasticsearch\Connections\ConnectionFactory;
+use Elasticsearch\Connections\ConnectionFactoryInterface;
 
 class StaticNoPingConnectionPool extends AbstractConnectionPool implements ConnectionPoolInterface
 {
@@ -22,7 +22,7 @@ class StaticNoPingConnectionPool extends AbstractConnectionPool implements Conne
     /**
      * {@inheritdoc}
      */
-    public function __construct($connections, SelectorInterface $selector, ConnectionFactory $factory, $connectionPoolParams)
+    public function __construct($connections, SelectorInterface $selector, ConnectionFactoryInterface $factory, $connectionPoolParams)
     {
         parent::__construct($connections, $selector, $factory, $connectionPoolParams);
     }

--- a/src/Elasticsearch/Connections/ConnectionFactory.php
+++ b/src/Elasticsearch/Connections/ConnectionFactory.php
@@ -19,6 +19,9 @@ class ConnectionFactory implements ConnectionFactoryInterface
     /** @var  array */
     private $connectionParams;
 
+    /** @var  SerializerInterface */
+    private $serializer;
+
     /** @var  LoggerInterface */
     private $logger;
 


### PR DESCRIPTION
Changing the ConnectionFactory with the `ClientBuilder::setConnectionFactory` can't work since in AbstractConnectionPool class, it was not the `ConnectionFactoryInterface` that is waiting but the `ConnectionFactory`

Also added 2 missing properties declaration.