### PR TITLE
update Simulate API as it uses POST instead of GET

### DIFF
--- a/src/Elasticsearch/Endpoints/Ingest/Simulate.php
+++ b/src/Elasticsearch/Endpoints/Ingest/Simulate.php
@@ -60,6 +60,6 @@ class Simulate extends AbstractEndpoint
      */
     public function getMethod()
     {
-        return 'GET';
+        return 'POST';
     }
 }


### PR DESCRIPTION
Ingest Simulate Endpoint has GET as HTTP method and instead it should be a **POST**

https://www.elastic.co/guide/en/elasticsearch/reference/current/simulate-pipeline-api.html