### PR TITLE
Travis: add PHP 7.2 + ES 6.0 to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,9 @@ matrix:
     - php: 7.1
       env: ES_VERSION="6.x" TEST_BUILD_REF="origin/6.x"
 
+    - php: 7.2
+      env: ES_VERSION="6.0" TEST_BUILD_REF="origin/6.0"
+
 env:
   global:
     - ES_TEST_HOST=http://localhost:9200


### PR DESCRIPTION
PHP 7.2 is already quite stable (they have released beta3, I'm using it locally for day-to-day work with no issues) so I suggest adding it to Travis matrix. 



(The build against ES 6.0 fails, but the failing tests are the same as on 7.1)