### PR TITLE
[TEST] build against ES 6 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ sudo: true
 php:
   - 7.0
   - 7.1
-  - hhvm
 
 matrix:
   fast_finish: true
@@ -28,8 +27,6 @@ matrix:
       env: ES_VERSION="5.1" TEST_BUILD_REF="origin/5.1"
     - php: 7.1
       env: ES_VERSION="5.2" TEST_BUILD_REF="origin/5.2"
-  allow_failures:
-    - php: hhvm
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,24 +14,28 @@ branches:
 
 sudo: true
 
-php:
-  - 7.0
-  - 7.1
-
 matrix:
   fast_finish: true
   include:
+    - php: 7.0
+      env: ES_VERSION="5.5" TEST_BUILD_REF="origin/5.5"
+    - php: 7.0
+      env: ES_VERSION="6.0" TEST_BUILD_REF="origin/6.0"
+    - php: 7.0
+      env: ES_VERSION="6.x" TEST_BUILD_REF="origin/6.x"
+
     - php: 7.1
-      env: ES_VERSION="5.0" TEST_BUILD_REF="origin/5.0"
+      env: ES_VERSION="5.5" TEST_BUILD_REF="origin/5.5"
     - php: 7.1
-      env: ES_VERSION="5.1" TEST_BUILD_REF="origin/5.1"
+      env: ES_VERSION="6.0" TEST_BUILD_REF="origin/6.0"
     - php: 7.1
-      env: ES_VERSION="5.2" TEST_BUILD_REF="origin/5.2"
+      env: ES_VERSION="6.x" TEST_BUILD_REF="origin/6.x"
+
+  allow_failures:
+    - env: ES_VERSION="6.x" TEST_BUILD_REF="origin/6.x"
 
 env:
   global:
-    - ES_VERSION="5.x"
-    - TEST_BUILD_REF="origin/5.x"
     - ES_TEST_HOST=http://localhost:9200
     - JAVA_HOME="/usr/lib/jvm/java-8-oracle/jre"
 

--- a/tests/Elasticsearch/Tests/YamlRunnerTest.php
+++ b/tests/Elasticsearch/Tests/YamlRunnerTest.php
@@ -56,6 +56,9 @@ class YamlRunnerTest extends \PHPUnit_Framework_TestCase
 
     /** @var array A list of skipped test with their reasons */
     private static $skippedTest = [
+        'cat.aliases/20_headers.yml' => 'Using java regex fails in PHP',
+        'cat.aliases/20_headers.yaml' => 'Using java regex fails in PHP',
+
         'cat.nodeattrs/10_basic.yml' => 'Using java regex fails in PHP',
         'cat.nodeattrs/10_basic.yaml' => 'Using java regex fails in PHP',
 

--- a/tests/Elasticsearch/Tests/YamlRunnerTest.php
+++ b/tests/Elasticsearch/Tests/YamlRunnerTest.php
@@ -57,17 +57,31 @@ class YamlRunnerTest extends \PHPUnit_Framework_TestCase
     /** @var array A list of skipped test with their reasons */
     private static $skippedTest = [
         'cat.nodeattrs/10_basic.yml' => 'Using java regex fails in PHP',
+        'cat.nodeattrs/10_basic.yaml' => 'Using java regex fails in PHP',
+
         'cat.repositories/10_basic.yml' => 'Using java regex fails in PHP',
+        'cat.repositories/10_basic.yaml' => 'Using java regex fails in PHP',
+
         'indices.shrink/10_basic.yml' => 'Shrink tests seem to require multiple nodes',
-        'indices.rollover/10_basic.yml' => 'Rollover test seems buggy atm'
+        'indices.shrink/10_basic.yaml' => 'Shrink tests seem to require multiple nodes',
+
+        'indices.rollover/10_basic.yml' => 'Rollover test seems buggy atm',
+        'indices.rollover/10_basic.yaml' => 'Rollover test seems buggy atm',
     ];
 
     /** @var array A list of files to skip completely, due to fatal parsing errors */
     private static $skippedFiles = [
         'indices.create/10_basic.yml' => 'Temporary: Yaml parser doesnt support "inline" empty keys',
+        'indices.create/10_basic.yaml' => 'Temporary: Yaml parser doesnt support "inline" empty keys',
+
         'indices.put_mapping/10_basic.yml' => 'Temporary: Yaml parser doesnt support "inline" empty keys',
+        'indices.put_mapping/10_basic.yaml' => 'Temporary: Yaml parser doesnt support "inline" empty keys',
+
         'search/110_field_collapsing.yml' => 'Temporary: parse error, malformed inline yaml',
-        'cat.nodes/10_basic.yml' => 'Temporary: parse error, something about $body: |'
+        'search/110_field_collapsing.yaml' => 'Temporary: parse error, malformed inline yaml',
+
+        'cat.nodes/10_basic.yml' => 'Temporary: parse error, something about $body: |',
+        'cat.nodes/10_basic.yaml' => 'Temporary: parse error, something about $body: |',
     ];
 
     /**
@@ -732,6 +746,9 @@ class YamlRunnerTest extends \PHPUnit_Framework_TestCase
         $finder->in($path);
         $finder->files();
         $finder->name('*.yml');
+
+        // *.yaml files should be included until the library is ES 6.0+ only
+        $finder->name('*.yaml');
 
         $filter = isset($_SERVER['TEST_CASE']) ? $_SERVER['TEST_CASE'] : null;
 


### PR DESCRIPTION
As mentioned in #609, the master should be tested against ES 6.x

- I've kept the 5.5 version there. So it can be easily seen, when the 5.x compatibility is broken. I think it should be kept there as it would allow the users to upgrade the elastisearch-php first and their ES cluster later.

TODO:
- [ ] Decide if the new version of elastisearch-php should support ES 5.x
- [x] Decide the fate of HHVM support: https://github.com/elastic/elasticsearch-php/issues/611
- [x] Merge https://github.com/elastic/elasticsearch-php/pull/616

EDIT:
The build fails for 6.0 which I think is OK as there are probably some changes required in `elastisearch-php` to fully support it.