### PR TITLE
Encode Url to accept UTF-8 Char

### DIFF
--- a/src/Elasticsearch/Endpoints/Cat/Aliases.php
+++ b/src/Elasticsearch/Endpoints/Cat/Aliases.php
@@ -29,7 +29,7 @@ class Aliases extends AbstractEndpoint
             return $this;
         }
 
-        $this->name = $name;
+        $this->name = urlencode($name);
 
         return $this;
     }

--- a/src/Elasticsearch/Endpoints/Cat/Allocation.php
+++ b/src/Elasticsearch/Endpoints/Cat/Allocation.php
@@ -29,7 +29,7 @@ class Allocation extends AbstractEndpoint
             return $this;
         }
 
-        $this->node_id = $node_id;
+        $this->node_id = urlencode($node_id);
 
         return $this;
     }

--- a/src/Elasticsearch/Endpoints/Cat/Fielddata.php
+++ b/src/Elasticsearch/Endpoints/Cat/Fielddata.php
@@ -28,7 +28,7 @@ class Fielddata extends AbstractEndpoint
             return $this;
         }
 
-        $this->fields = $fields;
+        $this->fields = urlencode($fields);
 
         return $this;
     }

--- a/src/Elasticsearch/Endpoints/Cluster/Nodes/AbstractNodesEndpoint.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Nodes/AbstractNodesEndpoint.php
@@ -18,6 +18,9 @@ abstract class AbstractNodesEndpoint extends AbstractEndpoint
 {
     /** @var  string  A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#039;re connecting to, leave empty to get information from all nodes */
     protected $nodeID;
+    
+    /** @var  string A comma-separated list of metrics you wish returned. Leave empty to return all. */
+    protected $metric;
 
     /**
      * @param $nodeID
@@ -40,7 +43,27 @@ abstract class AbstractNodesEndpoint extends AbstractEndpoint
             $nodeID = implode(',', $nodeID);
         }
 
-        $this->nodeID = $nodeID;
+        $this->nodeID = urlencode($nodeID);
+
+        return $this;
+    }
+
+    /**
+     * @param $metric
+     *
+     * @return $this
+     */
+    public function setMetric($metric)
+    {
+        if (isset($metric) !== true) {
+            return $this;
+        }
+
+        if (is_array($metric) === true) {
+            $metric = implode(",", $metric);
+        }
+
+        $this->metric = urlencode($metric);
 
         return $this;
     }

--- a/src/Elasticsearch/Endpoints/Cluster/Nodes/Info.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Nodes/Info.php
@@ -13,29 +13,6 @@ namespace Elasticsearch\Endpoints\Cluster\Nodes;
  */
 class Info extends AbstractNodesEndpoint
 {
-    // A comma-separated list of metrics you wish returned. Leave empty to return all.
-    private $metric;
-
-    /**
-     * @param $metric
-     *
-     * @return $this
-     */
-    public function setMetric($metric)
-    {
-        if (isset($metric) !== true) {
-            return $this;
-        }
-
-        if (is_array($metric) === true) {
-            $metric = implode(",", $metric);
-        }
-
-        $this->metric = $metric;
-
-        return $this;
-    }
-
     /**
      * @return string
      */

--- a/src/Elasticsearch/Endpoints/Cluster/Nodes/Stats.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Nodes/Stats.php
@@ -13,31 +13,8 @@ namespace Elasticsearch\Endpoints\Cluster\Nodes;
  */
 class Stats extends AbstractNodesEndpoint
 {
-    // Limit the information returned to the specified metrics
-    private $metric;
-
     // Limit the information returned for `indices` metric to the specific index metrics. Isn&#039;t used if `indices` (or `all`) metric isn&#039;t specified.
     private $indexMetric;
-
-    /**
-     * @param $metric
-     *
-     * @return $this
-     */
-    public function setMetric($metric)
-    {
-        if (isset($metric) !== true) {
-            return $this;
-        }
-
-        if (is_array($metric) === true) {
-            $metric = implode(",", $metric);
-        }
-
-        $this->metric = $metric;
-
-        return $this;
-    }
 
     /**
      * @param $indexMetric
@@ -54,7 +31,7 @@ class Stats extends AbstractNodesEndpoint
             $indexMetric = implode(",", $indexMetric);
         }
 
-        $this->indexMetric = $indexMetric;
+        $this->indexMetric = urlencode($indexMetric);
 
         return $this;
     }

--- a/src/Elasticsearch/Endpoints/Cluster/State.php
+++ b/src/Elasticsearch/Endpoints/Cluster/State.php
@@ -33,7 +33,7 @@ class State extends AbstractEndpoint
             $metric = implode(",", $metric);
         }
 
-        $this->metric = $metric;
+        $this->metric = urlencode($metric);
 
         return $this;
     }

--- a/src/Elasticsearch/Endpoints/Cluster/Stats.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Stats.php
@@ -29,7 +29,7 @@ class Stats extends AbstractEndpoint
             return $this;
         }
 
-        $this->nodeID = $node_id;
+        $this->nodeID = urlencode($node_id);
 
         return $this;
     }

--- a/src/Elasticsearch/Endpoints/Indices/Alias/AbstractAliasEndpoint.php
+++ b/src/Elasticsearch/Endpoints/Indices/Alias/AbstractAliasEndpoint.php
@@ -2,7 +2,6 @@
 
 namespace Elasticsearch\Endpoints\Indices\Alias;
 
-use Elasticsearch\Common\Exceptions\InvalidArgumentException;
 use Elasticsearch\Endpoints\AbstractEndpoint;
 
 /**
@@ -16,21 +15,20 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  */
 abstract class AbstractAliasEndpoint extends AbstractEndpoint
 {
-    /** @var null|string */
+    /** @var null|string : the name of alias */
     protected $name = null;
 
     /**
      * @param $name
      *
-     * @throws \Elasticsearch\Common\Exceptions\InvalidArgumentException
-     *
      * @return $this
      */
     public function setName($name)
     {
-        if (is_string($name) !== true) {
-            throw new InvalidArgumentException('Name must be a string');
+        if (isset($name) !== true) {
+            return $this;
         }
+
         $this->name = urlencode($name);
 
         return $this;

--- a/src/Elasticsearch/Endpoints/Indices/Alias/Delete.php
+++ b/src/Elasticsearch/Endpoints/Indices/Alias/Delete.php
@@ -2,7 +2,6 @@
 
 namespace Elasticsearch\Endpoints\Indices\Alias;
 
-use Elasticsearch\Endpoints\AbstractEndpoint;
 use Elasticsearch\Common\Exceptions;
 
 /**
@@ -14,26 +13,8 @@ use Elasticsearch\Common\Exceptions;
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elastic.co
  */
-class Delete extends AbstractEndpoint
+class Delete extends AbstractAliasEndpoint
 {
-    // A comma-separated list of aliases to delete (supports wildcards); use `_all` to delete all aliases for the specified indices.
-    private $name;
-
-    /**
-     * @param $name
-     *
-     * @return $this
-     */
-    public function setName($name)
-    {
-        if (isset($name) !== true) {
-            return $this;
-        }
-
-        $this->name = $name;
-
-        return $this;
-    }
 
     /**
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException

--- a/src/Elasticsearch/Endpoints/Indices/Alias/Exists.php
+++ b/src/Elasticsearch/Endpoints/Indices/Alias/Exists.php
@@ -2,7 +2,6 @@
 
 namespace Elasticsearch\Endpoints\Indices\Alias;
 
-use Elasticsearch\Endpoints\AbstractEndpoint;
 
 /**
  * Class Exists
@@ -13,26 +12,8 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elastic.co
  */
-class Exists extends AbstractEndpoint
+class Exists extends AbstractAliasEndpoint
 {
-    // A comma-separated list of alias names to return
-    private $name;
-
-    /**
-     * @param $name
-     *
-     * @return $this
-     */
-    public function setName($name)
-    {
-        if (isset($name) !== true) {
-            return $this;
-        }
-
-        $this->name = $name;
-
-        return $this;
-    }
 
     /**
      * @return string
@@ -41,7 +22,7 @@ class Exists extends AbstractEndpoint
     {
         $index = $this->index;
         $name = $this->name;
-        $uri   = "/_alias/$name";
+        $uri = "/_alias/$name";
 
         if (isset($index) === true && isset($name) === true) {
             $uri = "/$index/_alias/$name";

--- a/src/Elasticsearch/Endpoints/Indices/Alias/Get.php
+++ b/src/Elasticsearch/Endpoints/Indices/Alias/Get.php
@@ -2,7 +2,6 @@
 
 namespace Elasticsearch\Endpoints\Indices\Alias;
 
-use Elasticsearch\Endpoints\AbstractEndpoint;
 
 /**
  * Class Get
@@ -13,27 +12,8 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elastic.co
  */
-class Get extends AbstractEndpoint
+class Get extends AbstractAliasEndpoint
 {
-    // A comma-separated list of alias names to return
-    private $name;
-
-    /**
-     * @param $name
-     *
-     * @return $this
-     */
-    public function setName($name)
-    {
-        if (isset($name) !== true) {
-            return $this;
-        }
-
-        $this->name = $name;
-
-        return $this;
-    }
-
     /**
      * @return string
      */

--- a/src/Elasticsearch/Endpoints/Indices/Alias/Put.php
+++ b/src/Elasticsearch/Endpoints/Indices/Alias/Put.php
@@ -2,7 +2,6 @@
 
 namespace Elasticsearch\Endpoints\Indices\Alias;
 
-use Elasticsearch\Endpoints\AbstractEndpoint;
 use Elasticsearch\Common\Exceptions;
 
 /**
@@ -14,11 +13,8 @@ use Elasticsearch\Common\Exceptions;
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elastic.co
  */
-class Put extends AbstractEndpoint
+class Put extends AbstractAliasEndpoint
 {
-    // The name of the alias to be created or updated
-    private $name;
-
     /**
      * @param array $body
      *
@@ -32,22 +28,6 @@ class Put extends AbstractEndpoint
         }
 
         $this->body = $body;
-
-        return $this;
-    }
-
-    /**
-     * @param $name
-     *
-     * @return $this
-     */
-    public function setName($name)
-    {
-        if (isset($name) !== true) {
-            return $this;
-        }
-
-        $this->name = $name;
 
         return $this;
     }

--- a/src/Elasticsearch/Endpoints/Indices/Aliases/AbstractAliasesEndpoint.php
+++ b/src/Elasticsearch/Endpoints/Indices/Aliases/AbstractAliasesEndpoint.php
@@ -1,21 +1,21 @@
 <?php
-
-namespace Elasticsearch\Endpoints\Indices\Template;
+namespace Elasticsearch\Endpoints\Indices\Aliases;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;
 
 /**
- * Class AbstractTemplateEndpoint
+ * Class AbstractAliasesEndpoint
  *
  * @category Elasticsearch
- * @package  Elasticsearch\Endpoints\Indices\Template
- * @author   Zachary Tong <zach@elastic.co>
+ * @package  Elasticsearch\Endpoints\Indices\Aliases
+ * @author   Augustin Husson <husson.augustin@gmail.com>
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elastic.co
  */
-abstract class AbstractTemplateEndpoint extends AbstractEndpoint
+abstract class AbstractAliasesEndpoint extends AbstractEndpoint
 {
-    /** @var  string : the name of the template */
+
+    /** @var null|string */
     protected $name = null;
 
     /**
@@ -29,7 +29,7 @@ abstract class AbstractTemplateEndpoint extends AbstractEndpoint
             return $this;
         }
 
-        $this->name = $name;
+        $this->name = urlencode($name);
 
         return $this;
     }

--- a/src/Elasticsearch/Endpoints/Indices/Aliases/Get.php
+++ b/src/Elasticsearch/Endpoints/Indices/Aliases/Get.php
@@ -2,7 +2,6 @@
 
 namespace Elasticsearch\Endpoints\Indices\Aliases;
 
-use Elasticsearch\Endpoints\AbstractEndpoint;
 
 /**
  * Class Get
@@ -13,26 +12,8 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elastic.co
  */
-class Get extends AbstractEndpoint
+class Get extends AbstractAliasesEndpoint
 {
-    // A comma-separated list of alias names to filter
-    private $name;
-
-    /**
-     * @param $name
-     *
-     * @return $this
-     */
-    public function setName($name)
-    {
-        if (isset($name) !== true) {
-            return $this;
-        }
-
-        $this->name = $name;
-
-        return $this;
-    }
 
     /**
      * @return string
@@ -41,7 +22,7 @@ class Get extends AbstractEndpoint
     {
         $index = $this->index;
         $name = $this->name;
-        $uri   = "/_aliases";
+        $uri = "/_aliases";
 
         if (isset($index) === true && isset($name) === true) {
             $uri = "/$index/_aliases/$name";

--- a/src/Elasticsearch/Endpoints/Indices/Field/Get.php
+++ b/src/Elasticsearch/Endpoints/Indices/Field/Get.php
@@ -30,7 +30,7 @@ class Get extends AbstractEndpoint
             return $this;
         }
 
-        $this->field = $field;
+        $this->field = urlencode($field);
 
         return $this;
     }

--- a/src/Elasticsearch/Endpoints/Indices/Get.php
+++ b/src/Elasticsearch/Endpoints/Indices/Get.php
@@ -50,7 +50,7 @@ class Get extends AbstractEndpoint
             $feature = implode(",", $feature);
         }
 
-        $this->feature = $feature;
+        $this->feature = urlencode($feature);
 
         return $this;
     }

--- a/src/Elasticsearch/Endpoints/Indices/Mapping/GetField.php
+++ b/src/Elasticsearch/Endpoints/Indices/Mapping/GetField.php
@@ -34,7 +34,7 @@ class GetField extends AbstractEndpoint
             $fields = implode(",", $fields);
         }
 
-        $this->fields = $fields;
+        $this->fields = urlencode($fields);
 
         return $this;
     }

--- a/src/Elasticsearch/Endpoints/Indices/Settings/Get.php
+++ b/src/Elasticsearch/Endpoints/Indices/Settings/Get.php
@@ -29,7 +29,7 @@ class Get extends AbstractEndpoint
             return $this;
         }
 
-        $this->name = $name;
+        $this->name = urlencode($name);
 
         return $this;
     }

--- a/src/Elasticsearch/Endpoints/Indices/Shrink.php
+++ b/src/Elasticsearch/Endpoints/Indices/Shrink.php
@@ -47,7 +47,7 @@ class Shrink extends AbstractEndpoint
         if (isset($target) !== true) {
             return $this;
         }
-        $this->target = $target;
+        $this->target = urlencode($target);
 
         return $this;
     }

--- a/src/Elasticsearch/Endpoints/Indices/Stats.php
+++ b/src/Elasticsearch/Endpoints/Indices/Stats.php
@@ -33,7 +33,7 @@ class Stats extends AbstractEndpoint
             $metric = implode(",", $metric);
         }
 
-        $this->metric = $metric;
+        $this->metric = urlencode($metric);
 
         return $this;
     }

--- a/src/Elasticsearch/Endpoints/Indices/Template/Delete.php
+++ b/src/Elasticsearch/Endpoints/Indices/Template/Delete.php
@@ -2,7 +2,6 @@
 
 namespace Elasticsearch\Endpoints\Indices\Template;
 
-use Elasticsearch\Endpoints\AbstractEndpoint;
 use Elasticsearch\Common\Exceptions;
 
 /**
@@ -15,26 +14,8 @@ use Elasticsearch\Common\Exceptions;
  * @link     http://elastic.co
  */
 
-class Delete extends AbstractEndpoint
+class Delete extends AbstractTemplateEndpoint
 {
-    // The name of the template
-    private $name;
-
-    /**
-     * @param $name
-     *
-     * @return $this
-     */
-    public function setName($name)
-    {
-        if (isset($name) !== true) {
-            return $this;
-        }
-
-        $this->name = $name;
-
-        return $this;
-    }
 
     /**
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException

--- a/src/Elasticsearch/Endpoints/Indices/Template/Exists.php
+++ b/src/Elasticsearch/Endpoints/Indices/Template/Exists.php
@@ -2,7 +2,6 @@
 
 namespace Elasticsearch\Endpoints\Indices\Template;
 
-use Elasticsearch\Endpoints\AbstractEndpoint;
 use Elasticsearch\Common\Exceptions;
 
 /**
@@ -14,26 +13,8 @@ use Elasticsearch\Common\Exceptions;
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elastic.co
  */
-class Exists extends AbstractEndpoint
+class Exists extends AbstractTemplateEndpoint
 {
-    // The name of the template
-    private $name;
-
-    /**
-     * @param $name
-     *
-     * @return $this
-     */
-    public function setName($name)
-    {
-        if (isset($name) !== true) {
-            return $this;
-        }
-
-        $this->name = $name;
-
-        return $this;
-    }
 
     /**
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException

--- a/src/Elasticsearch/Endpoints/Indices/Template/Get.php
+++ b/src/Elasticsearch/Endpoints/Indices/Template/Get.php
@@ -2,7 +2,6 @@
 
 namespace Elasticsearch\Endpoints\Indices\Template;
 
-use Elasticsearch\Endpoints\AbstractEndpoint;
 use Elasticsearch\Common\Exceptions;
 
 /**
@@ -14,27 +13,8 @@ use Elasticsearch\Common\Exceptions;
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elastic.co
  */
-class Get extends AbstractEndpoint
+class Get extends AbstractTemplateEndpoint
 {
-    // The name of the template
-    private $name;
-
-    /**
-     * @param $name
-     *
-     * @return $this
-     */
-    public function setName($name)
-    {
-        if (isset($name) !== true) {
-            return $this;
-        }
-
-        $this->name = $name;
-
-        return $this;
-    }
-
     /**
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string

--- a/src/Elasticsearch/Endpoints/Indices/Template/Put.php
+++ b/src/Elasticsearch/Endpoints/Indices/Template/Put.php
@@ -2,7 +2,6 @@
 
 namespace Elasticsearch\Endpoints\Indices\Template;
 
-use Elasticsearch\Endpoints\AbstractEndpoint;
 use Elasticsearch\Common\Exceptions;
 
 /**
@@ -14,11 +13,8 @@ use Elasticsearch\Common\Exceptions;
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elastic.co
  */
-class Put extends AbstractEndpoint
+class Put extends AbstractTemplateEndpoint
 {
-    // The name of the template
-    private $name;
-
     /**
      * @param array $body
      *
@@ -32,22 +28,6 @@ class Put extends AbstractEndpoint
         }
 
         $this->body = $body;
-
-        return $this;
-    }
-
-    /**
-     * @param $name
-     *
-     * @return $this
-     */
-    public function setName($name)
-    {
-        if (isset($name) !== true) {
-            return $this;
-        }
-
-        $this->name = $name;
 
         return $this;
     }

--- a/src/Elasticsearch/Endpoints/Script/AbstractScriptEndpoint.php
+++ b/src/Elasticsearch/Endpoints/Script/AbstractScriptEndpoint.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Elasticsearch\Endpoints\Script;
+
+use Elasticsearch\Endpoints\AbstractEndpoint;
+
+/**
+ * Class AbstractScriptEndpoint
+ *
+ * @category Elasticsearch
+ * @package  Elasticsearch\Endpoints\Script
+ * @author   Augustin Husson <husson.augustin@gmail.com>
+ * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
+ * @link     http://elastic.co
+ */
+abstract class AbstractScriptEndpoint extends AbstractEndpoint
+{
+    /** @var  String */
+    protected $lang;
+
+    /**
+     * @param $lang
+     *
+     * @return $this
+     */
+    public function setLang($lang)
+    {
+        if (isset($lang) !== true) {
+            return $this;
+        }
+
+        $this->lang = urlencode($lang);
+
+        return $this;
+    }
+
+}

--- a/src/Elasticsearch/Endpoints/Script/Delete.php
+++ b/src/Elasticsearch/Endpoints/Script/Delete.php
@@ -2,7 +2,6 @@
 
 namespace Elasticsearch\Endpoints\Script;
 
-use Elasticsearch\Endpoints\AbstractEndpoint;
 use Elasticsearch\Common\Exceptions;
 
 /**
@@ -14,27 +13,8 @@ use Elasticsearch\Common\Exceptions;
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elastic.co
  */
-class Delete extends AbstractEndpoint
+class Delete extends AbstractScriptEndpoint
 {
-    /** @var  String */
-    private $lang;
-
-    /**
-     * @param $lang
-     *
-     * @return $this
-     */
-    public function setLang($lang)
-    {
-        if (isset($lang) !== true) {
-            return $this;
-        }
-
-        $this->lang = $lang;
-
-        return $this;
-    }
-
     /**
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string

--- a/src/Elasticsearch/Endpoints/Script/Get.php
+++ b/src/Elasticsearch/Endpoints/Script/Get.php
@@ -2,7 +2,6 @@
 
 namespace Elasticsearch\Endpoints\Script;
 
-use Elasticsearch\Endpoints\AbstractEndpoint;
 use Elasticsearch\Common\Exceptions;
 
 /**
@@ -14,27 +13,8 @@ use Elasticsearch\Common\Exceptions;
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elastic.co
  */
-class Get extends AbstractEndpoint
+class Get extends AbstractScriptEndpoint
 {
-    /** @var  String */
-    private $lang;
-
-    /**
-     * @param $lang
-     *
-     * @return $this
-     */
-    public function setLang($lang)
-    {
-        if (isset($lang) !== true) {
-            return $this;
-        }
-
-        $this->lang = $lang;
-
-        return $this;
-    }
-
     /**
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string

--- a/src/Elasticsearch/Endpoints/Script/Put.php
+++ b/src/Elasticsearch/Endpoints/Script/Put.php
@@ -2,7 +2,6 @@
 
 namespace Elasticsearch\Endpoints\Script;
 
-use Elasticsearch\Endpoints\AbstractEndpoint;
 use Elasticsearch\Common\Exceptions;
 
 /**
@@ -14,27 +13,8 @@ use Elasticsearch\Common\Exceptions;
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elastic.co
  */
-class Put extends AbstractEndpoint
+class Put extends AbstractScriptEndpoint
 {
-    /** @var  String */
-    private $lang;
-
-    /**
-     * @param $lang
-     *
-     * @return $this
-     */
-    public function setLang($lang)
-    {
-        if (isset($lang) !== true) {
-            return $this;
-        }
-
-        $this->lang = $lang;
-
-        return $this;
-    }
-
     /**
      * @param array $body
      *

--- a/src/Elasticsearch/Endpoints/Snapshot/AbstractSnapshotEndpoint.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/AbstractSnapshotEndpoint.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Elasticsearch\Endpoints\Snapshot;
+
+use Elasticsearch\Endpoints\AbstractEndpoint;
+
+/**
+ * Class AbstractSnapshotEndpoint
+ *
+ * @category Elasticsearch
+ * @package  Elasticsearch\Endpoints\Snapshot
+ * @author   Augustin Husson <husson.augustin@gmail.com>
+ * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
+ * @link     http://elastic.co
+ */
+abstract class AbstractSnapshotEndpoint extends AbstractEndpoint
+{
+    /** @var  string A repository name or a comma-separated list of repository names (depends on the function) */
+    protected $repository;
+
+    /** @var  string A snapshot name or a comma-separated list of snapshot names (depends on the function) */
+    protected $snapshot;
+
+    /**
+     * @param $repository
+     *
+     * @return $this
+     */
+    public function setRepository($repository)
+    {
+        if (isset($repository) !== true) {
+            return $this;
+        }
+
+        $this->repository = urlencode($repository);
+
+        return $this;
+    }
+
+    /**
+     * @param $snapshot
+     *
+     * @return $this
+     */
+    public function setSnapshot($snapshot)
+    {
+        if (isset($snapshot) !== true) {
+            return $this;
+        }
+
+        $this->snapshot = $snapshot;
+
+        return $this;
+    }
+
+}

--- a/src/Elasticsearch/Endpoints/Snapshot/Create.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Create.php
@@ -2,7 +2,6 @@
 
 namespace Elasticsearch\Endpoints\Snapshot;
 
-use Elasticsearch\Endpoints\AbstractEndpoint;
 use Elasticsearch\Common\Exceptions;
 
 /**
@@ -14,14 +13,8 @@ use Elasticsearch\Common\Exceptions;
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elastic.co
  */
-class Create extends AbstractEndpoint
+class Create extends AbstractSnapshotEndpoint
 {
-    // A repository name
-    private $repository;
-
-    // A snapshot name
-    private $snapshot;
-
     /**
      * @param array $body
      *
@@ -35,38 +28,6 @@ class Create extends AbstractEndpoint
         }
 
         $this->body = $body;
-
-        return $this;
-    }
-
-    /**
-     * @param $repository
-     *
-     * @return $this
-     */
-    public function setRepository($repository)
-    {
-        if (isset($repository) !== true) {
-            return $this;
-        }
-
-        $this->repository = $repository;
-
-        return $this;
-    }
-
-    /**
-     * @param $snapshot
-     *
-     * @return $this
-     */
-    public function setSnapshot($snapshot)
-    {
-        if (isset($snapshot) !== true) {
-            return $this;
-        }
-
-        $this->snapshot = $snapshot;
 
         return $this;
     }

--- a/src/Elasticsearch/Endpoints/Snapshot/Delete.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Delete.php
@@ -2,7 +2,6 @@
 
 namespace Elasticsearch\Endpoints\Snapshot;
 
-use Elasticsearch\Endpoints\AbstractEndpoint;
 use Elasticsearch\Common\Exceptions;
 
 /**
@@ -14,46 +13,8 @@ use Elasticsearch\Common\Exceptions;
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elastic.co
  */
-class Delete extends AbstractEndpoint
+class Delete extends AbstractSnapshotEndpoint
 {
-    // A repository name
-    private $repository;
-
-    // A snapshot name
-    private $snapshot;
-
-    /**
-     * @param $repository
-     *
-     * @return $this
-     */
-    public function setRepository($repository)
-    {
-        if (isset($repository) !== true) {
-            return $this;
-        }
-
-        $this->repository = $repository;
-
-        return $this;
-    }
-
-    /**
-     * @param $snapshot
-     *
-     * @return $this
-     */
-    public function setSnapshot($snapshot)
-    {
-        if (isset($snapshot) !== true) {
-            return $this;
-        }
-
-        $this->snapshot = $snapshot;
-
-        return $this;
-    }
-
     /**
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string

--- a/src/Elasticsearch/Endpoints/Snapshot/Get.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Get.php
@@ -2,7 +2,6 @@
 
 namespace Elasticsearch\Endpoints\Snapshot;
 
-use Elasticsearch\Endpoints\AbstractEndpoint;
 use Elasticsearch\Common\Exceptions;
 
 /**
@@ -14,46 +13,8 @@ use Elasticsearch\Common\Exceptions;
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elastic.co
  */
-class Get extends AbstractEndpoint
+class Get extends AbstractSnapshotEndpoint
 {
-    // A comma-separated list of repository names
-    private $repository;
-
-    // A comma-separated list of snapshot names
-    private $snapshot;
-
-    /**
-     * @param $repository
-     *
-     * @return $this
-     */
-    public function setRepository($repository)
-    {
-        if (isset($repository) !== true) {
-            return $this;
-        }
-
-        $this->repository = $repository;
-
-        return $this;
-    }
-
-    /**
-     * @param $snapshot
-     *
-     * @return $this
-     */
-    public function setSnapshot($snapshot)
-    {
-        if (isset($snapshot) !== true) {
-            return $this;
-        }
-
-        $this->snapshot = $snapshot;
-
-        return $this;
-    }
-
     /**
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string

--- a/src/Elasticsearch/Endpoints/Snapshot/Repository/AbstractRepositoryEndpoint.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Repository/AbstractRepositoryEndpoint.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Elasticsearch\Endpoints\Snapshot\Repository;
+
+use Elasticsearch\Endpoints\AbstractEndpoint;
+
+/**
+ * Class AbstractRepositoryEndpoint
+ *
+ * @category Elasticsearch
+ * @package  Elasticsearch\Endpoints\Snapshot\Repository
+ * @author   Augustin Husson <husson.augustin@gmail.com>
+ * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
+ * @link     http://elastic.co
+ */
+abstract class AbstractRepositoryEndpoint extends AbstractEndpoint
+{
+    /** @var  string A repository name or a comma-separated list of repository names (depends on the function) */ 
+    protected $repository;
+
+    /**
+     * @param $repository
+     *
+     * @return $this
+     */
+    public function setRepository($repository)
+    {
+        if (isset($repository) !== true) {
+            return $this;
+        }
+
+        $this->repository = urlencode($repository);
+
+        return $this;
+    }
+
+}

--- a/src/Elasticsearch/Endpoints/Snapshot/Repository/Create.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Repository/Create.php
@@ -2,7 +2,6 @@
 
 namespace Elasticsearch\Endpoints\Snapshot\Repository;
 
-use Elasticsearch\Endpoints\AbstractEndpoint;
 use Elasticsearch\Common\Exceptions;
 
 /**
@@ -14,10 +13,8 @@ use Elasticsearch\Common\Exceptions;
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elastic.co
  */
-class Create extends AbstractEndpoint
+class Create extends AbstractRepositoryEndpoint
 {
-    // A repository name
-    private $repository;
 
     /**
      * @param array $body
@@ -35,23 +32,7 @@ class Create extends AbstractEndpoint
 
         return $this;
     }
-
-    /**
-     * @param $repository
-     *
-     * @return $this
-     */
-    public function setRepository($repository)
-    {
-        if (isset($repository) !== true) {
-            return $this;
-        }
-
-        $this->repository = $repository;
-
-        return $this;
-    }
-
+    
     /**
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string

--- a/src/Elasticsearch/Endpoints/Snapshot/Repository/Delete.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Repository/Delete.php
@@ -2,7 +2,6 @@
 
 namespace Elasticsearch\Endpoints\Snapshot\Repository;
 
-use Elasticsearch\Endpoints\AbstractEndpoint;
 use Elasticsearch\Common\Exceptions;
 
 /**
@@ -14,27 +13,8 @@ use Elasticsearch\Common\Exceptions;
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elastic.co
  */
-class Delete extends AbstractEndpoint
+class Delete extends AbstractRepositoryEndpoint
 {
-    // A comma-separated list of repository names
-    private $repository;
-
-    /**
-     * @param $repository
-     *
-     * @return $this
-     */
-    public function setRepository($repository)
-    {
-        if (isset($repository) !== true) {
-            return $this;
-        }
-
-        $this->repository = $repository;
-
-        return $this;
-    }
-
     /**
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string

--- a/src/Elasticsearch/Endpoints/Snapshot/Repository/Get.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Repository/Get.php
@@ -2,8 +2,6 @@
 
 namespace Elasticsearch\Endpoints\Snapshot\Repository;
 
-use Elasticsearch\Endpoints\AbstractEndpoint;
-
 /**
  * Class Get
  *
@@ -13,26 +11,8 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elastic.co
  */
-class Get extends AbstractEndpoint
+class Get extends AbstractRepositoryEndpoint
 {
-    // A comma-separated list of repository names
-    private $repository;
-
-    /**
-     * @param $repository
-     *
-     * @return $this
-     */
-    public function setRepository($repository)
-    {
-        if (isset($repository) !== true) {
-            return $this;
-        }
-
-        $this->repository = $repository;
-
-        return $this;
-    }
 
     /**
      * @return string

--- a/src/Elasticsearch/Endpoints/Snapshot/Repository/Verify.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Repository/Verify.php
@@ -2,7 +2,6 @@
 
 namespace Elasticsearch\Endpoints\Snapshot\Repository;
 
-use Elasticsearch\Endpoints\AbstractEndpoint;
 use Elasticsearch\Common\Exceptions;
 
 /**
@@ -14,27 +13,8 @@ use Elasticsearch\Common\Exceptions;
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elastic.co
  */
-class Verify extends AbstractEndpoint
+class Verify extends AbstractRepositoryEndpoint
 {
-    // A comma-separated list of repository names
-    private $repository;
-
-    /**
-     * @param $repository
-     *
-     * @return $this
-     */
-    public function setRepository($repository)
-    {
-        if (isset($repository) !== true) {
-            return $this;
-        }
-
-        $this->repository = $repository;
-
-        return $this;
-    }
-
     /**
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string

--- a/src/Elasticsearch/Endpoints/Snapshot/Restore.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Restore.php
@@ -2,7 +2,6 @@
 
 namespace Elasticsearch\Endpoints\Snapshot;
 
-use Elasticsearch\Endpoints\AbstractEndpoint;
 use Elasticsearch\Common\Exceptions;
 
 /**
@@ -14,14 +13,8 @@ use Elasticsearch\Common\Exceptions;
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elastic.co
  */
-class Restore extends AbstractEndpoint
+class Restore extends AbstractSnapshotEndpoint
 {
-    // A repository name
-    private $repository;
-
-    // A snapshot name
-    private $snapshot;
-
     /**
      * @param array $body
      *
@@ -38,39 +31,7 @@ class Restore extends AbstractEndpoint
 
         return $this;
     }
-
-    /**
-     * @param $repository
-     *
-     * @return $this
-     */
-    public function setRepository($repository)
-    {
-        if (isset($repository) !== true) {
-            return $this;
-        }
-
-        $this->repository = $repository;
-
-        return $this;
-    }
-
-    /**
-     * @param $snapshot
-     *
-     * @return $this
-     */
-    public function setSnapshot($snapshot)
-    {
-        if (isset($snapshot) !== true) {
-            return $this;
-        }
-
-        $this->snapshot = $snapshot;
-
-        return $this;
-    }
-
+    
     /**
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string

--- a/src/Elasticsearch/Endpoints/Snapshot/Status.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Status.php
@@ -2,7 +2,6 @@
 
 namespace Elasticsearch\Endpoints\Snapshot;
 
-use Elasticsearch\Endpoints\AbstractEndpoint;
 use Elasticsearch\Common\Exceptions;
 
 /**
@@ -14,46 +13,8 @@ use Elasticsearch\Common\Exceptions;
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elastic.co
  */
-class Status extends AbstractEndpoint
+class Status extends AbstractSnapshotEndpoint
 {
-    // A comma-separated list of repository names
-    private $repository;
-
-    // A comma-separated list of snapshot names
-    private $snapshot;
-
-    /**
-     * @param $repository
-     *
-     * @return $this
-     */
-    public function setRepository($repository)
-    {
-        if (isset($repository) !== true) {
-            return $this;
-        }
-
-        $this->repository = $repository;
-
-        return $this;
-    }
-
-    /**
-     * @param $snapshot
-     *
-     * @return $this
-     */
-    public function setSnapshot($snapshot)
-    {
-        if (isset($snapshot) !== true) {
-            return $this;
-        }
-
-        $this->snapshot = $snapshot;
-
-        return $this;
-    }
-
     /**
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string

--- a/src/Elasticsearch/Endpoints/Tasks/AbstractTasksEndpoint.php
+++ b/src/Elasticsearch/Endpoints/Tasks/AbstractTasksEndpoint.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Elasticsearch\Endpoints\Tasks;
+use Elasticsearch\Endpoints\AbstractEndpoint;
+
+/**
+ * Class AbstractTasksEndpoint
+ *
+ * @category Elasticsearch
+ * @package  Elasticsearch\Tasks
+ * @author   Augustin Husson <husson.augustin@gmail.com>
+ * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
+ * @link     http://elastic.co
+ */
+abstract class AbstractTasksEndpoint extends AbstractEndpoint
+{
+    protected $taskId;
+
+    /**
+     * @param string $taskId
+     *
+     * @throws \Elasticsearch\Common\Exceptions\InvalidArgumentException
+     * @return $this
+     */
+    public function setTaskId($taskId)
+    {
+        if (isset($taskId) !== true) {
+            return $this;
+        }
+
+        $this->taskId = urlencode($taskId);
+
+        return $this;
+    }
+
+}

--- a/src/Elasticsearch/Endpoints/Tasks/Cancel.php
+++ b/src/Elasticsearch/Endpoints/Tasks/Cancel.php
@@ -3,7 +3,6 @@
 namespace Elasticsearch\Endpoints\Tasks;
 
 use Elasticsearch\Common\Exceptions;
-use Elasticsearch\Endpoints\AbstractEndpoint;
 
 /**
  * Class Cancel
@@ -14,26 +13,8 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elastic.co
  */
-class Cancel extends AbstractEndpoint
+class Cancel extends AbstractTasksEndpoint
 {
-    private $taskId;
-
-    /**
-     * @param string $taskId
-     *
-     * @throws \Elasticsearch\Common\Exceptions\InvalidArgumentException
-     * @return $this
-     */
-    public function setTaskId($taskId)
-    {
-        if (isset($taskId) !== true) {
-            return $this;
-        }
-
-        $this->taskId = $taskId;
-
-        return $this;
-    }
 
     /**
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException

--- a/src/Elasticsearch/Endpoints/Tasks/Get.php
+++ b/src/Elasticsearch/Endpoints/Tasks/Get.php
@@ -3,7 +3,6 @@
 namespace Elasticsearch\Endpoints\Tasks;
 
 use Elasticsearch\Common\Exceptions;
-use Elasticsearch\Endpoints\AbstractEndpoint;
 
 /**
  * Class Get
@@ -14,27 +13,8 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elastic.co
  */
-class Get extends AbstractEndpoint
+class Get extends AbstractTasksEndpoint
 {
-    private $taskId;
-
-    /**
-     * @param string $taskId
-     *
-     * @throws \Elasticsearch\Common\Exceptions\InvalidArgumentException
-     * @return $this
-     */
-    public function setTaskId($taskId)
-    {
-        if (isset($taskId) !== true) {
-            return $this;
-        }
-
-        $this->taskId = $taskId;
-
-        return $this;
-    }
-
     /**
      * @throws \Elasticsearch\Common\Exceptions\RuntimeException
      * @return string


### PR DESCRIPTION
Hello,

I'm currently working with alias managing. And when a utf-8 char (like japan char : 金魚) is used for creating alias or search or anything in relation with alias, there is an error (like alias notfound). So I fixed it by putting the method `urlencode` in the method `setName` in the Endpoint Alias (for example : in the class `Elasticsearch\Endpoints\Indices\Alias\Get`) like this :

``` php
$this->name = urlencode($name);
```

Aaand, juste after fixing this bug, I saw the class `AbstractAliasEndpoint` where I find my fix. So I remove my fixe and extend all EndPoint Alias to the AbstractAliasEndpoint :

``` php
class Exists extends AbstractAliasEndpoint{
}
```

After that, I thought that maybe I could apply the same method in other endpoint. And that's why, you have another Pull Request with a lot of changes :). 

I hope you will enjoy it.

PS : I'm sorry to do not do some unit commits but one big commit (I have some trouble with the command `git --amend`. If you don't like it, I could do it again with unit commit. 
