### PR TITLE
Fix RoundRobinSelector

### DIFF
--- a/src/Elasticsearch/ConnectionPool/Selectors/RoundRobinSelector.php
+++ b/src/Elasticsearch/ConnectionPool/Selectors/RoundRobinSelector.php
@@ -29,8 +29,10 @@ class RoundRobinSelector implements SelectorInterface
      */
     public function select($connections)
     {
+        $returnConnection = $connections[$this->current % count($connections)];
+
         $this->current += 1;
 
-        return $connections[$this->current % count($connections)];
+        return $returnConnection;
     }
 }

--- a/tests/Elasticsearch/Tests/ConnectionPool/Selectors/RoundRobinSelectorTest.php
+++ b/tests/Elasticsearch/Tests/ConnectionPool/Selectors/RoundRobinSelectorTest.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Elasticsearch\Tests\ConnectionPool\Selectors;
 
 use Elasticsearch;
+use Elasticsearch\Connections\ConnectionInterface;
 
 /**
  * Class SnifferTest
@@ -29,19 +30,32 @@ class RoundRobinSelectorTest extends \PHPUnit_Framework_TestCase
     {
         $roundRobin = new Elasticsearch\ConnectionPool\Selectors\RoundRobinSelector();
 
-        $mockConnections = array();
-        foreach (range(0, 10) as $index) {
-            $mockConnections[$index] = $this->getMockBuilder('\Elasticsearch\Connections\CurlMultiConnection')
+        $mockConnections = [];
+        foreach (range(0, 9) as $index) {
+            $mockConnections[$index] = $this->getMockBuilder(ConnectionInterface::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         }
 
-        foreach (range(0, 15) as $index) {
-            $retConnection = $roundRobin->select($mockConnections);
+        // select ten
+        $this->assertSame($mockConnections[0], $roundRobin->select($mockConnections));
+        $this->assertSame($mockConnections[1], $roundRobin->select($mockConnections));
+        $this->assertSame($mockConnections[2], $roundRobin->select($mockConnections));
+        $this->assertSame($mockConnections[3], $roundRobin->select($mockConnections));
+        $this->assertSame($mockConnections[4], $roundRobin->select($mockConnections));
+        $this->assertSame($mockConnections[5], $roundRobin->select($mockConnections));
+        $this->assertSame($mockConnections[6], $roundRobin->select($mockConnections));
+        $this->assertSame($mockConnections[7], $roundRobin->select($mockConnections));
+        $this->assertSame($mockConnections[8], $roundRobin->select($mockConnections));
+        $this->assertSame($mockConnections[9], $roundRobin->select($mockConnections));
 
-            $nextIndex = ($index % 10) + 1;
-            $this->assertEquals($mockConnections[$nextIndex], $retConnection);
-        }
+        // select five - should start from the first one (index: 0)
+        $this->assertSame($mockConnections[0], $roundRobin->select($mockConnections));
+        $this->assertSame($mockConnections[1], $roundRobin->select($mockConnections));
+        $this->assertSame($mockConnections[2], $roundRobin->select($mockConnections));
+        $this->assertSame($mockConnections[3], $roundRobin->select($mockConnections));
+        $this->assertSame($mockConnections[4], $roundRobin->select($mockConnections));
+
     }
 
     /**
@@ -52,33 +66,39 @@ class RoundRobinSelectorTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testAddTenConnectionsestFiveTRemoveThree()
+    public function testAddTenConnectionsTestFiveRemoveThreeTestTen()
     {
         $roundRobin = new Elasticsearch\ConnectionPool\Selectors\RoundRobinSelector();
 
-        $mockConnections = array();
-        foreach (range(0, 10) as $index) {
-            $mockConnections[$index] = $this->getMockBuilder('\Elasticsearch\Connections\CurlMultiConnection')
+        $mockConnections = [];
+        foreach (range(0, 9) as $index) {
+            $mockConnections[$index] = $this->getMockBuilder(ConnectionInterface::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         }
 
-        foreach (range(0, 4) as $index) {
-            $retConnection = $roundRobin->select($mockConnections);
+        // select five
+        $this->assertSame($mockConnections[0], $roundRobin->select($mockConnections));
+        $this->assertSame($mockConnections[1], $roundRobin->select($mockConnections));
+        $this->assertSame($mockConnections[2], $roundRobin->select($mockConnections));
+        $this->assertSame($mockConnections[3], $roundRobin->select($mockConnections));
+        $this->assertSame($mockConnections[4], $roundRobin->select($mockConnections));
 
-            $nextIndex = ($index % (count($mockConnections)-1)) + 1;
-            $this->assertEquals($mockConnections[$nextIndex], $retConnection);
-        }
-
+        // remove three
         unset($mockConnections[8]);
         unset($mockConnections[9]);
         unset($mockConnections[10]);
 
-        foreach (range(5, 15) as $index) {
-            $retConnection = $roundRobin->select($mockConnections);
-
-            $nextIndex = ($index % (count($mockConnections)-1)) + 1;
-            $this->assertEquals($mockConnections[$nextIndex], $retConnection);
-        }
+        // select ten after removal
+        $this->assertSame($mockConnections[5], $roundRobin->select($mockConnections));
+        $this->assertSame($mockConnections[6], $roundRobin->select($mockConnections));
+        $this->assertSame($mockConnections[7], $roundRobin->select($mockConnections));
+        $this->assertSame($mockConnections[0], $roundRobin->select($mockConnections));
+        $this->assertSame($mockConnections[1], $roundRobin->select($mockConnections));
+        $this->assertSame($mockConnections[2], $roundRobin->select($mockConnections));
+        $this->assertSame($mockConnections[3], $roundRobin->select($mockConnections));
+        $this->assertSame($mockConnections[4], $roundRobin->select($mockConnections));
+        $this->assertSame($mockConnections[5], $roundRobin->select($mockConnections));
+        $this->assertSame($mockConnections[6], $roundRobin->select($mockConnections));
     }
 }

--- a/tests/Elasticsearch/Tests/ConnectionPool/Selectors/StickyRoundRobinSelectorTest.php
+++ b/tests/Elasticsearch/Tests/ConnectionPool/Selectors/StickyRoundRobinSelectorTest.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Elasticsearch\Tests\ConnectionPool\Selectors;
 
 use Elasticsearch;
+use Elasticsearch\Connections\ConnectionInterface;
 use Mockery as m;
 
 /**
@@ -28,18 +29,18 @@ class StickyRoundRobinSelectorTest extends \PHPUnit_Framework_TestCase
     {
         $roundRobin = new Elasticsearch\ConnectionPool\Selectors\StickyRoundRobinSelector();
 
-        $mockConnections = array();
-        $mockConnections[] = m::mock('\Elasticsearch\Connections\GuzzleConnection')
+        $mockConnections = [];
+        $mockConnections[] = m::mock(ConnectionInterface::class)
                              ->shouldReceive('isAlive')->times(16)->andReturn(true)->getMock();
 
         foreach (range(0, 9) as $index) {
-            $mockConnections[] = m::mock('\Elasticsearch\Connections\GuzzleConnection');
+            $mockConnections[] = m::mock(ConnectionInterface::class);
         }
 
         foreach (range(0, 15) as $index) {
             $retConnection = $roundRobin->select($mockConnections);
 
-            $this->assertEquals($mockConnections[0], $retConnection);
+            $this->assertSame($mockConnections[0], $retConnection);
         }
     }
 
@@ -47,21 +48,21 @@ class StickyRoundRobinSelectorTest extends \PHPUnit_Framework_TestCase
     {
         $roundRobin = new Elasticsearch\ConnectionPool\Selectors\StickyRoundRobinSelector();
 
-        $mockConnections = array();
-        $mockConnections[] = m::mock('\Elasticsearch\Connections\GuzzleConnection')
+        $mockConnections = [];
+        $mockConnections[] = m::mock(ConnectionInterface::class)
                              ->shouldReceive('isAlive')->once()->andReturn(false)->getMock();
 
-        $mockConnections[] = m::mock('\Elasticsearch\Connections\GuzzleConnection')
+        $mockConnections[] = m::mock(ConnectionInterface::class)
                              ->shouldReceive('isAlive')->times(15)->andReturn(true)->getMock();
 
         foreach (range(0, 8) as $index) {
-            $mockConnections[] = m::mock('\Elasticsearch\Connections\GuzzleConnection');
+            $mockConnections[] = m::mock(ConnectionInterface::class);
         }
 
         foreach (range(0, 15) as $index) {
             $retConnection = $roundRobin->select($mockConnections);
 
-            $this->assertEquals($mockConnections[1], $retConnection);
+            $this->assertSame($mockConnections[1], $retConnection);
         }
     }
 }


### PR DESCRIPTION
When working on some tests cleanup, I realized that there is an issue with `RoundRobinSelectorTest`. It was wasn't actually testing anything, because there was `assertEquals()` used to compare different instances of same class. It compares with `==` which means that different instances with same data are seen as same.

See https://3v4l.org/6Qipd

You can try it yourself, simply by changing `assertEquals()` to `assertSame()` in those two tests.

I changed several things - see the comments directly in the "Diff" tab.