### PR TITLE
Add possibility of choosing the default URL of project by .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,15 @@ Version Matrix
  - You should never use Elasticsearch-PHP Master branch, as it tracks Elasticearch master and may contain incomplete features or breaks in backwards compat.  Only use ES-PHP master if you are developing against ES master for some reason.
 
 Documentation
---------------
+-------------
 [Full documentation can be found here.](http://www.elasticsearch.org/guide/en/elasticsearch/client/php-api/5.0/index.html)  Docs are stored within the repo under /docs/, so if you see a typo or problem, please submit a PR to fix it!
+
+Environment
+-----------
+Using the `.env` file pattern you can define the default host of ElasticSearch. The default value is `localhost:9200`, but you can replace it setting the variable in your `.env` like this:
+```
+ELASTICSEARCH_DEFAULT_HOST=elasticsearch:9200
+```
 
 Installation via Composer
 -------------------------

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "php": "^7.0",
     "ext-json": ">=1.3.7",
     "psr/log": "~1.0",
-    "guzzlehttp/ringphp" : "~1.0"
+    "guzzlehttp/ringphp" : "~1.0",
+    "vlucas/phpdotenv": "^2.4"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.7|^5.4",

--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -2,6 +2,8 @@
 
 namespace Elasticsearch;
 
+use Composer\Autoload\ClassLoader;
+use Dotenv\Dotenv;
 use Elasticsearch\Common\Exceptions\InvalidArgumentException;
 use Elasticsearch\Common\Exceptions\RuntimeException;
 use Elasticsearch\ConnectionPool\AbstractConnectionPool;
@@ -215,7 +217,7 @@ class ClientBuilder
     /**
      * @param $path string
      * @param int $level
-     * @return \Monolog\Logger\Logger
+     * @return Logger
      */
     public static function defaultLogger($path, $level = Logger::WARNING)
     {
@@ -592,7 +594,13 @@ class ClientBuilder
      */
     private function getDefaultHost()
     {
-        return ['localhost:9200'];
+        $reflection = new \ReflectionClass(ClassLoader::class);
+        $vendorDir = dirname(dirname($reflection->getFileName()));
+
+        $dotenv = new Dotenv(implode(DIRECTORY_SEPARATOR, [$vendorDir, '..']));
+        $dotenv->load();
+
+        return [getenv('ELASTICSEARCH_DEFAULT_HOST', 'elasticsearch:9200')];
     }
 
     /**

--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -600,7 +600,7 @@ class ClientBuilder
         $dotenv = new Dotenv(implode(DIRECTORY_SEPARATOR, [$vendorDir, '..']));
         $dotenv->load();
 
-        return [getenv('ELASTICSEARCH_DEFAULT_HOST', 'elasticsearch:9200')];
+        return [getenv('ELASTICSEARCH_DEFAULT_HOST', 'localhost:9200')];
     }
 
     /**


### PR DESCRIPTION
The method `Elasticsearch\ClientBuilder::getDefaultHost()` does not have the possibility of choosing our default host of Elastic Search. With this PR, we will can chose by adding the entry `ELASTICSEARCH_DEFAULT_HOST` in our `.env` file.