### PR TITLE
[DOCS] Documentation fixes (typos, etc.)

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -53,7 +53,7 @@ $client = $clientBuilder->build();          // Build the client object
 
 The client also supports an _extended_ host configuration syntax.  The inline configuration method relies on PHP's
 `filter_var()` and `parse_url()` methods to validate and extract the components of a URL.  Unfortunately, these built-in
-methods run into problems with certain edge-cases.  For example, `filter_var()` will not accept URL's that have underscores
+methods run into problems with certain edge-cases.  For example, `filter_var()` will not accept URLs that have underscores
 (which are questionably legal, depending on how you interpret the RFCs).  Similarly, `parse_url()` will choke if a
 Basic Auth's password contains special characters such as a pound sign (`#`) or question-marks (`?`).
 
@@ -130,11 +130,11 @@ try {
         echo "Max retries!";
     }
 }
-----------------------------
+----
 
 Alternatively, all "hard" curl exceptions (`CouldNotConnectToHost`, `CouldNotResolveHostException`, `OperationTimeoutException`)
 extend the more general `TransportException`.  So you could instead catch the general `TransportException` and then
-check it's previous value:
+check its previous value:
 
 [source,php]
 ----
@@ -151,7 +151,7 @@ try {
         echo "Max retries!";
     }
 }
-----------------------------
+----
 
 
 [[enabling_logger]]
@@ -366,7 +366,7 @@ The ConnectionFactory requires a working HTTP handler, serializer, logger and tr
 
 The client uses an Endpoint closure to dispatch API requests to the correct Endpoint object.  A namespace object will
 construct a new Endpoint via this closure, which means this is a handy location if you wish to extend the available set
-of API endpoints available
+of API endpoints available.
 
 For example, we could add a new endpoint like so:
 

--- a/docs/connection-pool.asciidoc
+++ b/docs/connection-pool.asciidoc
@@ -60,7 +60,7 @@ Note that the implementation is specified via a namespace path to the class.
 
 === simpleConnectionPool
 
-The `SimpleConnectionPool` simply returns the next node as specified by the Selector; it does not perform track
+The `SimpleConnectionPool` simply returns the next node as specified by the Selector; it does not track
 the "liveness" of nodes.  This pool will return nodes whether they are alive or dead.  It is just a simple pool of static
 hosts.
 
@@ -81,7 +81,7 @@ Note that the implementation is specified via a namespace path to the class.
 
 Unlike the two previous static connection pools, this one is dynamic.  The user provides a seed list of hosts, which the
 client uses to "sniff" and discover the rest of the cluster.  It achieves this through the Cluster State API.  As new
-nodes are added or removed from the cluster, the client will update it's pool of active connections.
+nodes are added or removed from the cluster, the client will update its pool of active connections.
 
 To use the `SniffingConnectionPool`:
 
@@ -195,7 +195,7 @@ Sniffing is a relatively lightweight operation (one API call to `/_cluster/state
 it may be a non-negligible overhead for certain PHP applications.  The average PHP script will likely load the client,
 execute a few queries and then close.  Imagine this script being called 1000 times per second: the sniffing connection
 pool will perform the sniffing and pinging process 1000 times per second.  The sniffing process will add a large
-amount of overhead
+amount of overhead.
 
 In reality, if your script only executes a few queries, the sniffing concept is _too_ robust.  It tends to be more
 useful in long-lived processes which potentially "out-live" a static list.

--- a/docs/crud.asciidoc
+++ b/docs/crud.asciidoc
@@ -133,7 +133,7 @@ if (!empty($params['body'])) {
 
 Elasticsearch provides realtime GETs of documents.  This means that as soon as the document has been indexed and your
 client receives an acknowledgement, you can immediately retrieve the document from any shard.  Get operations are
-performed by requesting a document by it's full `index/type/id` path:
+performed by requesting a document by its full `index/type/id` path:
 
 [source,php]
 ----
@@ -156,7 +156,7 @@ update to just some fields (either changing an existing field, or adding new fie
 === Partial document update
 
 If you want to partially update a document (e.g. change an existing field, or add a new one) you can do so by specifying
-the `doc` in the `body` parameter.  This will merge the fields in `doc` with the existing document
+the `doc` in the `body` parameter.  This will merge the fields in `doc` with the existing document.
 
 
 [source,php]

--- a/docs/futures.asciidoc
+++ b/docs/futures.asciidoc
@@ -6,9 +6,9 @@ to the cluster), which can have a dramatic impact on performance and throughput.
 
 PHP is fundamentally single-threaded, however libcurl provides functionality called the "multi interface".  This allows
 languages like PHP to gain concurrency by providing a batch of requests to process.  The batch is executed in a parallel
-by the underlying multithreaded libcurl library, and the batch of responses is then returned to PHP.
+fashion by the underlying multithreaded libcurl library, and the batch of responses is then returned to PHP.
 
-In a single-threaded environment, the time to execute `n` requests is the sum of those `n` request's latencies.  With
+In a single-threaded environment, the time to execute `n` requests is the sum of those `n` requests' latencies.  With
 the multi interface, the time to execute `n` requests is the latency of the slowest request (assuming enough handles
 are available to execute all requests in parallel).
 
@@ -239,7 +239,7 @@ $doc = $futures['getRequest']['_source'];
 === Caveats to Future mode
 
 There are a few caveats to using future mode.  The biggest is also the most obvious: you need to deal with resolving the
-future yourself.  This is usually trivia, but can sometimes introduce unexpected complications.
+future yourself.  This is usually trivial, but can sometimes introduce unexpected complications.
 
 For example, if you resolve manually using `wait()`, you may need to call `wait()` several times if there were retries.
 This is because each retry will introduce another layer of wrapped futures, and each needs to be resolved to get the

--- a/docs/namespaces.asciidoc
+++ b/docs/namespaces.asciidoc
@@ -43,7 +43,7 @@ As you can see, the same `stats()` call is made through three different
 namespaces.  Sometimes the methods require parameters.  These parameters work
 just like any other method in the library.
 
-For example, we can requests index stats about a specific index, or multiple
+For example, we can request index stats about a specific index, or multiple
 indices:
 
 [source,php]

--- a/docs/per-request-configuration.asciidoc
+++ b/docs/per-request-configuration.asciidoc
@@ -219,7 +219,7 @@ Array
 === Curl Timeouts
 
 It is possible to configure per-request curl timeouts via the `timeout` and `connect_timeout` parameters.  These
-control the client-side, curl timeouts.  The `connect_timeout` paramter controls how long curl should wait for the
+control the client-side, curl timeouts.  The `connect_timeout` parameter controls how long curl should wait for the
 "connect" phase to finish, while the `timeout` parameter controls how long curl should wait for the entire request
 to finish.
 

--- a/docs/php_json_objects.asciidoc
+++ b/docs/php_json_objects.asciidoc
@@ -3,7 +3,7 @@
 
 A common source of confusion with the client revolves around JSON arrays and objects, and how to specify them in PHP.
 In particular, problems are caused by empty objects and arrays of objects.  This page will show you some common patterns
-used in Elasticsearch JSON API, and how to convert that to a PHP representation
+used in Elasticsearch JSON API, and how to convert that to a PHP representation.
 
 === Empty Objects
 


### PR DESCRIPTION
This is my attempt at eliminating a few typos I spotted in the docs for the 2.0 branch.
Hopefully you won't mind me submitting one commit for each file changed.