### PR TITLE
Use `array_diff` to Check Endpoint Parameters

### DIFF
--- a/src/Elasticsearch/Endpoints/AbstractEndpoint.php
+++ b/src/Elasticsearch/Endpoints/AbstractEndpoint.php
@@ -214,14 +214,15 @@ abstract class AbstractEndpoint
 
         $whitelist = array_merge($this->getParamWhitelist(), array('client', 'custom', 'filter_path'));
 
-        foreach ($params as $key => $value) {
-            if (array_search($key, $whitelist) === false) {
-                throw new UnexpectedValueException(sprintf(
-                    '"%s" is not a valid parameter. Allowed parameters are: "%s"',
-                    $key,
-                    implode('", "', $whitelist)
-                ));
-            }
+        $invalid = array_diff(array_keys($params), $whitelist);
+        if (count($invalid) > 0) {
+            sort($invalid);
+            sort($whitelist);
+            throw new UnexpectedValueException(sprintf(
+                (count($invalid) > 1 ? '"%s" are not valid parameters.' : '"%s" is not a valid parameter.').' Allowed parameters are "%s"',
+                implode('", "', $invalid),
+                implode('", "', $whitelist)
+            ));
         }
     }
 

--- a/tests/Elasticsearch/Tests/Endpoints/AbstractEndpointTest.php
+++ b/tests/Elasticsearch/Tests/Endpoints/AbstractEndpointTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Elasticsearch\Tests\Endpoints;
+
+use Elasticsearch\Endpoints\AbstractEndpoint;
+
+class AbstractEndpointTest extends \PHPUnit_Framework_TestCase
+{
+    private $endpoint;
+
+    public static function invalidParameters()
+    {
+        return [
+            [['invalid' => 10]],
+            [['invalid' => 10, 'invalid2' => 'another']],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidParameters
+     * @expectedException Elasticsearch\Common\Exceptions\UnexpectedValueException
+     */
+    public function testInvalidParamsCauseErrorsWhenProvidedToSetParams(array $params)
+    {
+        $this->endpoint->expects($this->once())
+            ->method('getParamWhitelist')
+            ->willReturn(['one', 'two']);
+
+        $this->endpoint->setParams($params);
+    }
+
+    protected function setUp()
+    {
+        $this->endpoint = $this->getMockForAbstractClass(AbstractEndpoint::class);
+    }
+}


### PR DESCRIPTION
Slightly nicer than the old array_search method that iterates through every user provided param. Also gives the user feed back on *all* invalid parameters at once, rather than just one at a time.

Also adds a test for `AbstractEndpoint` to verify that the exception does actually happen.