### PR TITLE
Introducing constant JSON_FORCE_OBJECT to json_encode

### DIFF
--- a/phpunit-integration.xml
+++ b/phpunit-integration.xml
@@ -8,7 +8,7 @@
         verbose="true"
 >
     <php>
-        <env name="ES_TEST_HOST" value="http://localhost:9200"/>
+        <server name="ES_TEST_HOST" value="http://localhost:9200"/>
     </php>
     <testsuites>
         <testsuite>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,7 @@
         verbose="true"
 >
     <php>
-        <env name="ES_TEST_HOST" value="http://localhost:9200"/>
+        <server name="ES_TEST_HOST" value="http://localhost:9200"/>
     </php>
     <testsuites>
         <testsuite>

--- a/src/Elasticsearch/Serializers/ArrayToJSONSerializer.php
+++ b/src/Elasticsearch/Serializers/ArrayToJSONSerializer.php
@@ -22,16 +22,9 @@ class ArrayToJSONSerializer implements SerializerInterface
      */
     public function serialize($data)
     {
-        if (is_string($data) === true) {
-            return $data;
-        } else {
-            $data = json_encode($data, JSON_PRESERVE_ZERO_FRACTION);
-            if ($data === '[]') {
-                return '{}';
-            } else {
-                return $data;
-            }
-        }
+        return is_string($data)
+            ? $data
+            : json_encode($data, JSON_FORCE_OBJECT | JSON_PRESERVE_ZERO_FRACTION);
     }
 
     /**

--- a/src/Elasticsearch/Serializers/EverythingToJSONSerializer.php
+++ b/src/Elasticsearch/Serializers/EverythingToJSONSerializer.php
@@ -22,12 +22,7 @@ class EverythingToJSONSerializer implements SerializerInterface
      */
     public function serialize($data)
     {
-        $data = json_encode($data, JSON_PRESERVE_ZERO_FRACTION);
-        if ($data === '[]') {
-            return '{}';
-        } else {
-            return $data;
-        }
+        return json_encode($data, JSON_FORCE_OBJECT | JSON_PRESERVE_ZERO_FRACTION);
     }
 
     /**

--- a/src/Elasticsearch/Serializers/SmartSerializer.php
+++ b/src/Elasticsearch/Serializers/SmartSerializer.php
@@ -24,16 +24,9 @@ class SmartSerializer implements SerializerInterface
      */
     public function serialize($data)
     {
-        if (is_string($data) === true) {
-            return $data;
-        } else {
-            $data = json_encode($data, JSON_PRESERVE_ZERO_FRACTION);
-            if ($data === '[]') {
-                return '{}';
-            } else {
-                return $data;
-            }
-        }
+        return is_string($data)
+            ? $data
+            : json_encode($data, JSON_FORCE_OBJECT | JSON_PRESERVE_ZERO_FRACTION);
     }
 
     /**

--- a/tests/Elasticsearch/Tests/Serializers/ArrayToJSONSerializerTest.php
+++ b/tests/Elasticsearch/Tests/Serializers/ArrayToJSONSerializerTest.php
@@ -28,6 +28,15 @@ class ArrayToJSONSerializerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($body, $ret);
     }
 
+    public function testSerializeEmptyArray()
+    {
+        $serializer = new ArrayToJSONSerializer();
+
+        $actual = $serializer->serialize([]);
+
+        $this->assertEquals('{}', $actual);
+    }
+
     public function testSerializeString()
     {
         $serializer = new ArrayToJSONSerializer();

--- a/tests/Elasticsearch/Tests/Serializers/EverythingToJSONSerializerTest.php
+++ b/tests/Elasticsearch/Tests/Serializers/EverythingToJSONSerializerTest.php
@@ -28,6 +28,15 @@ class EverythingToJSONSerializerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($body, $ret);
     }
 
+    public function testSerializeEmptyArray()
+    {
+        $serializer = new EverythingToJSONSerializer();
+
+        $actual = $serializer->serialize([]);
+
+        $this->assertEquals('{}', $actual);
+    }
+
     public function testSerializeString()
     {
         $serializer = new EverythingToJSONSerializer();


### PR DESCRIPTION
 - small fix to PHPUnit configuration
 - 2 tests to ensure nothing will be broken
 - serializers method serialize simplification and adding constant JSON_FORCE_OBJECT

It will resolve #495 and also make serializers to work on 2.* and 5.* versions of Elasticsearch.