### PR TITLE
Fix typo

### DIFF
--- a/src/Elasticsearch/Client.php
+++ b/src/Elasticsearch/Client.php
@@ -709,7 +709,7 @@ class Client
         /** @var callback $endpointBuilder */
         $endpointBuilder = $this->endpoints;
         /** @var \Elasticsearch\Endpoints\Reindex $endpoint */
-        $endpoint = $endpointBuilder('Reindex');
+        $endpoint = $endpointBuilder('ReIndex');
         $endpoint->setBody($body);
         $endpoint->setParams($params);
 


### PR DESCRIPTION
Fix typo, the endpoint class is `ReIndex`, not `Reindex`