### PR TITLE
[TEST] Use tests from corresponding ES version

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,9 +22,8 @@ The process for contributing to any of the Elasticsearch repositories is similar
             -Des.index.store.type=memory -Des.discovery.zen.ping.multicast.enabled=false \
             -Des.node.bench=true -Des.script.disable_dynamic=false
 
-4. Run the unit and yaml integration tests to ensure your changes do not break existing code.  The exported `TEST_BUILD_REF` should match the branch of Elasticsearch that is running on your machine (since tests are specific to the server version):
+4. Run the unit and yaml integration tests to ensure your changes do not break existing code. The `util/RestSpecRunner.php` script will automatically checkout the tests for the exact same build as is the Elasticsearch you are running on your machine (since tests are specific to the server version):
 
-        $> export TEST_BUILD_REF='origin/1.x'
         $> export ES_TEST_HOST='http://localhost:9200'
 
     Then proceed to initialize the REST yaml tests and run the package. **WARNING: the unit tests will clear your cluster

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,9 @@ matrix:
     - php: 7.2
       env: ES_VERSION="6.0"
 
+  allow_failures:
+    - env: ES_VERSION="6.x"
+
 env:
   global:
     - ES_TEST_HOST=http://localhost:9200

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,17 +18,17 @@ matrix:
   fast_finish: true
   include:
     - php: 7.0
-      env: ES_VERSION="6.0" TEST_BUILD_REF="origin/6.0"
+      env: ES_VERSION="6.0"
     - php: 7.0
-      env: ES_VERSION="6.x" TEST_BUILD_REF="origin/6.x"
+      env: ES_VERSION="6.x"
 
     - php: 7.1
-      env: ES_VERSION="6.0" TEST_BUILD_REF="origin/6.0"
+      env: ES_VERSION="6.0"
     - php: 7.1
-      env: ES_VERSION="6.x" TEST_BUILD_REF="origin/6.x"
+      env: ES_VERSION="6.x"
 
     - php: 7.2
-      env: ES_VERSION="6.0" TEST_BUILD_REF="origin/6.0"
+      env: ES_VERSION="6.0"
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,10 @@ matrix:
   fast_finish: true
   include:
     - php: 7.0
-      env: ES_VERSION="5.5" TEST_BUILD_REF="origin/5.5"
-    - php: 7.0
       env: ES_VERSION="6.0" TEST_BUILD_REF="origin/6.0"
     - php: 7.0
       env: ES_VERSION="6.x" TEST_BUILD_REF="origin/6.x"
 
-    - php: 7.1
-      env: ES_VERSION="5.5" TEST_BUILD_REF="origin/5.5"
     - php: 7.1
       env: ES_VERSION="6.0" TEST_BUILD_REF="origin/6.0"
     - php: 7.1

--- a/util/RestSpecRunner.php
+++ b/util/RestSpecRunner.php
@@ -19,6 +19,12 @@ echo "Base directory: ". dirname(__DIR__)."\n";
 // Include the composer autoloader
 $autoloader = require_once(dirname(__DIR__) . '/vendor/autoload.php');
 
+$client = \Elasticsearch\ClientBuilder::fromConfig([
+	'hosts' => [$_SERVER['ES_TEST_HOST']]
+]);
+$serverInfo = $client->info();
+var_dump($serverInfo);
+
 $gitWrapper = new \GitWrapper\GitWrapper();
 echo "Git cwd: ".dirname(__DIR__) . "/util/elasticsearch\n";
 $git = $gitWrapper->workingCopy(dirname(__DIR__) . '/util/elasticsearch');
@@ -26,6 +32,6 @@ $git = $gitWrapper->workingCopy(dirname(__DIR__) . '/util/elasticsearch');
 echo "Update elasticsearch submodule\n";
 $git->fetchAll(array('verbose' => true));
 
-$hash = $_SERVER['TEST_BUILD_REF'];
+$hash = $serverInfo['version']['build_hash'];
 echo "Checkout yaml tests (hash: $hash)\n";
 $git->checkout($hash, array('force' => true, 'quiet' => true));


### PR DESCRIPTION
This changes the build so it checks out the very same version of the tests as the ES instance.

TODO:
- [x] Maybe change it so it does not depend on ES binary. Build hash can be fetched from running ES `version.build_hash` (also safer than parsing the output)
- [x] wait for 6.x to pass? Or we can move it to allowed failures - seems more future-proof to me
- [x] drop 5.5 from Travis // I'm fine with that
- [x] Update `.github/CONTRIBUTING.md` - it references TEST_BUILD_REF


It passed for ES 6.0.