### PR TITLE
JSON seriasers should throw exception on encode error

### DIFF
--- a/src/Elasticsearch/Serializers/ArrayToJSONSerializer.php
+++ b/src/Elasticsearch/Serializers/ArrayToJSONSerializer.php
@@ -2,6 +2,8 @@
 
 namespace Elasticsearch\Serializers;
 
+use Elasticsearch\Common\Exceptions\RuntimeException;
+
 /**
  * Class JSONSerializer
  *
@@ -26,6 +28,9 @@ class ArrayToJSONSerializer implements SerializerInterface
             return $data;
         } else {
             $data = json_encode($data, JSON_PRESERVE_ZERO_FRACTION);
+            if ($data === false) {
+                throw new RuntimeException("Failed to JSON encode: ".json_last_error());
+            }
             if ($data === '[]') {
                 return '{}';
             } else {

--- a/src/Elasticsearch/Serializers/EverythingToJSONSerializer.php
+++ b/src/Elasticsearch/Serializers/EverythingToJSONSerializer.php
@@ -2,6 +2,8 @@
 
 namespace Elasticsearch\Serializers;
 
+use Elasticsearch\Common\Exceptions\RuntimeException;
+
 /**
  * Class EverythingToJSONSerializer
  *
@@ -23,6 +25,9 @@ class EverythingToJSONSerializer implements SerializerInterface
     public function serialize($data)
     {
         $data = json_encode($data, JSON_PRESERVE_ZERO_FRACTION);
+        if ($data === false) {
+            throw new RuntimeException("Failed to JSON encode: ".json_last_error());
+        }
         if ($data === '[]') {
             return '{}';
         } else {

--- a/src/Elasticsearch/Serializers/SmartSerializer.php
+++ b/src/Elasticsearch/Serializers/SmartSerializer.php
@@ -28,6 +28,9 @@ class SmartSerializer implements SerializerInterface
             return $data;
         } else {
             $data = json_encode($data, JSON_PRESERVE_ZERO_FRACTION);
+            if ($data === false) {
+                throw new RuntimeException("Failed to JSON encode: ".json_last_error());
+            }
             if ($data === '[]') {
                 return '{}';
             } else {


### PR DESCRIPTION
If request data is not properly encoded the serialisers can return boolean false

This eventually leads to an uncaugh InvalidArgumentException: "Invalid request body provided" from GuzzleHttp\Ring\Client\CurlFactory which is expecting a body.

IMHO throwing an exception early would be preferable, as it should explain why the body is not correct and make things easier for developers to find their code which is not encoding the body correctly.