### PR TITLE
Client::exists() should not throw a warning when a resource does not exist

### DIFF
--- a/src/Elasticsearch/Client.php
+++ b/src/Elasticsearch/Client.php
@@ -559,6 +559,9 @@ class Client
         //manually make this verbose so we can check status code
         $params['client']['verbose'] = true;
 
+        //ignore warning when resource does not exist
+        $params['client']['ignore'] = ['404'];
+
         /** @var callback $endpointBuilder */
         $endpointBuilder = $this->endpoints;
 

--- a/src/Elasticsearch/Client.php
+++ b/src/Elasticsearch/Client.php
@@ -559,8 +559,10 @@ class Client
         //manually make this verbose so we can check status code
         $params['client']['verbose'] = true;
 
-        //ignore warning when resource does not exist
-        $params['client']['ignore'] = ['404'];
+        //ignore warning when the resource does not exist
+        if (is_array($params['client']['ignore']) {
+            $params['client']['ignore'][] = '404';
+        }
 
         /** @var callback $endpointBuilder */
         $endpointBuilder = $this->endpoints;

--- a/src/Elasticsearch/Client.php
+++ b/src/Elasticsearch/Client.php
@@ -560,7 +560,7 @@ class Client
         $params['client']['verbose'] = true;
 
         //ignore warning when the resource does not exist
-        if (is_array($params['client']['ignore']) {
+        if (is_array($params['client']['ignore'])) {
             $params['client']['ignore'][] = '404';
         }
 


### PR DESCRIPTION
I made a change in the `exist()` method, it should not trigger a warning when the resource could not be found. Because the sole purpose of `exist()` is that it checks for this.

Therefore that method should ignore 404 response errors.