### PR TITLE
Allow Sliced Scroll for the Search endpoint

### DIFF
--- a/src/Elasticsearch/Endpoints/Search.php
+++ b/src/Elasticsearch/Endpoints/Search.php
@@ -79,6 +79,7 @@ class Search extends AbstractEndpoint
             'scroll',
             'search_type',
             'size',
+            'slice',
             'sort',
             'source',
             '_source',


### PR DESCRIPTION
Allow to use "slice" parameter for the scroll search according to https://www.elastic.co/guide/en/elasticsearch/reference/5.5/search-request-scroll.html#sliced-scroll