### PR TITLE
Fixed missing "body" in example.

### DIFF
--- a/docs/search-operations.asciidoc
+++ b/docs/search-operations.asciidoc
@@ -266,8 +266,10 @@ while (isset($response['hits']['hits']) && count($response['hits']['hits']) > 0)
 
     // Execute a Scroll request and repeat
     $response = $client->scroll([
-            "scroll_id" => $scroll_id,  //...using our previously obtained _scroll_id
-            "scroll" => "30s"           // and the same timeout window
+            "body" => [
+                "scroll_id" => $scroll_id,  //...using our previously obtained _scroll_id
+                "scroll" => "30s"           // and the same timeout window
+            ]
         ]
     );
 }


### PR DESCRIPTION
The example to scroll for php is wrong atm. This PR fixes the example.