### PR TITLE
Make id param optionnal for termvectors requests.

### DIFF
--- a/src/Elasticsearch/Endpoints/TermVectors.php
+++ b/src/Elasticsearch/Endpoints/TermVectors.php
@@ -39,27 +39,31 @@ class TermVectors extends AbstractEndpoint
     public function getURI()
     {
         if (isset($this->index) !== true) {
-            throw new Exceptions\RuntimeException(
-                'index is required for TermVectors'
-            );
-        }
-        if (isset($this->type) !== true) {
-            throw new Exceptions\RuntimeException(
-                'type is required for TermVectors'
-            );
-        }
-        if (isset($this->id) !== true) {
-            throw new Exceptions\RuntimeException(
-                'id is required for TermVectors'
-            );
-        }
+           throw new Exceptions\RuntimeException(
+               'index is required for TermVectors'
+           );
+       }
+       if (isset($this->type) !== true) {
+           throw new Exceptions\RuntimeException(
+               'type is required for TermVectors'
+           );
+       }
+       if (isset($this->id) !== true && isset($this->body['doc']) !== true) {
+           throw new Exceptions\RuntimeException(
+               'id or doc is required for TermVectors'
+           );
+       }
 
-        $index = $this->index;
-        $type  = $this->type;
-        $id    = $this->id;
-        $uri   = "/$index/$type/$id/_termvectors";
+       $index = $this->index;
+       $type  = $this->type;
+       $id    = $this->id;
+       $uri   = "/$index/$type/_termvectors";
 
-        return $uri;
+       if ($id !== null) {
+           $uri = "/$index/$type/$id/_termvectors";
+       }
+
+       return $uri;
     }
 
     /**


### PR DESCRIPTION
ES REST API allow usage of the termvectors API to process document that are not existing into an index as explained in the Example 3. Artificial documents of the termvectors documentation page (https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-termvectors.html).

The PHP client is not consistent with the REST API since the id parameter is mandatory.
This PR allows to check the presence of an id or of a document and raise an exception if neither of those parameters is present.

It was not required until recently (<5.x) since we were to hack this able to specifiy a empty string as an id.