### PR TITLE
fixed Endpoint for case sensitive filesystems

### DIFF
--- a/src/Elasticsearch/Client.php
+++ b/src/Elasticsearch/Client.php
@@ -708,8 +708,8 @@ class Client
 
         /** @var callback $endpointBuilder */
         $endpointBuilder = $this->endpoints;
-        /** @var \Elasticsearch\Endpoints\Reindex $endpoint */
-        $endpoint = $endpointBuilder('Reindex');
+        /** @var \Elasticsearch\Endpoints\ReIndex $endpoint */
+        $endpoint = $endpointBuilder('ReIndex');
         $endpoint->setBody($body);
         $endpoint->setParams($params);
 


### PR DESCRIPTION
the class is `Elasticsearch\Endpoints\ReIndex`, not with a lower  ì`

finding this class fails on case-sensitive filesystem (probably all except macos fs)