### PR TITLE
add JSON_PRESERVE_ZERO_FRACTION for Json_encode

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": "^5.6|^7.0",
+    "php": "^5.6.6|^7.0",
     "psr/log": "~1.0",
     "guzzlehttp/ringphp" : "~1.0"
   },

--- a/src/Elasticsearch/Serializers/ArrayToJSONSerializer.php
+++ b/src/Elasticsearch/Serializers/ArrayToJSONSerializer.php
@@ -25,7 +25,7 @@ class ArrayToJSONSerializer implements SerializerInterface
         if (is_string($data) === true) {
             return $data;
         } else {
-            $data = json_encode($data);
+            $data = json_encode($data, JSON_PRESERVE_ZERO_FRACTION);
             if ($data === '[]') {
                 return '{}';
             } else {

--- a/src/Elasticsearch/Serializers/EverythingToJSONSerializer.php
+++ b/src/Elasticsearch/Serializers/EverythingToJSONSerializer.php
@@ -22,7 +22,7 @@ class EverythingToJSONSerializer implements SerializerInterface
      */
     public function serialize($data)
     {
-        $data = json_encode($data);
+        $data = json_encode($data, JSON_PRESERVE_ZERO_FRACTION);
         if ($data === '[]') {
             return '{}';
         } else {

--- a/src/Elasticsearch/Serializers/SmartSerializer.php
+++ b/src/Elasticsearch/Serializers/SmartSerializer.php
@@ -27,7 +27,7 @@ class SmartSerializer implements SerializerInterface
         if (is_string($data) === true) {
             return $data;
         } else {
-            $data = json_encode($data);
+            $data = json_encode($data, JSON_PRESERVE_ZERO_FRACTION);
             if ($data === '[]') {
                 return '{}';
             } else {

--- a/tests/Elasticsearch/Tests/Serializers/ArrayToJSONSerializerTest.php
+++ b/tests/Elasticsearch/Tests/Serializers/ArrayToJSONSerializerTest.php
@@ -24,7 +24,7 @@ class ArrayToJSONSerializerTest extends PHPUnit_Framework_TestCase
 
         $ret = $serializer->serialize($body);
 
-        $body = json_encode($body);
+        $body = json_encode($body, JSON_PRESERVE_ZERO_FRACTION);
         $this->assertEquals($body, $ret);
     }
 

--- a/tests/Elasticsearch/Tests/Serializers/EverythingToJSONSerializerTest.php
+++ b/tests/Elasticsearch/Tests/Serializers/EverythingToJSONSerializerTest.php
@@ -24,7 +24,7 @@ class EverythingToJSONSerializerTest extends PHPUnit_Framework_TestCase
 
         $ret = $serializer->serialize($body);
 
-        $body = json_encode($body);
+        $body = json_encode($body, JSON_PRESERVE_ZERO_FRACTION);
         $this->assertEquals($body, $ret);
     }
 


### PR DESCRIPTION
Problem discuss here
http://stackoverflow.com/questions/30726049/php-how-to-prevent-json-encode-rounding-number-automatically
This is important with dynamic mapping, when the first stored value is 0.0 but the field should be fractional. In current version (float)0.0 converted to (int)0 and elastic created field with long type.

Warning! JSON_PRESERVE_ZERO_FRACTION option available since PHP 5.6.6.