### PR TITLE
[DOCS] Documentation fixes for 5.0 (typos, etc.)

### DIFF
--- a/docs/breaking-changes.asciidoc
+++ b/docs/breaking-changes.asciidoc
@@ -1,6 +1,6 @@
 == Breaking changes from 2.x
 
-- Indices/Analyze Endpoint: `filters` and `char_filters` URI parameters have renamed to `filter` and `char_filter` respectively
+- Indices/Analyze Endpoint: `filters` and `char_filters` URI parameters have been renamed to `filter` and `char_filter` respectively
 - SearchExists endpoint has been removed (use `size=0` and `terminate_after=1` instead)
 - Warmers have been removed because they are no longer useful
 - Indices/Optimize Endpoint has been removed (use `_forcemerge` instead)

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -58,7 +58,7 @@ methods run into problems with certain edge-cases.  For example, `filter_var()` 
 Basic Auth's password contains special characters such as a pound sign (`#`) or question-marks (`?`).
 
 For this reason, the client supports an extended host syntax which provides greater control over host initialization.
-None of the components are validated, so edge-cases like underscores domain names will not cause problems.
+None of the components are validated, so edge-cases like underscores in domain names will not cause problems.
 
 The extended syntax is an array of parameters for each host:
 
@@ -227,7 +227,7 @@ $client = ClientBuilder::create()       // Instantiate a new ClientBuilder
 
 Elasticsearch-PHP uses an interchangeable HTTP transport layer called https://github.com/guzzle/RingPHP/[RingPHP].  This
 allows the client to construct a generic HTTP request, then pass it to the transport layer to execute.  The actual execution
-details are hidden from the client and modular, so that you can choose from several HTTP handlers depending on your needs.
+details are hidden from the client and it is modular, so that you can choose from several HTTP handlers depending on your needs.
 
 The default handler that the client uses is a combination handler.  When executing in synchronous mode, the handler
 uses `CurlHandler`, which executes single curl calls.  These are very fast for single requests.  When asynchronous (future)

--- a/docs/connection-pool.asciidoc
+++ b/docs/connection-pool.asciidoc
@@ -60,7 +60,7 @@ Note that the implementation is specified via a namespace path to the class.
 
 === simpleConnectionPool
 
-The `SimpleConnectionPool` simply returns the next node as specified by the Selector; it does not perform track
+The `SimpleConnectionPool` simply returns the next node as specified by the Selector; it does not track
 the "liveness" of nodes.  This pool will return nodes whether they are alive or dead.  It is just a simple pool of static
 hosts.
 
@@ -81,7 +81,7 @@ Note that the implementation is specified via a namespace path to the class.
 
 Unlike the two previous static connection pools, this one is dynamic.  The user provides a seed list of hosts, which the
 client uses to "sniff" and discover the rest of the cluster.  It achieves this through the Cluster State API.  As new
-nodes are added or removed from the cluster, the client will update it's pool of active connections.
+nodes are added or removed from the cluster, the client will update its pool of active connections.
 
 To use the `SniffingConnectionPool`:
 
@@ -195,7 +195,7 @@ Sniffing is a relatively lightweight operation (one API call to `/_cluster/state
 it may be a non-negligible overhead for certain PHP applications.  The average PHP script will likely load the client,
 execute a few queries and then close.  Imagine this script being called 1000 times per second: the sniffing connection
 pool will perform the sniffing and pinging process 1000 times per second.  The sniffing process will add a large
-amount of overhead
+amount of overhead.
 
 In reality, if your script only executes a few queries, the sniffing concept is _too_ robust.  It tends to be more
 useful in long-lived processes which potentially "out-live" a static list.

--- a/docs/crud.asciidoc
+++ b/docs/crud.asciidoc
@@ -3,7 +3,7 @@
 
 When you add documents to Elasticsearch, you index JSON documents.  This maps naturally to PHP associative arrays, since
 they can easily be encoded in JSON.  Therefore, in Elasticsearch-PHP you create and pass associative arrays to the client
-for indexing.  There are several methods of ingesting data into Elasticsearch, which we will cover here
+for indexing.  There are several methods of ingesting data into Elasticsearch, which we will cover here.
 
 === Single document indexing
 
@@ -133,7 +133,7 @@ if (!empty($params['body'])) {
 
 Elasticsearch provides realtime GETs of documents.  This means that as soon as the document has been indexed and your
 client receives an acknowledgement, you can immediately retrieve the document from any shard.  Get operations are
-performed by requesting a document by it's full `index/type/id` path:
+performed by requesting a document by its full `index/type/id` path:
 
 [source,php]
 ----
@@ -156,7 +156,7 @@ update to just some fields (either changing an existing field, or adding new fie
 === Partial document update
 
 If you want to partially update a document (e.g. change an existing field, or add a new one) you can do so by specifying
-the `doc` in the `body` parameter.  This will merge the fields in `doc` with the existing document
+the `doc` in the `body` parameter.  This will merge the fields in `doc` with the existing document:
 
 
 [source,php]

--- a/docs/futures.asciidoc
+++ b/docs/futures.asciidoc
@@ -6,9 +6,9 @@ to the cluster), which can have a dramatic impact on performance and throughput.
 
 PHP is fundamentally single-threaded, however libcurl provides functionality called the "multi interface".  This allows
 languages like PHP to gain concurrency by providing a batch of requests to process.  The batch is executed in a parallel
-by the underlying multithreaded libcurl library, and the batch of responses is then returned to PHP.
+fashion by the underlying multithreaded libcurl library, and the batch of responses is then returned to PHP.
 
-In a single-threaded environment, the time to execute `n` requests is the sum of those `n` request's latencies.  With
+In a single-threaded environment, the time to execute `n` requests is the sum of those `n` requests' latencies.  With
 the multi interface, the time to execute `n` requests is the latency of the slowest request (assuming enough handles
 are available to execute all requests in parallel).
 

--- a/docs/installation.asciidoc
+++ b/docs/installation.asciidoc
@@ -1,20 +1,20 @@
 == Installation
 
-Elasticsearch-php only has a four requirements that you need to worry about:
+Elasticsearch-php only has four requirements that you need to worry about:
 
 * PHP 5.6.6 or higher
 * http://getcomposer.org[Composer]
 * http://php.net/manual/en/book.curl.php[ext-curl]: the Libcurl extension for PHP (see note below)
 * Native JSON Extensions (`ext-json`) 1.3.7 or higher
 
-The rest of the dependencies will automatically be downloaded and installed by Composer.  Composer is a package and dependency manager for PHP.  Installing elasticsearch-php with Composer is very easy
+The rest of the dependencies will automatically be downloaded and installed by Composer.  Composer is a package and dependency manager for PHP.  Installing elasticsearch-php with Composer is very easy.
 
 [NOTE]
 .Libcurl can be replaced
 ====
 The default HTTP handlers that ship with Elasticsearch-php require the PHP libcurl extension, but it is not technically
 required for the client to operate.  If you have a host that does not have libcurl installed, you can use an
-alternate HTTP handler based on PHP streams.  Performance _will_ suffer, as the libcurl extension is much faster
+alternate HTTP handler based on PHP streams.  Performance _will_ suffer, as the libcurl extension is much faster.
 ====
 
 === Version Matrix
@@ -44,7 +44,7 @@ The master branch will always track Elasticsearch master, but it is not recommen
 }
 --------------------------
 
-* Install the client with composer.  The first command download the `composer.phar` PHP package, and the second command invokes the installation.  Composer will automatically download any required dependencies, store them in a /vendor/ directory and build an autoloader.:
+* Install the client with composer.  The first command downloads the `composer.phar` PHP package, and the second command invokes the installation.  Composer will automatically download any required dependencies, store them in a /vendor/ directory and build an autoloader.
 +
 [source,shell]
 --------------------------
@@ -65,7 +65,7 @@ $client = Elasticsearch\ClientBuilder::create()->build();
 +
 Client instantiation is performed with a static helper function `create()`.  This creates a ClientBuilder object,
 which helps you to set custom configurations.  When you are done configuring, you call the `build()` method to generate
-a `Client` object.  We'll discuss configuration more in the Configuration section
+a `Client` object.  We'll discuss configuration more in the Configuration section.
 
 
 === --no-dev flag
@@ -73,7 +73,7 @@ You'll notice that the installation command specified `--no-dev`.  This prevents
 from installing the various testing and development dependencies.  For average users, there
 is no need to install the test suite.  In particular, the development dependencies include
 a full copy of Elasticsearch so that tests can be run against the REST specifications.  This
-is a rather large download for non-developers, hence the --no-dev flag
+is a rather large download for non-developers, hence the `--no-dev` flag
 
 If you wish to contribute to development of this library, just omit the `--no-dev` flag to
 be able to run tests.

--- a/docs/namespaces.asciidoc
+++ b/docs/namespaces.asciidoc
@@ -43,7 +43,7 @@ As you can see, the same `stats()` call is made through three different
 namespaces.  Sometimes the methods require parameters.  These parameters work
 just like any other method in the library.
 
-For example, we can requests index stats about a specific index, or multiple
+For example, we can request index stats about a specific index, or multiple
 indices:
 
 [source,php]

--- a/docs/per-request-configuration.asciidoc
+++ b/docs/per-request-configuration.asciidoc
@@ -217,7 +217,7 @@ Array
 === Curl Timeouts
 
 It is possible to configure per-request curl timeouts via the `timeout` and `connect_timeout` parameters.  These
-control the client-side, curl timeouts.  The `connect_timeout` paramter controls how long curl should wait for the
+control the client-side, curl timeouts.  The `connect_timeout` parameter controls how long curl should wait for the
 "connect" phase to finish, while the `timeout` parameter controls how long curl should wait for the entire request
 to finish.
 
@@ -268,7 +268,7 @@ $future = $client->get($params);
 $results = $future->wait();       // resolve the future
 ----
 
-Future mode supports two options: `true` or `'lazy'`.  For more details about how asynchronous execution functions, and
+Future mode supports two options: `true` or `lazy`.  For more details about how asynchronous execution functions, and
 how to work with the results, see the dedicated page on <<_future_mode>>.
 
 === SSL Encryption

--- a/docs/php_json_objects.asciidoc
+++ b/docs/php_json_objects.asciidoc
@@ -3,7 +3,7 @@
 
 A common source of confusion with the client revolves around JSON arrays and objects, and how to specify them in PHP.
 In particular, problems are caused by empty objects and arrays of objects.  This page will show you some common patterns
-used in Elasticsearch JSON API, and how to convert that to a PHP representation
+used in Elasticsearch JSON API, and how to convert that to a PHP representation.
 
 === Empty Objects
 

--- a/docs/quickstart.asciidoc
+++ b/docs/quickstart.asciidoc
@@ -258,7 +258,7 @@ Array
 
 === Wrap up
 
-That was just a crash-course overview of the client and it's syntax.  If you are familiar with elasticsearch, you'll
+That was just a crash-course overview of the client and its syntax.  If you are familiar with elasticsearch, you'll
 notice that the methods are named just like REST endpoints.
 
 You'll also notice that the client is configured in a manner that facilitates easy discovery via your IDE.  All core


### PR DESCRIPTION
More documentation fixes, this time for the 5.0 branch.
It's trivial stuff like correcting typos, adding periods at the end of sentences, and so on.
One commit for each file changed, sorry about that 😞
(I tried to rebase/squash but apparently it needs to be done before pushing...)