### PR TITLE
add ClientBuilder->setConnectionParams()

### DIFF
--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -67,6 +67,9 @@ class ClientBuilder
     /** @var array */
     private $hosts;
 
+    /** @var array */
+    private $connectionParams;
+
     /** @var  int */
     private $retries;
 
@@ -297,6 +300,17 @@ class ClientBuilder
     }
 
     /**
+     * @param array $params
+     * @return $this
+     */
+    public function setConnectionParams(array $params)
+    {
+        $this->connectionParams = $params;
+
+        return $this;
+    }
+
+    /**
      * @param int $retries
      * @return $this
      */
@@ -409,8 +423,10 @@ class ClientBuilder
         }
 
         if (is_null($this->connectionFactory)) {
-            $connectionParams = [];
-            $this->connectionFactory = new ConnectionFactory($this->handler, $connectionParams, $this->serializer, $this->logger, $this->tracer);
+            if (is_null($this->connectionParams)) {
+                $this->connectionParams = [];
+            }
+            $this->connectionFactory = new ConnectionFactory($this->handler, $this->connectionParams, $this->serializer, $this->logger, $this->tracer);
         }
 
         if (is_null($this->hosts)) {


### PR DESCRIPTION
We want to be able to pass `['client'][]` options globally instead of "per request".

This PR hopes to be merged in a 2.3.0 release (because I don't use 5.x yet). 👼 
See https://github.com/elastic/elasticsearch-php/pull/507 for `master` branch PR.

Related issues: https://github.com/elastic/elasticsearch-php/issues/382 https://github.com/elastic/elasticsearch-php/issues/259