### PR TITLE
Remove incorrect Composer instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The recommended method to install _Elasticsearch-PHP_ is through [Composer](http
 3. Install your dependencies:
 
     ```bash
-        php composer.phar install --no-dev
+        php composer.phar install
     ```
 
 4. Require Composer's autoloader
@@ -79,8 +79,6 @@ The recommended method to install _Elasticsearch-PHP_ is through [Composer](http
         $client = ClientBuilder::create()->build();
     ```
 You can find out more on how to install Composer, configure autoloading, and other best-practices for defining dependencies at [getcomposer.org](http://getcomposer.org).
-
-You'll notice that the installation command specified `--no-dev`.  This prevents Composer from installing the various testing and development dependencies.  For average users, there is no need to install the test suite (which also includes the complete source code of Elasticsearch).  If you wish to contribute to development, just omit the `--no-dev` flag to be able to run tests.
 
 PHP Version Requirement
 ----


### PR DESCRIPTION
Instructions on using the `--no-dev` flag were wrong as Composer will in this case never install the dev dependencies anyway. Dev dependencies are only ever resolved in the root package of an application for exactly the reasons that were described here. A consumer of the library will therefore never get the dev requirements of any library, with any flag.