### PR TITLE
[TEST] Fix Travis CI build failures for 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ env:
     - JAVA_HOME="/usr/lib/jvm/java-8-oracle/jre"
 
 before_install:
-  - if [ $TRAVIS_PHP_VERSION = '5.6' ]; then pecl uninstall json && pecl install json-1.3.7 fi
+  - if [ $TRAVIS_PHP_VERSION = '5.6' ]; then pecl uninstall json && pecl install json-1.3.7; fi
   - sudo update-java-alternatives -s java-8-oracle
   - ./travis/download_and_run_es.sh
 


### PR DESCRIPTION
I just came across this while investigating why my recent documentation-related PR (#543) (which did not touch any _real_ code) has [1 errored check](https://travis-ci.org/elastic/elasticsearch-php/jobs/202960996#L311-L315).
Apparently, this (and other build failures in the 5.0 branch like [here](https://travis-ci.org/elastic/elasticsearch-php/jobs/189494338#L293-L297) and [here](https://travis-ci.org/elastic/elasticsearch-php/jobs/184981892#L294-L298)) is related to commit 3409a81.