### PR TITLE
Update search-operations.asciidoc

### DIFF
--- a/docs/search-operations.asciidoc
+++ b/docs/search-operations.asciidoc
@@ -221,7 +221,7 @@ $results = $client->search($params);
 
 === Scan/Scroll
 
-The Scan/Scroll functionality of Elasticsearch is similar to search, but different in many ways.  It works by executing a search query with a `search_type` of `scan`.  This initiates a "scan window" which will remain open for the duration of the scan.  This allows proper, consistent pagination.
+The Scan/Scroll functionality of Elasticsearch is similar to search, but different in many ways. This initiates a "scan window" which will remain open for the duration of the scan.  This allows proper, consistent pagination.
 
 Once a scan window is open, you may start `_scrolling` over that window.  This returns results matching your query... but returns them in random order.  This random ordering is important to performance.  Deep pagination is expensive when you need to maintain a sorted, consistent order across shards.  By removing this obligation, Scan/Scroll can efficiently export all the data from your index.
 
@@ -231,7 +231,6 @@ This is an example which can be used as a template for more advanced operations:
 ----
 $client = ClientBuilder::create()->build();
 $params = [
-    "search_type" => "scan",    // use search_type=scan
     "scroll" => "30s",          // how long between scroll requests. should be small!
     "size" => 50,               // how many results *per shard* you want back
     "index" => "my_index",


### PR DESCRIPTION
search_type=scan is removed in Elasticsearch 5.x

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you signed [Contributor License Agreement](http://www.elasticsearch.org/contributor-agreement/)?
PR's (no matter how small) cannot be merged until the CLA has been signed.  It only needs to be signed once,
however.

- Have you read the [Contributing Guidelines](https://github.com/elastic/elasticsearch-php/blob/master/.github/CONTRIBUTING.md)?

If you answered yes to both, thanks for the PR and we'll get to it ASAP! :)

-->