### PR TITLE
Change inheritance of 'NoNodesAvailableException' to 'ServerErrorResp…

### DIFF
--- a/src/Elasticsearch/Common/Exceptions/NoNodesAvailableException.php
+++ b/src/Elasticsearch/Common/Exceptions/NoNodesAvailableException.php
@@ -13,6 +13,6 @@ namespace Elasticsearch\Common\Exceptions;
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elastic.co
  */
-class NoNodesAvailableException extends \Exception implements ElasticsearchException
+class NoNodesAvailableException extends ServerErrorResponseException implements ElasticsearchException
 {
 }


### PR DESCRIPTION
Hi,

I've seen that `NoNodesAvailableException` extends from generic `\Exception` instead of `ServerErrorResponseException`. That's why I want to request information about client only if the engine will respond using `ElasticSearch\Client::info()` and I can't do it if an error on server exists.

Thank you!