### PR TITLE
[TEST] add PHP_CodeSniffer to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ before_script:
   - php util/EnsureClusterAlive.php
 
 script:
+  - composer run-script phpcs
   - composer run-script phpstan
   - vendor/bin/phpunit $PHPUNIT_FLAGS
   - vendor/bin/phpunit -c phpunit-integration.xml --group sync $PHPUNIT_FLAGS

--- a/composer.json
+++ b/composer.json
@@ -12,17 +12,17 @@
   "require": {
     "php": "^7.0",
     "ext-json": ">=1.3.7",
-    "psr/log": "~1.0",
-    "guzzlehttp/ringphp" : "~1.0"
+    "guzzlehttp/ringphp": "~1.0",
+    "psr/log": "~1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "6.3.0",
-    "mockery/mockery": "0.9.4",
-    "symfony/yaml": "^2.8",
-    "symfony/finder": "^2.8",
     "cpliakas/git-wrapper": "~1.0",
     "doctrine/inflector": "^1.1",
-    "phpstan/phpstan-shim": "0.8.3"
+    "mockery/mockery": "0.9.4",
+    "phpstan/phpstan-shim": "0.8.3",
+    "phpunit/phpunit": "6.3.0",
+    "symfony/finder": "^2.8",
+    "symfony/yaml": "^2.8"
   },
   "suggest": {
     "ext-curl": "*",
@@ -37,6 +37,9 @@
     "psr-4": {
       "Elasticsearch\\Tests\\":      "tests/Elasticsearch/Tests/"
     }
+  },
+  "config": {
+    "sort-packages": true
   },
   "scripts": {
     "phpstan": [

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "mockery/mockery": "0.9.4",
     "phpstan/phpstan-shim": "0.8.3",
     "phpunit/phpunit": "6.3.0",
+    "squizlabs/php_codesniffer": "3.0.2",
     "symfony/finder": "^2.8",
     "symfony/yaml": "^2.8"
   },
@@ -42,6 +43,9 @@
     "sort-packages": true
   },
   "scripts": {
+    "phpcs": [
+      "phpcs --standard=ruleset.xml --extensions=php --encoding=utf-8 --tab-width=4 -sp tests"
+    ],
     "phpstan": [
       "@php vendor/phpstan/phpstan-shim/phpstan.phar analyse -c phpstan.neon tests --level 7 --no-progress"
     ]

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<ruleset name="Elasticsearch-PHP">
+	<rule ref="PSR2">
+		<exclude name="Generic.Files.LineLength.TooLong"/>
+	</rule>
+</ruleset>

--- a/tests/Elasticsearch/Tests/ClientIntegrationTests.php
+++ b/tests/Elasticsearch/Tests/ClientIntegrationTests.php
@@ -34,5 +34,4 @@ class ClientIntegrationTests extends \PHPUnit\Framework\TestCase
 
         $this->assertFalse($exists);
     }
-
 }

--- a/tests/Elasticsearch/Tests/ConnectionPool/Selectors/RoundRobinSelectorTest.php
+++ b/tests/Elasticsearch/Tests/ConnectionPool/Selectors/RoundRobinSelectorTest.php
@@ -55,7 +55,6 @@ class RoundRobinSelectorTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($mockConnections[2], $roundRobin->select($mockConnections));
         $this->assertSame($mockConnections[3], $roundRobin->select($mockConnections));
         $this->assertSame($mockConnections[4], $roundRobin->select($mockConnections));
-
     }
 
     /**

--- a/tests/Elasticsearch/Tests/ConnectionPool/SniffingConnectionPoolTest.php
+++ b/tests/Elasticsearch/Tests/ConnectionPool/SniffingConnectionPoolTest.php
@@ -274,7 +274,7 @@ class SniffingConnectionPoolTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($newConnections[1], $retConnection);
     }
 
-    public function testAddSeed_SniffTwo_TimeoutTwo()
+    public function testAddSeedSniffTwoTimeoutTwo()
     {
         $clusterState = json_decode('{"ok":true,"cluster_name":"elasticsearch_zach","nodes":{"node1":{"name":"Vesta","transport_address":"inet[/192.168.1.119:9300]","hostname":"zach-ThinkPad-W530","version":"0.90.5","http_address":"inet[/192.168.1.119:9200]"}, "node2":{"name":"Vesta","transport_address":"inet[/192.168.1.119:9301]","hostname":"zach-ThinkPad-W530","version":"0.90.5","http_address":"inet[/192.168.1.119:9201]"}}}', true);
 
@@ -320,7 +320,7 @@ class SniffingConnectionPoolTest extends \PHPUnit\Framework\TestCase
         $retConnection = $connectionPool->nextConnection();
     }
 
-    public function testTen_TimeoutNine_SniffTenth_AddTwoAlive()
+    public function testTenTimeoutNineSniffTenthAddTwoAlive()
     {
         $clusterState = json_decode('{"ok":true,"cluster_name":"elasticsearch_zach","nodes":{"node1":{"name":"Vesta","transport_address":"inet[/192.168.1.119:9300]","hostname":"zach-ThinkPad-W530","version":"0.90.5","http_address":"inet[/192.168.1.119:9200]"}, "node2":{"name":"Vesta","transport_address":"inet[/192.168.1.119:9301]","hostname":"zach-ThinkPad-W530","version":"0.90.5","http_address":"inet[/192.168.1.119:9201]"}}}', true);
 
@@ -374,7 +374,7 @@ class SniffingConnectionPoolTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($newConnections[12], $retConnection);
     }
 
-    public function testTen_TimeoutNine_SniffTenth_AddTwoDead_TimeoutEveryone()
+    public function testTenTimeoutNineSniffTenthAddTwoDeadTimeoutEveryone()
     {
         $clusterState = json_decode('{"ok":true,"cluster_name":"elasticsearch_zach","nodes":{"node1":{"name":"Vesta","transport_address":"inet[/192.168.1.119:9300]","hostname":"zach-ThinkPad-W530","version":"0.90.5","http_address":"inet[/192.168.1.119:9200]"}, "node2":{"name":"Vesta","transport_address":"inet[/192.168.1.119:9301]","hostname":"zach-ThinkPad-W530","version":"0.90.5","http_address":"inet[/192.168.1.119:9201]"}}}', true);
 

--- a/tests/Elasticsearch/Tests/ConnectionPool/StaticConnectionPoolIntegrationTest.php
+++ b/tests/Elasticsearch/Tests/ConnectionPool/StaticConnectionPoolIntegrationTest.php
@@ -19,7 +19,8 @@ use Elasticsearch;
 class StaticConnectionPoolIntegrationTest extends \PHPUnit\Framework\TestCase
 {
     // Issue #636
-    public function test404Liveness() {
+    public function test404Liveness()
+    {
         $client = \Elasticsearch\ClientBuilder::create()
             ->setHosts([$_SERVER['ES_TEST_HOST']])
             ->setConnectionPool(\Elasticsearch\ConnectionPool\StaticConnectionPool::class)

--- a/tests/Elasticsearch/Tests/ConnectionPool/StaticConnectionPoolTest.php
+++ b/tests/Elasticsearch/Tests/ConnectionPool/StaticConnectionPoolTest.php
@@ -126,9 +126,6 @@ class StaticConnectionPoolTest extends \PHPUnit\Framework\TestCase
         $this->expectException(\Elasticsearch\Common\Exceptions\NoNodesAvailableException::class);
         $this->expectExceptionMessage('No alive nodes found in your cluster');
 
-        $this->expectException(\Elasticsearch\Common\Exceptions\NoNodesAvailableException::class);
-        $this->expectExceptionMessage('No alive nodes found in your cluster');
-
         $connectionPool->nextConnection();
     }
 

--- a/tests/Elasticsearch/Tests/Helper/Iterators/SearchResponseIteratorTest.php
+++ b/tests/Elasticsearch/Tests/Helper/Iterators/SearchResponseIteratorTest.php
@@ -107,7 +107,8 @@ class SearchResponseIteratorTest extends \PHPUnit\Framework\TestCase
                             ]
                         ]
                     ]
-                ]);
+                ]
+            );
 
         $mock_client->shouldReceive('scroll')
             ->once()

--- a/tests/Elasticsearch/Tests/RegisteredNamespaceTest.php
+++ b/tests/Elasticsearch/Tests/RegisteredNamespaceTest.php
@@ -46,6 +46,7 @@ class RegisteredNamespaceTest extends \PHPUnit\Framework\TestCase
     }
 }
 
+// @codingStandardsIgnoreStart "Each class must be in a file by itself" - not worth the extra work here
 class FooNamespaceBuilder implements Elasticsearch\Namespaces\NamespaceBuilderInterface
 {
     public function getName()
@@ -66,3 +67,4 @@ class FooNamespace
         return "123";
     }
 }
+// @codingStandardsIgnoreEnd

--- a/tests/Elasticsearch/Tests/YamlRunnerTest.php
+++ b/tests/Elasticsearch/Tests/YamlRunnerTest.php
@@ -203,7 +203,7 @@ class YamlRunnerTest extends \PHPUnit\Framework\TestCase
      * @param      $operation
      * @param      $lastOperationResult
      * @param      $testName
-     * @param array $context 
+     * @param array $context
      * @param bool $async
      *
      * @return mixed
@@ -412,7 +412,6 @@ class YamlRunnerTest extends \PHPUnit\Framework\TestCase
     public function executeAsyncExistRequest($caller, $method, $endpointParams, $expectedError, $expectedWarnings, $testName)
     {
         try {
-
             $response = $caller->$method($endpointParams);
 
             while ($response instanceof FutureArrayInterface) {
@@ -439,7 +438,8 @@ class YamlRunnerTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    public function checkForWarnings($expectedWarnings) {
+    public function checkForWarnings($expectedWarnings)
+    {
         $last = $this->client->transport->getLastConnection()->getLastRequestInfo();
 
 
@@ -475,7 +475,6 @@ class YamlRunnerTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('application/json', $last['request']['headers']['Content-Type'][0], print_r($last['request']['headers'], true));
         $this->assertArrayHasKey('Accept', $last['request']['headers'], print_r($last['request']['headers'], true));
         $this->assertSame('application/json', $last['request']['headers']['Accept'][0], print_r($last['request']['headers'], true));
-
     }
 
     /**
@@ -667,7 +666,7 @@ class YamlRunnerTest extends \PHPUnit\Framework\TestCase
      */
     public function operationSkip($operation, $lastOperationResult, $testName)
     {
-        if (is_object($operation) !== true ) {
+        if (is_object($operation) !== true) {
             return $lastOperationResult;
         }
 
@@ -696,7 +695,7 @@ class YamlRunnerTest extends \PHPUnit\Framework\TestCase
                 $version[0] = ~PHP_INT_MAX;
             }
 
-            if (!isset($version[1]) || $version[1] === "" ) {
+            if (!isset($version[1]) || $version[1] === "") {
                 $version[1] = PHP_INT_MAX;
             }
 
@@ -1029,7 +1028,6 @@ class YamlRunnerTest extends \PHPUnit\Framework\TestCase
 
                     $response = curl_exec($ch);
                     curl_close($ch);
-
                 }
             }
         }
@@ -1043,8 +1041,9 @@ class YamlRunnerTest extends \PHPUnit\Framework\TestCase
         $this->waitForYellow();
     }
 
-    private function rmDirRecursively($dir) {
-        if (!is_dir($dir )) {
+    private function rmDirRecursively($dir)
+    {
+        if (!is_dir($dir)) {
             return;
         }
         $files = new RecursiveIteratorIterator(


### PR DESCRIPTION
ontributors are supposed to follow PSR-2 (https://github.com/elastic/elasticsearch-php/blob/master/.github/CONTRIBUTING.md). So it would be best to check it automatically during TravisCI build.

This PR fixes the CS and adds checking of the `tests` as a part of the build. (I plan to the the `src` later)

--


**This PR depends on #649**

~~**This PR depends on #627 and #628 (which must be merged first to prevent conflicts)**~~