### PR TITLE
endpoint index and type getters

### DIFF
--- a/src/Elasticsearch/Endpoints/AbstractEndpoint.php
+++ b/src/Elasticsearch/Endpoints/AbstractEndpoint.php
@@ -96,6 +96,14 @@ abstract class AbstractEndpoint
     }
 
     /**
+     * @return string|null
+     */
+    public function getIndex()
+    {
+        return $this->index;
+    }
+
+    /**
      * @param string $index
      *
      * @return $this
@@ -114,6 +122,14 @@ abstract class AbstractEndpoint
         $this->index = urlencode($index);
 
         return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getType()
+    {
+        return $this->type;
     }
 
     /**


### PR DESCRIPTION
1. Is it possible to add getIndex and getType getters for AbstractEndpoint?
If not, what is a purpose to make it so private?

We need it for https://github.com/ruflin/Elastica/pull/1275

2. Also, why:
```
        public function setType($type)
    {
        if ($type === null) {
            return $this;
        }


```
so strange? If I want drop type for my endpoint, why client force me to recreate full endpoint? Or at least why it is so silent?