### PR TITLE
[TEST] add newer ES versions to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,28 +14,31 @@ branches:
 
 sudo: true
 
-php:
-  - 5.6
-  - 7.0
-  - 7.1
-  - hhvm
-
 matrix:
   fast_finish: true
   include:
+    - php: 5.6
+      env: ES_VERSION="5.0" TEST_BUILD_REF="origin/5.0"
+    - php: 5.6
+      env: ES_VERSION="5.5" TEST_BUILD_REF="origin/5.5"
+
+    - php: 7.0
+      env: ES_VERSION="5.0" TEST_BUILD_REF="origin/5.0"
+    - php: 7.0
+      env: ES_VERSION="5.5" TEST_BUILD_REF="origin/5.5"
+
     - php: 7.1
       env: ES_VERSION="5.0" TEST_BUILD_REF="origin/5.0"
     - php: 7.1
-      env: ES_VERSION="5.1" TEST_BUILD_REF="origin/5.1"
-    - php: 7.1
-      env: ES_VERSION="5.2" TEST_BUILD_REF="origin/5.2"
+      env: ES_VERSION="5.5" TEST_BUILD_REF="origin/5.5"
+
+    - php: hhvm
+      env: ES_VERSION="5.5" TEST_BUILD_REF="origin/5.5"
   allow_failures:
     - php: hhvm
 
 env:
   global:
-    - ES_VERSION="5.x"
-    - TEST_BUILD_REF="origin/5.x"
     - ES_TEST_HOST=http://localhost:9200
     - JAVA_HOME="/usr/lib/jvm/java-8-oracle/jre"
 


### PR DESCRIPTION
This PR adds newer Elasticsearch versions to the TravisCI build matrix.

The tests are failing for ES 5.6 (unreleased?) - which is used as a default for the builds without the ES version specified. It probably does not block the merge of the PR as the tests would start failing for any other PR as well.

Maybe the Travis configuration can be changed so it is always running the builds against specific version (so the tests won't start failing after the new version is released). <-- What do you think?