### PR TITLE
[TEST] add PHPStan to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ before_script:
   - php util/EnsureClusterAlive.php
 
 script:
+  - composer run-script phpstan
   - vendor/bin/phpunit $PHPUNIT_FLAGS
   - vendor/bin/phpunit -c phpunit-integration.xml --group sync $PHPUNIT_FLAGS
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "symfony/yaml": "^2.8",
     "symfony/finder": "^2.8",
     "cpliakas/git-wrapper": "~1.0",
-    "doctrine/inflector": "^1.1"
+    "doctrine/inflector": "^1.1",
+    "phpstan/phpstan-shim": "0.8.3"
   },
   "suggest": {
     "ext-curl": "*",
@@ -36,5 +37,10 @@
     "psr-4": {
       "Elasticsearch\\Tests\\":      "tests/Elasticsearch/Tests/"
     }
+  },
+  "scripts": {
+    "phpstan": [
+      "@php vendor/phpstan/phpstan-shim/phpstan.phar analyse -c phpstan.neon tests --level 7 --no-progress"
+    ]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "guzzlehttp/ringphp" : "~1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.7|^5.4",
+    "phpunit/phpunit": "5.7.21",
     "mockery/mockery": "0.9.4",
     "symfony/yaml": "^2.8",
     "symfony/finder": "^2.8",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "guzzlehttp/ringphp" : "~1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "5.7.21",
+    "phpunit/phpunit": "6.3.0",
     "mockery/mockery": "0.9.4",
     "symfony/yaml": "^2.8",
     "symfony/finder": "^2.8",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,9 @@
+parameters:
+    ignoreErrors:
+        - '#Mockery\\MockInterface::shouldReceive\(\)#'
+        - '#Mockery\\MockInterface given#'
+        - '#Mockery\\MockInterface\[\] given#'
+
+        # because of \Elasticsearch\Tests\RegisteredNamespaceTest
+        - '#Call to an undefined method Elasticsearch\\Client::foo\(\)#'
+        - '#Call to an undefined method Elasticsearch\\Client::bar\(\)#'

--- a/phpunit-integration.xml
+++ b/phpunit-integration.xml
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.7/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.3/phpunit.xsd"
          bootstrap="tests/bootstrap.php"
          colors="true"
          failOnRisky="true"
          verbose="true"
-         backupGlobals="false"
          beStrictAboutChangesToGlobalState="true"
          beStrictAboutOutputDuringTests="true"
-         beStrictAboutTestsThatDoNotTestAnything="true"
 >
     <php>
         <env name="ES_TEST_HOST" value="http://localhost:9200"/>

--- a/phpunit-integration.xml
+++ b/phpunit-integration.xml
@@ -1,17 +1,20 @@
-<phpunit
-        bootstrap="tests/bootstrap.php"
-        colors="true"
-        convertNoticesToExceptions="true"
-        convertWarningsToExceptions="true"
-        convertErrorsToExceptions="true"
-        syntaxCheck="true"
-        verbose="true"
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.7/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
+         colors="true"
+         failOnRisky="true"
+         verbose="true"
+         backupGlobals="false"
+         beStrictAboutChangesToGlobalState="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
 >
     <php>
         <env name="ES_TEST_HOST" value="http://localhost:9200"/>
     </php>
     <testsuites>
-        <testsuite>
+        <testsuite name="Integration Tests">
             <file>tests/Elasticsearch/Tests/YamlRunnerTest.php</file>
         </testsuite>
     </testsuites>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,17 +1,20 @@
-<phpunit
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.7/phpunit.xsd"
         bootstrap="tests/bootstrap.php"
         colors="true"
-        convertNoticesToExceptions="true"
-        convertWarningsToExceptions="true"
-        convertErrorsToExceptions="true"
-        syntaxCheck="true"
+        failOnRisky="true"
         verbose="true"
+        backupGlobals="false"
+        beStrictAboutChangesToGlobalState="true"
+        beStrictAboutOutputDuringTests="true"
+        beStrictAboutTestsThatDoNotTestAnything="true"
 >
     <php>
-        <env name="ES_TEST_HOST" value="http://localhost:9200"/>
+        <server name="ES_TEST_HOST" value="http://localhost:9200"/>
     </php>
     <testsuites>
-        <testsuite>
+        <testsuite name="Tests">
             <directory>tests</directory>
             <exclude>tests/Elasticsearch/Tests/YamlRunnerTest.php</exclude>
         </testsuite>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.7/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.3/phpunit.xsd"
         bootstrap="tests/bootstrap.php"
         colors="true"
         failOnRisky="true"
         verbose="true"
-        backupGlobals="false"
         beStrictAboutChangesToGlobalState="true"
         beStrictAboutOutputDuringTests="true"
-        beStrictAboutTestsThatDoNotTestAnything="true"
 >
     <php>
         <server name="ES_TEST_HOST" value="http://localhost:9200"/>

--- a/tests/Elasticsearch/Tests/ClientIntegrationTests.php
+++ b/tests/Elasticsearch/Tests/ClientIntegrationTests.php
@@ -2,6 +2,10 @@
 
 declare(strict_types = 1);
 
+namespace Elasticsearch\Tests;
+
+use Elasticsearch;
+
 /**
  * Class ClientTest
  *

--- a/tests/Elasticsearch/Tests/ClientIntegrationTests.php
+++ b/tests/Elasticsearch/Tests/ClientIntegrationTests.php
@@ -12,12 +12,10 @@ declare(strict_types = 1);
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link       http://elasticsearch.org
  */
-class ClientIntegrationTests extends \PHPUnit_Framework_TestCase
+class ClientIntegrationTests extends \PHPUnit\Framework\TestCase
 {
     public function testCustomQueryParams()
     {
-        $params = [];
-
         $client = Elasticsearch\ClientBuilder::create()->setHosts([$_SERVER['ES_TEST_HOST']])->build();
 
         $getParams = [

--- a/tests/Elasticsearch/Tests/ClientIntegrationTests.php
+++ b/tests/Elasticsearch/Tests/ClientIntegrationTests.php
@@ -16,19 +16,21 @@ class ClientIntegrationTests extends \PHPUnit_Framework_TestCase
 {
     public function testCustomQueryParams()
     {
-        $params = array();
+        $params = [];
 
         $client = Elasticsearch\ClientBuilder::create()->setHosts([$_SERVER['ES_TEST_HOST']])->build();
 
-        $getParams = array(
+        $getParams = [
             'index' => 'test',
             'type' => 'test',
             'id' => 1,
             'parent' => 'abc',
-            'custom' => array('customToken' => 'abc', 'otherToken' => 123),
+            'custom' => ['customToken' => 'abc', 'otherToken' => 123],
             'client' => ['ignore' => 400]
-        );
+        ];
         $exists = $client->exists($getParams);
+
+        $this->assertFalse($exists);
     }
 
 }

--- a/tests/Elasticsearch/Tests/ClientTest.php
+++ b/tests/Elasticsearch/Tests/ClientTest.php
@@ -20,7 +20,7 @@ use Mockery as m;
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link       http://elasticsearch.org
  */
-class ClientTest extends \PHPUnit_Framework_TestCase
+class ClientTest extends \PHPUnit\Framework\TestCase
 {
     public function tearDown()
     {

--- a/tests/Elasticsearch/Tests/ClientTest.php
+++ b/tests/Elasticsearch/Tests/ClientTest.php
@@ -27,11 +27,11 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         m::close();
     }
 
-    /**
-     * @expectedException \Elasticsearch\Common\Exceptions\InvalidArgumentException
-     */
     public function testConstructorIllegalPort()
     {
+        $this->expectException(\Elasticsearch\Common\Exceptions\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Could not parse URI');
+
         $client = Elasticsearch\ClientBuilder::create()->setHosts(['localhost:abc'])->build();
     }
 
@@ -49,9 +49,6 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(Client::class, $client);
     }
 
-    /**
-     * @expectedException \Elasticsearch\Common\Exceptions\RuntimeException
-     */
     public function testFromConfigBadParam()
     {
         $params = [
@@ -61,6 +58,10 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             'retries' => 2,
             'imNotReal' => 5
         ];
+
+        $this->expectException(\Elasticsearch\Common\Exceptions\RuntimeException::class);
+        $this->expectExceptionMessage('Unknown parameters provided: imNotReal');
+
         $client = ClientBuilder::fromConfig($params);
     }
 

--- a/tests/Elasticsearch/Tests/ClientTest.php
+++ b/tests/Elasticsearch/Tests/ClientTest.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Elasticsearch\Tests;
 
 use Elasticsearch;
+use Elasticsearch\Client;
 use Elasticsearch\ClientBuilder;
 use Elasticsearch\Common\Exceptions\MaxRetriesException;
 use Mockery as m;
@@ -44,6 +45,8 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             'handler' => ClientBuilder::multiHandler()
         ];
         $client = ClientBuilder::fromConfig($params);
+
+        $this->assertInstanceOf(Client::class, $client);
     }
 
     /**
@@ -71,136 +74,148 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             'imNotReal' => 5
         ];
         $client = ClientBuilder::fromConfig($params, true);
+
+        $this->assertInstanceOf(Client::class, $client);
     }
 
-    public function testNullDelete()
+    public function testIndexCannotBeNullForDelete()
     {
         $client = ClientBuilder::create()->build();
 
-        try {
-            $client->delete([
-                'index' => null,
-                'type' => 'test',
-                'id' => 'test'
-            ]);
-            $this->fail("InvalidArgumentException was not thrown");
-        } catch (Elasticsearch\Common\Exceptions\InvalidArgumentException $e) {
-            // all good
-        }
+        $this->expectException(Elasticsearch\Common\Exceptions\InvalidArgumentException::class);
+        $this->expectExceptionMessage('index cannot be null.');
 
-        try {
-            $client->delete([
-                'index' => 'test',
-                'type' => null,
-                'id' => 'test'
-            ]);
-            $this->fail("InvalidArgumentException was not thrown");
-        } catch (Elasticsearch\Common\Exceptions\InvalidArgumentException $e) {
-            // all good
-        }
-
-        try {
-            $client->delete([
-                'index' => 'test',
-                'type' => 'test',
-                'id' => null
-            ]);
-            $this->fail("InvalidArgumentException was not thrown");
-        } catch (Elasticsearch\Common\Exceptions\InvalidArgumentException $e) {
-            // all good
-        }
+        $client->delete([
+            'index' => null,
+            'type' => 'test',
+            'id' => 'test'
+        ]);
     }
 
-    public function testEmptyStringDelete()
+    public function testTypeCannotBeNullForDelete()
     {
         $client = ClientBuilder::create()->build();
 
-        try {
-            $client->delete([
-                'index' => '',
-                'type' => 'test',
-                'id' => 'test'
-            ]);
-            $this->fail("InvalidArgumentException was not thrown");
-        } catch (Elasticsearch\Common\Exceptions\InvalidArgumentException $e) {
-            // all good
-        }
+        $this->expectException(Elasticsearch\Common\Exceptions\InvalidArgumentException::class);
+        $this->expectExceptionMessage('type cannot be null.');
 
-        try {
-            $client->delete([
-                'index' => 'test',
-                'type' => '',
-                'id' => 'test'
-            ]);
-            $this->fail("InvalidArgumentException was not thrown");
-        } catch (Elasticsearch\Common\Exceptions\InvalidArgumentException $e) {
-            // all good
-        }
-
-        try {
-            $client->delete([
-                'index' => 'test',
-                'type' => 'test',
-                'id' => ''
-            ]);
-            $this->fail("InvalidArgumentException was not thrown");
-        } catch (Elasticsearch\Common\Exceptions\InvalidArgumentException $e) {
-            // all good
-        }
+        $client->delete([
+            'index' => 'test',
+            'type' => null,
+            'id' => 'test'
+        ]);
     }
 
-    public function testArrayOfEmptyStringDelete()
+    public function testIdCannotBeNullForDelete()
     {
         $client = ClientBuilder::create()->build();
 
-        try {
-            $client->delete([
-                'index' => ['', '', ''],
-                'type' => 'test',
-                'id' => 'test'
-            ]);
-            $this->fail("InvalidArgumentException was not thrown");
-        } catch (Elasticsearch\Common\Exceptions\InvalidArgumentException $e) {
-            // all good
-        }
+        $this->expectException(Elasticsearch\Common\Exceptions\InvalidArgumentException::class);
+        $this->expectExceptionMessage('id cannot be null.');
 
-        try {
-            $client->delete([
-                'index' => 'test',
-                'type' => ['', '', ''],
-                'id' => 'test'
-            ]);
-            $this->fail("InvalidArgumentException was not thrown");
-        } catch (Elasticsearch\Common\Exceptions\InvalidArgumentException $e) {
-            // all good
-        }
+        $client->delete([
+            'index' => 'test',
+            'type' => 'test',
+            'id' => null
+        ]);
     }
 
-    public function testArrayOfNullDelete()
+    public function testIndexCannotBeEmptyStringForDelete()
     {
         $client = ClientBuilder::create()->build();
 
-        try {
-            $client->delete([
-                'index' => [null, null, null],
-                'type' => 'test',
-                'id' => 'test'
-            ]);
-            $this->fail("InvalidArgumentException was not thrown");
-        } catch (Elasticsearch\Common\Exceptions\InvalidArgumentException $e) {
-            // all good
-        }
+        $this->expectException(Elasticsearch\Common\Exceptions\InvalidArgumentException::class);
+        $this->expectExceptionMessage('index cannot be an empty string');
 
-        try {
-            $client->delete([
-                'index' => 'test',
-                'type' => [null, null, null],
-                'id' => 'test'
-            ]);
-            $this->fail("InvalidArgumentException was not thrown");
-        } catch (Elasticsearch\Common\Exceptions\InvalidArgumentException $e) {
-            // all good
-        }
+        $client->delete([
+            'index' => '',
+            'type' => 'test',
+            'id' => 'test'
+        ]);
+    }
+
+    public function testTypeCannotBeEmptyStringForDelete()
+    {
+        $client = ClientBuilder::create()->build();
+
+        $this->expectException(Elasticsearch\Common\Exceptions\InvalidArgumentException::class);
+        $this->expectExceptionMessage('type cannot be an empty string');
+
+        $client->delete([
+            'index' => 'test',
+            'type' => '',
+            'id' => 'test'
+        ]);
+    }
+
+    public function testIdCannotBeEmptyStringForDelete()
+    {
+        $client = ClientBuilder::create()->build();
+
+        $this->expectException(Elasticsearch\Common\Exceptions\InvalidArgumentException::class);
+        $this->expectExceptionMessage('id cannot be an empty string');
+
+        $client->delete([
+            'index' => 'test',
+            'type' => 'test',
+            'id' => ''
+        ]);
+    }
+
+    public function testIndexCannotBeArrayOfEmptyStringsForDelete()
+    {
+        $client = ClientBuilder::create()->build();
+
+        $this->expectException(Elasticsearch\Common\Exceptions\InvalidArgumentException::class);
+        $this->expectExceptionMessage('index cannot be an array of empty strings');
+
+        $client->delete([
+            'index' => ['', '', ''],
+            'type' => 'test',
+            'id' => 'test'
+        ]);
+    }
+
+    public function testTypeCannotBeArrayOfEmptyStringsForDelete()
+    {
+        $client = ClientBuilder::create()->build();
+
+        $this->expectException(Elasticsearch\Common\Exceptions\InvalidArgumentException::class);
+        $this->expectExceptionMessage('type cannot be an array of empty strings');
+
+        $client->delete([
+            'index' => 'test',
+            'type' => ['', '', ''],
+            'id' => 'test'
+        ]);
+    }
+
+    public function testIndexCannotBeArrayOfNullsForDelete()
+    {
+        $client = ClientBuilder::create()->build();
+
+        $this->expectException(Elasticsearch\Common\Exceptions\InvalidArgumentException::class);
+        $this->expectExceptionMessage('index cannot be an array of empty strings');
+
+        $client->delete([
+            'index' => [null, null, null],
+            'type' => 'test',
+            'id' => 'test'
+        ]);
+    }
+
+    public function testTypeCannotBeArrayOfNullsForDelete()
+    {
+        $client = ClientBuilder::create()->build();
+
+        $this->expectException(Elasticsearch\Common\Exceptions\InvalidArgumentException::class);
+        $this->expectExceptionMessage('type cannot be an array of empty strings');
+
+        $client->delete([
+            'index' => 'test',
+            'type' => [null, null, null],
+            'id' => 'test'
+        ]);
     }
 
     public function testMaxRetriesException()

--- a/tests/Elasticsearch/Tests/ConnectionPool/Selectors/RoundRobinSelectorTest.php
+++ b/tests/Elasticsearch/Tests/ConnectionPool/Selectors/RoundRobinSelectorTest.php
@@ -17,7 +17,7 @@ use Elasticsearch\Connections\ConnectionInterface;
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link       http://elasticsearch.org
  */
-class RoundRobinSelectorTest extends \PHPUnit_Framework_TestCase
+class RoundRobinSelectorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Add Ten connections, select 15 to verify round robin

--- a/tests/Elasticsearch/Tests/ConnectionPool/Selectors/StickyRoundRobinSelectorTest.php
+++ b/tests/Elasticsearch/Tests/ConnectionPool/Selectors/StickyRoundRobinSelectorTest.php
@@ -18,7 +18,7 @@ use Mockery as m;
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link       http://elasticsearch.org
  */
-class StickyRoundRobinSelectorTest extends \PHPUnit_Framework_TestCase
+class StickyRoundRobinSelectorTest extends \PHPUnit\Framework\TestCase
 {
     public function tearDown()
     {

--- a/tests/Elasticsearch/Tests/ConnectionPool/SniffingConnectionPoolIntegrationTest.php
+++ b/tests/Elasticsearch/Tests/ConnectionPool/SniffingConnectionPoolIntegrationTest.php
@@ -26,6 +26,8 @@ class SniffingConnectionPoolIntegrationTest extends \PHPUnit_Framework_TestCase
             ->setConnectionPool(SniffingConnectionPool::class, ['sniffingInterval' => -10])
             ->build();
 
-        $client->ping();
+        $pinged = $client->ping();
+
+        $this->assertTrue($pinged);
     }
 }

--- a/tests/Elasticsearch/Tests/ConnectionPool/SniffingConnectionPoolIntegrationTest.php
+++ b/tests/Elasticsearch/Tests/ConnectionPool/SniffingConnectionPoolIntegrationTest.php
@@ -17,7 +17,7 @@ use Elasticsearch\ConnectionPool\SniffingConnectionPool;
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link       http://elasticsearch.org
  */
-class SniffingConnectionPoolIntegrationTest extends \PHPUnit_Framework_TestCase
+class SniffingConnectionPoolIntegrationTest extends \PHPUnit\Framework\TestCase
 {
     public function testSniff()
     {

--- a/tests/Elasticsearch/Tests/ConnectionPool/SniffingConnectionPoolTest.php
+++ b/tests/Elasticsearch/Tests/ConnectionPool/SniffingConnectionPoolTest.php
@@ -21,7 +21,7 @@ use Elasticsearch\Common\Exceptions\Curl\OperationTimeoutException;
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link       http://elasticsearch.org
  */
-class SniffingConnectionPoolTest extends \PHPUnit_Framework_TestCase
+class SniffingConnectionPoolTest extends \PHPUnit\Framework\TestCase
 {
     public function tearDown()
     {

--- a/tests/Elasticsearch/Tests/ConnectionPool/SniffingConnectionPoolTest.php
+++ b/tests/Elasticsearch/Tests/ConnectionPool/SniffingConnectionPoolTest.php
@@ -191,9 +191,6 @@ class SniffingConnectionPoolTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($connections[9], $retConnection);
     }
 
-    /**
-     * @expectedException \Elasticsearch\Common\Exceptions\NoNodesAvailableException
-     */
     public function testAddTenNodesAllTimeout()
     {
         $connections = [];
@@ -219,6 +216,9 @@ class SniffingConnectionPoolTest extends \PHPUnit\Framework\TestCase
 
         $connectionPoolParams = ['randomizeHosts' => false];
         $connectionPool = new SniffingConnectionPool($connections, $selector, $connectionFactory, $connectionPoolParams);
+
+        $this->expectException(\Elasticsearch\Common\Exceptions\NoNodesAvailableException::class);
+        $this->expectExceptionMessage('No alive nodes found in your cluster');
 
         $retConnection = $connectionPool->nextConnection();
     }
@@ -268,9 +268,6 @@ class SniffingConnectionPoolTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($newConnections[1], $retConnection);
     }
 
-    /**
-     * @expectedException \Elasticsearch\Common\Exceptions\NoNodesAvailableException
-     */
     public function testAddSeed_SniffTwo_TimeoutTwo()
     {
         $clusterState = json_decode('{"ok":true,"cluster_name":"elasticsearch_zach","nodes":{"node1":{"name":"Vesta","transport_address":"inet[/192.168.1.119:9300]","hostname":"zach-ThinkPad-W530","version":"0.90.5","http_address":"inet[/192.168.1.119:9200]"}, "node2":{"name":"Vesta","transport_address":"inet[/192.168.1.119:9301]","hostname":"zach-ThinkPad-W530","version":"0.90.5","http_address":"inet[/192.168.1.119:9201]"}}}', true);
@@ -311,8 +308,10 @@ class SniffingConnectionPoolTest extends \PHPUnit\Framework\TestCase
         ];
         $connectionPool = new SniffingConnectionPool($connections, $selector, $connectionFactory, $connectionPoolParams);
 
+        $this->expectException(\Elasticsearch\Common\Exceptions\NoNodesAvailableException::class);
+        $this->expectExceptionMessage('No alive nodes found in your cluster');
+
         $retConnection = $connectionPool->nextConnection();
-        $this->assertSame($mockConnection, $retConnection);
     }
 
     public function testTen_TimeoutNine_SniffTenth_AddTwoAlive()
@@ -369,9 +368,6 @@ class SniffingConnectionPoolTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($newConnections[12], $retConnection);
     }
 
-    /**
-     * @expectedException \Elasticsearch\Common\Exceptions\NoNodesAvailableException
-     */
     public function testTen_TimeoutNine_SniffTenth_AddTwoDead_TimeoutEveryone()
     {
         $clusterState = json_decode('{"ok":true,"cluster_name":"elasticsearch_zach","nodes":{"node1":{"name":"Vesta","transport_address":"inet[/192.168.1.119:9300]","hostname":"zach-ThinkPad-W530","version":"0.90.5","http_address":"inet[/192.168.1.119:9200]"}, "node2":{"name":"Vesta","transport_address":"inet[/192.168.1.119:9301]","hostname":"zach-ThinkPad-W530","version":"0.90.5","http_address":"inet[/192.168.1.119:9201]"}}}', true);
@@ -412,8 +408,6 @@ class SniffingConnectionPoolTest extends \PHPUnit\Framework\TestCase
                     ->andReturnValues($newConnections)
                     ->getMock();
 
-        $RRConnections = $newConnections;
-        //array_push($connections);
         $connectionFactory = m::mock(ConnectionFactory::class)
                              ->shouldReceive('create')->with(['host' => '192.168.1.119', 'port' => 9200])->andReturn($newConnections[10])->getMock()
                              ->shouldReceive('create')->with(['host' => '192.168.1.119', 'port' => 9201])->andReturn($newConnections[11])->getMock();
@@ -424,10 +418,9 @@ class SniffingConnectionPoolTest extends \PHPUnit\Framework\TestCase
         ];
         $connectionPool = new SniffingConnectionPool($connections, $selector, $connectionFactory, $connectionPoolParams);
 
-        $retConnection = $connectionPool->nextConnection();
-        $this->assertSame($newConnections[11], $retConnection);
+        $this->expectException(\Elasticsearch\Common\Exceptions\NoNodesAvailableException::class);
+        $this->expectExceptionMessage('No alive nodes found in your cluster');
 
         $retConnection = $connectionPool->nextConnection();
-        $this->assertSame($newConnections[12], $retConnection);
     }
 }

--- a/tests/Elasticsearch/Tests/ConnectionPool/StaticConnectionPoolIntegrationTest.php
+++ b/tests/Elasticsearch/Tests/ConnectionPool/StaticConnectionPoolIntegrationTest.php
@@ -12,7 +12,7 @@ declare(strict_types = 1);
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link       http://elasticsearch.org
  */
-class StaticConnectionPoolIntegrationTest extends \PHPUnit_Framework_TestCase
+class StaticConnectionPoolIntegrationTest extends \PHPUnit\Framework\TestCase
 {
     // Issue #636
     public function test404Liveness() {

--- a/tests/Elasticsearch/Tests/ConnectionPool/StaticConnectionPoolIntegrationTest.php
+++ b/tests/Elasticsearch/Tests/ConnectionPool/StaticConnectionPoolIntegrationTest.php
@@ -2,6 +2,10 @@
 
 declare(strict_types = 1);
 
+namespace Elasticsearch\Tests\ConnectionPool;
+
+use Elasticsearch;
+
 /**
  * Class StaticConnectionPoolIntegrationTest
  *

--- a/tests/Elasticsearch/Tests/ConnectionPool/StaticConnectionPoolTest.php
+++ b/tests/Elasticsearch/Tests/ConnectionPool/StaticConnectionPoolTest.php
@@ -21,7 +21,7 @@ use Mockery as m;
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link       http://elasticsearch.org
  */
-class StaticConnectionPoolTest extends \PHPUnit_Framework_TestCase
+class StaticConnectionPoolTest extends \PHPUnit\Framework\TestCase
 {
     public function tearDown()
     {

--- a/tests/Elasticsearch/Tests/ConnectionPool/StaticConnectionPoolTest.php
+++ b/tests/Elasticsearch/Tests/ConnectionPool/StaticConnectionPoolTest.php
@@ -224,13 +224,9 @@ class StaticConnectionPoolTest extends \PHPUnit_Framework_TestCase
             ->setConnectionPool(StaticConnectionPool::class, [])
             ->build();
 
-        try {
-            $client->search([]);
-            $this->fail("Should have thrown NoNodesAvailableException");
-        } catch (Elasticsearch\Common\Exceptions\NoNodesAvailableException $e) {
-            // All good
-        } catch (\Exception $e) {
-            throw $e;
-        }
+        $this->expectException(Elasticsearch\Common\Exceptions\NoNodesAvailableException::class);
+        $this->expectExceptionMessage('No alive nodes found in your cluster');
+
+        $client->search([]);
     }
 }

--- a/tests/Elasticsearch/Tests/ConnectionPool/StaticConnectionPoolTest.php
+++ b/tests/Elasticsearch/Tests/ConnectionPool/StaticConnectionPoolTest.php
@@ -88,9 +88,6 @@ class StaticConnectionPoolTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($connections[0], $retConnection);
     }
 
-    /**
-     * @expectedException \Elasticsearch\Common\Exceptions\NoNodesAvailableException
-     */
     public function testAllHostsFailPing()
     {
         $connections = [];
@@ -119,6 +116,9 @@ class StaticConnectionPoolTest extends \PHPUnit\Framework\TestCase
 
         $randomizeHosts = false;
         $connectionPool = new StaticConnectionPool($connections, $selector, $connectionFactory, $randomizeHosts);
+
+        $this->expectException(\Elasticsearch\Common\Exceptions\NoNodesAvailableException::class);
+        $this->expectExceptionMessage('No alive nodes found in your cluster');
 
         $connectionPool->nextConnection();
     }

--- a/tests/Elasticsearch/Tests/ConnectionPool/StaticConnectionPoolTest.php
+++ b/tests/Elasticsearch/Tests/ConnectionPool/StaticConnectionPoolTest.php
@@ -48,8 +48,10 @@ class StaticConnectionPoolTest extends \PHPUnit\Framework\TestCase
 
         $connectionFactory = m::mock(ConnectionFactory::class);
 
-        $randomizeHosts = false;
-        $connectionPool = new StaticConnectionPool($connections, $selector, $connectionFactory, $randomizeHosts);
+        $connectionPoolParams = [
+            'randomizeHosts' => false,
+        ];
+        $connectionPool = new StaticConnectionPool($connections, $selector, $connectionFactory, $connectionPoolParams);
 
         $retConnection = $connectionPool->nextConnection();
 
@@ -80,8 +82,10 @@ class StaticConnectionPoolTest extends \PHPUnit\Framework\TestCase
 
         $connectionFactory = m::mock(ConnectionFactory::class);
 
-        $randomizeHosts = false;
-        $connectionPool = new StaticConnectionPool($connections, $selector, $connectionFactory, $randomizeHosts);
+        $connectionPoolParams = [
+            'randomizeHosts' => false,
+        ];
+        $connectionPool = new StaticConnectionPool($connections, $selector, $connectionFactory, $connectionPoolParams);
 
         $retConnection = $connectionPool->nextConnection();
 
@@ -114,8 +118,10 @@ class StaticConnectionPoolTest extends \PHPUnit\Framework\TestCase
 
         $connectionFactory = m::mock(ConnectionFactory::class);
 
-        $randomizeHosts = false;
-        $connectionPool = new StaticConnectionPool($connections, $selector, $connectionFactory, $randomizeHosts);
+        $connectionPoolParams = [
+            'randomizeHosts' => false,
+        ];
+        $connectionPool = new StaticConnectionPool($connections, $selector, $connectionFactory, $connectionPoolParams);
 
         $this->expectException(\Elasticsearch\Common\Exceptions\NoNodesAvailableException::class);
         $this->expectExceptionMessage('No alive nodes found in your cluster');
@@ -162,8 +168,10 @@ class StaticConnectionPoolTest extends \PHPUnit\Framework\TestCase
 
         $connectionFactory = m::mock(ConnectionFactory::class);
 
-        $randomizeHosts = false;
-        $connectionPool = new StaticConnectionPool($connections, $selector, $connectionFactory, $randomizeHosts);
+        $connectionPoolParams = [
+            'randomizeHosts' => false,
+        ];
+        $connectionPool = new StaticConnectionPool($connections, $selector, $connectionFactory, $connectionPoolParams);
 
         $ret = $connectionPool->nextConnection();
         $this->assertSame($goodConnection, $ret);
@@ -208,8 +216,10 @@ class StaticConnectionPoolTest extends \PHPUnit\Framework\TestCase
 
         $connectionFactory = m::mock(ConnectionFactory::class);
 
-        $randomizeHosts = false;
-        $connectionPool = new StaticConnectionPool($connections, $selector, $connectionFactory, $randomizeHosts);
+        $connectionPoolParams = [
+            'randomizeHosts' => false,
+        ];
+        $connectionPool = new StaticConnectionPool($connections, $selector, $connectionFactory, $connectionPoolParams);
 
         $ret = $connectionPool->nextConnection();
         $this->assertSame($goodConnection, $ret);

--- a/tests/Elasticsearch/Tests/Endpoints/AbstractEndpointTest.php
+++ b/tests/Elasticsearch/Tests/Endpoints/AbstractEndpointTest.php
@@ -20,13 +20,14 @@ class AbstractEndpointTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @dataProvider invalidParameters
-     * @expectedException \Elasticsearch\Common\Exceptions\UnexpectedValueException
      */
     public function testInvalidParamsCauseErrorsWhenProvidedToSetParams(array $params)
     {
         $this->endpoint->expects($this->once())
             ->method('getParamWhitelist')
             ->willReturn(['one', 'two']);
+
+        $this->expectException(\Elasticsearch\Common\Exceptions\UnexpectedValueException::class);
 
         $this->endpoint->setParams($params);
     }

--- a/tests/Elasticsearch/Tests/Endpoints/AbstractEndpointTest.php
+++ b/tests/Elasticsearch/Tests/Endpoints/AbstractEndpointTest.php
@@ -6,7 +6,7 @@ namespace Elasticsearch\Tests\Endpoints;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;
 
-class AbstractEndpointTest extends \PHPUnit_Framework_TestCase
+class AbstractEndpointTest extends \PHPUnit\Framework\TestCase
 {
     private $endpoint;
 

--- a/tests/Elasticsearch/Tests/Helper/Iterators/SearchResponseIteratorTest.php
+++ b/tests/Elasticsearch/Tests/Helper/Iterators/SearchResponseIteratorTest.php
@@ -15,7 +15,7 @@ use Mockery as m;
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link    http://Elasticsearch.org
  */
-class SearchResponseIteratorTest extends \PHPUnit_Framework_TestCase
+class SearchResponseIteratorTest extends \PHPUnit\Framework\TestCase
 {
 
     public function tearDown()

--- a/tests/Elasticsearch/Tests/RegisteredNamespaceTest.php
+++ b/tests/Elasticsearch/Tests/RegisteredNamespaceTest.php
@@ -34,14 +34,15 @@ class RegisteredNamespaceTest extends \PHPUnit\Framework\TestCase
         $this->assertSame("123", $client->foo()->fooMethod());
     }
 
-    /**
-     * @expectedException \Elasticsearch\Common\Exceptions\BadMethodCallException
-     */
     public function testNonExistingNamespace()
     {
         $builder = new FooNamespaceBuilder();
         $client = ClientBuilder::create()->registerNamespace($builder)->build();
-        $this->assertSame("123", $client->bar()->fooMethod());
+
+        $this->expectException(\Elasticsearch\Common\Exceptions\BadMethodCallException::class);
+        $this->expectExceptionMessage('Namespace [bar] not found');
+
+        $client->bar()->fooMethod();
     }
 }
 

--- a/tests/Elasticsearch/Tests/RegisteredNamespaceTest.php
+++ b/tests/Elasticsearch/Tests/RegisteredNamespaceTest.php
@@ -20,7 +20,7 @@ use Mockery as m;
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link       http://elasticsearch.org
  */
-class RegisteredNamespaceTest extends \PHPUnit_Framework_TestCase
+class RegisteredNamespaceTest extends \PHPUnit\Framework\TestCase
 {
     public function tearDown()
     {

--- a/tests/Elasticsearch/Tests/Serializers/ArrayToJSONSerializerTest.php
+++ b/tests/Elasticsearch/Tests/Serializers/ArrayToJSONSerializerTest.php
@@ -5,14 +5,13 @@ declare(strict_types = 1);
 namespace Elasticsearch\Tests\Serializers;
 
 use Elasticsearch\Serializers\ArrayToJSONSerializer;
-use PHPUnit_Framework_TestCase;
 use Mockery as m;
 
 /**
  * Class ArrayToJSONSerializerTest
  * @package Elasticsearch\Tests\Serializers
  */
-class ArrayToJSONSerializerTest extends PHPUnit_Framework_TestCase
+class ArrayToJSONSerializerTest extends \PHPUnit\Framework\TestCase
 {
     public function tearDown()
     {

--- a/tests/Elasticsearch/Tests/Serializers/EverythingToJSONSerializerTest.php
+++ b/tests/Elasticsearch/Tests/Serializers/EverythingToJSONSerializerTest.php
@@ -5,14 +5,13 @@ declare(strict_types = 1);
 namespace Elasticsearch\Tests\Serializers;
 
 use Elasticsearch\Serializers\EverythingToJSONSerializer;
-use PHPUnit_Framework_TestCase;
 use Mockery as m;
 
 /**
  * Class EverythingToJSONSerializerTest
  * @package Elasticsearch\Tests\Serializers
  */
-class EverythingToJSONSerializerTest extends PHPUnit_Framework_TestCase
+class EverythingToJSONSerializerTest extends \PHPUnit\Framework\TestCase
 {
     public function tearDown()
     {

--- a/tests/Elasticsearch/Tests/YamlRunnerTest.php
+++ b/tests/Elasticsearch/Tests/YamlRunnerTest.php
@@ -31,7 +31,7 @@ use Symfony\Component\Yaml\Yaml;
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link       http://elasticsearch.org
  */
-class YamlRunnerTest extends \PHPUnit_Framework_TestCase
+class YamlRunnerTest extends \PHPUnit\Framework\TestCase
 {
     /** @var \Symfony\Component\Yaml\Yaml Yaml parser for reading integrations tests */
     private $yaml;

--- a/tests/Elasticsearch/Tests/YamlRunnerTest.php
+++ b/tests/Elasticsearch/Tests/YamlRunnerTest.php
@@ -169,7 +169,7 @@ class YamlRunnerTest extends \PHPUnit\Framework\TestCase
         }
 
         if (null !== $setupProcedure) {
-            $this->processProcedure(current($setupProcedure), 'setup');
+            $this->processProcedure(current($setupProcedure), 'setup', $fileName);
             $this->waitForYellow();
         }
 
@@ -326,6 +326,9 @@ class YamlRunnerTest extends \PHPUnit\Framework\TestCase
             $endpointParams->client['headers'] = $headers;
         }
 
+        if (!is_string($method)) {
+            throw new \Exception('$method must be string');
+        }
         list($method, $namespace) = $this->mapEndpoint($method, $namespace);
 
         if (null !== $namespace) {
@@ -404,7 +407,7 @@ class YamlRunnerTest extends \PHPUnit\Framework\TestCase
      *
      * @throws \Exception
      *
-     * @return bool
+     * @return bool|mixed[]
      */
     public function executeAsyncExistRequest($caller, $method, $endpointParams, $expectedError, $expectedWarnings, $testName)
     {


### PR DESCRIPTION
I suggest adding [PHPStan](https://github.com/phpstan/phpstan) as a part of the build (for the tests now, for the src later). It is a tool that statically analyzes PHP code and detects potential issues - such as missing required parameters for methods, incorrect parameter types and many others.

We've been using it at the company I'm working at since December and it helped us to catch various issues early in development phase.

--

**This PR depends on https://github.com/elastic/elasticsearch-php/pull/627 (which must be merged first to prevent conflicts)**