### PR TITLE
Integration test with UTF-8 char

### DIFF
--- a/tests/Elasticsearch/Tests/ClientIntegrationTests.php
+++ b/tests/Elasticsearch/Tests/ClientIntegrationTests.php
@@ -76,8 +76,8 @@ class ClientIntegrationTests extends \PHPUnit\Framework\TestCase
     public function existAliasDataProvider()
     {
         return [
-            ['myindextest'],
-            ['⿇⽸⾽']
+            'latin-char' => ['myindextest'],
+            'utf-8-char' => ['⿇⽸⾽']
         ];
     }
 

--- a/tests/Elasticsearch/Tests/ClientIntegrationTests.php
+++ b/tests/Elasticsearch/Tests/ClientIntegrationTests.php
@@ -102,7 +102,7 @@ class ClientIntegrationTests extends \PHPUnit\Framework\TestCase
         self::$client->indices()->putAlias($params);
 
         $params = array(
-            'name' => urlencode($alias)
+            'name' => $alias
         );
         $this->assertEquals($alias . '_v1', array_keys(self::$client->indices()->getAlias($params))[0]);
     }

--- a/tests/Elasticsearch/Tests/ClientIntegrationTests.php
+++ b/tests/Elasticsearch/Tests/ClientIntegrationTests.php
@@ -1,10 +1,11 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Elasticsearch\Tests;
 
 use Elasticsearch;
+use stdClass;
 
 /**
  * Class ClientTest
@@ -33,6 +34,47 @@ class ClientIntegrationTests extends \PHPUnit\Framework\TestCase
         $exists = $client->exists($getParams);
 
         $this->assertFalse($exists);
+    }
+
+    /**
+     * @dataProvider
+     */
+    public function testExistAlias($alias)
+    {
+        $client = Elasticsearch\ClientBuilder::create()->setHosts([$_SERVER['ES_TEST_HOST']])->build();
+
+        $this->createIndexWithAlias($alias, $client);
+
+        $params = array(
+            'name' => $alias
+        );
+
+        $this->assertTrue($client->indices()->existsAlias($params));
+    }
+
+    public function existAliasDataProvider()
+    {
+        return [
+            ['myindextest'],
+            ['⿇⽸⾽']
+        ];
+    }
+
+    /**
+     * @param $alias
+     * @param $client Elasticsearch\Client
+     */
+    private function createIndexWithAlias($alias, $client)
+    {
+        $params = array(
+            'index' => $alias . '_v1',
+            'body' => array(
+                'aliases' => array(
+                    $alias => new stdClass()
+                )),
+        );
+
+        $client->indices()->create($params);
     }
 
 }

--- a/tests/Elasticsearch/Tests/ClientIntegrationTests.php
+++ b/tests/Elasticsearch/Tests/ClientIntegrationTests.php
@@ -41,8 +41,6 @@ class ClientIntegrationTests extends \PHPUnit\Framework\TestCase
 
     public function testCustomQueryParams()
     {
-        $this->client = Elasticsearch\ClientBuilder::create()->setHosts([$_SERVER['ES_TEST_HOST']])->build();
-
         $getParams = [
             'index' => 'test',
             'type' => 'test',

--- a/tests/Elasticsearch/Tests/ClientIntegrationTests.php
+++ b/tests/Elasticsearch/Tests/ClientIntegrationTests.php
@@ -59,7 +59,7 @@ class ClientIntegrationTests extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider aliasDataProvider
      */
-    public function testExistAlias($alias)
+    public function testExistAlias(string $alias)
     {
         $this->createIndexWithAlias($alias);
 
@@ -73,7 +73,7 @@ class ClientIntegrationTests extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider aliasDataProvider
      */
-    public function testFindIndexByAlias($alias)
+    public function testFindIndexByAlias(string $alias)
     {
         $this->createIndexWithAlias($alias);
 
@@ -86,7 +86,7 @@ class ClientIntegrationTests extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider aliasDataProvider
      */
-    public function testPutAlias($alias)
+    public function testPutAlias(string $alias)
     {
         $this->createIndexWithoutAlias($alias);
 
@@ -111,7 +111,7 @@ class ClientIntegrationTests extends \PHPUnit\Framework\TestCase
         ];
     }
 
-    private function createIndexWithAlias($alias)
+    private function createIndexWithAlias(string $alias)
     {
         $params = array(
             'index' => $alias . '_v1',
@@ -124,7 +124,7 @@ class ClientIntegrationTests extends \PHPUnit\Framework\TestCase
         $this->client->indices()->create($params);
     }
 
-    private function createIndexWithoutAlias($alias)
+    private function createIndexWithoutAlias(string $alias)
     {
         $params = array('index' => $alias . '_v1');
 

--- a/tests/Elasticsearch/Tests/ClientIntegrationTests.php
+++ b/tests/Elasticsearch/Tests/ClientIntegrationTests.php
@@ -80,7 +80,7 @@ class ClientIntegrationTests extends \PHPUnit\Framework\TestCase
         $params = array(
             'name' => $alias
         );
-        $this->assertEquals($alias . '_v1', array_keys($this->client->indices()->getAlias($params))[0]);
+        $this->assertSame($alias . '_v1', array_keys($this->client->indices()->getAlias($params))[0]);
     }
 
     /**
@@ -100,7 +100,7 @@ class ClientIntegrationTests extends \PHPUnit\Framework\TestCase
         $params = array(
             'name' => $alias
         );
-        $this->assertEquals($alias . '_v1', array_keys($this->client->indices()->getAlias($params))[0]);
+        $this->assertSame($alias . '_v1', array_keys($this->client->indices()->getAlias($params))[0]);
     }
 
     public function aliasDataProvider()

--- a/tests/Elasticsearch/Tests/ClientIntegrationTests.php
+++ b/tests/Elasticsearch/Tests/ClientIntegrationTests.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Elasticsearch\Tests;
 
@@ -23,14 +23,11 @@ class ClientIntegrationTests extends \PHPUnit\Framework\TestCase
     /**
      * @var $client Elasticsearch\Client
      */
-    protected static $client;
+    protected $client;
 
-    /**
-     * initialize elasticsearch client
-     */
-    public static function setUpBeforeClass()
+    public function setUp()
     {
-        self::$client = Elasticsearch\ClientBuilder::create()->setHosts([$_SERVER['ES_TEST_HOST']])->build();
+        $this->client = Elasticsearch\ClientBuilder::create()->setHosts([$_SERVER['ES_TEST_HOST']])->build();
     }
 
     public function tearDown()
@@ -39,12 +36,12 @@ class ClientIntegrationTests extends \PHPUnit\Framework\TestCase
         $param = [
             'index' => '_all'
         ];
-        self::$client->indices()->delete($param);
+        $this->client->indices()->delete($param);
     }
 
     public function testCustomQueryParams()
     {
-        self::$client = Elasticsearch\ClientBuilder::create()->setHosts([$_SERVER['ES_TEST_HOST']])->build();
+        $this->client = Elasticsearch\ClientBuilder::create()->setHosts([$_SERVER['ES_TEST_HOST']])->build();
 
         $getParams = [
             'index' => 'test',
@@ -54,7 +51,7 @@ class ClientIntegrationTests extends \PHPUnit\Framework\TestCase
             'custom' => ['customToken' => 'abc', 'otherToken' => 123],
             'client' => ['ignore' => 400]
         ];
-        $exists = self::$client->exists($getParams);
+        $exists = $this->client->exists($getParams);
 
         $this->assertFalse($exists);
     }
@@ -70,7 +67,7 @@ class ClientIntegrationTests extends \PHPUnit\Framework\TestCase
             'name' => $alias
         );
 
-        $this->assertTrue(self::$client->indices()->existsAlias($params));
+        $this->assertTrue($this->client->indices()->existsAlias($params));
     }
 
     /**
@@ -83,7 +80,7 @@ class ClientIntegrationTests extends \PHPUnit\Framework\TestCase
         $params = array(
             'name' => $alias
         );
-        $this->assertEquals($alias . '_v1', array_keys(self::$client->indices()->getAlias($params))[0]);
+        $this->assertEquals($alias . '_v1', array_keys($this->client->indices()->getAlias($params))[0]);
     }
 
     /**
@@ -91,7 +88,6 @@ class ClientIntegrationTests extends \PHPUnit\Framework\TestCase
      */
     public function testPutAlias($alias)
     {
-
         $this->createIndexWithoutAlias($alias);
 
         $params = array(
@@ -99,12 +95,12 @@ class ClientIntegrationTests extends \PHPUnit\Framework\TestCase
             'name' => $alias
         );
 
-        self::$client->indices()->putAlias($params);
+        $this->client->indices()->putAlias($params);
 
         $params = array(
             'name' => $alias
         );
-        $this->assertEquals($alias . '_v1', array_keys(self::$client->indices()->getAlias($params))[0]);
+        $this->assertEquals($alias . '_v1', array_keys($this->client->indices()->getAlias($params))[0]);
     }
 
     public function aliasDataProvider()
@@ -125,14 +121,13 @@ class ClientIntegrationTests extends \PHPUnit\Framework\TestCase
                 )),
         );
 
-        self::$client->indices()->create($params);
+        $this->client->indices()->create($params);
     }
 
     private function createIndexWithoutAlias($alias)
     {
         $params = array('index' => $alias . '_v1');
 
-        self::$client->indices()->create($params);
+        $this->client->indices()->create($params);
     }
-
 }

--- a/tests/Elasticsearch/Tests/ClientIntegrationTests.php
+++ b/tests/Elasticsearch/Tests/ClientIntegrationTests.php
@@ -86,6 +86,27 @@ class ClientIntegrationTests extends \PHPUnit\Framework\TestCase
         $this->assertEquals($alias . '_v1', array_keys(self::$client->indices()->getAlias($params))[0]);
     }
 
+    /**
+     * @dataProvider aliasDataProvider
+     */
+    public function testPutAlias($alias)
+    {
+
+        $this->createIndexWithoutAlias($alias);
+
+        $params = array(
+            'index' => $alias . '_v1',
+            'name' => $alias
+        );
+
+        self::$client->indices()->putAlias($params);
+
+        $params = array(
+            'name' => urlencode($alias)
+        );
+        $this->assertEquals($alias . '_v1', array_keys(self::$client->indices()->getAlias($params))[0]);
+    }
+
     public function aliasDataProvider()
     {
         return [
@@ -103,6 +124,13 @@ class ClientIntegrationTests extends \PHPUnit\Framework\TestCase
                     $alias => new stdClass()
                 )),
         );
+
+        self::$client->indices()->create($params);
+    }
+
+    private function createIndexWithoutAlias($alias)
+    {
+        $params = array('index' => $alias . '_v1');
 
         self::$client->indices()->create($params);
     }

--- a/tests/Elasticsearch/Tests/ClientIntegrationTests.php
+++ b/tests/Elasticsearch/Tests/ClientIntegrationTests.php
@@ -60,7 +60,7 @@ class ClientIntegrationTests extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @dataProvider existAliasDataProvider
+     * @dataProvider aliasDataProvider
      */
     public function testExistAlias($alias)
     {
@@ -73,7 +73,20 @@ class ClientIntegrationTests extends \PHPUnit\Framework\TestCase
         $this->assertTrue(self::$client->indices()->existsAlias($params));
     }
 
-    public function existAliasDataProvider()
+    /**
+     * @dataProvider aliasDataProvider
+     */
+    public function testFindIndexByAlias($alias)
+    {
+        $this->createIndexWithAlias($alias);
+
+        $params = array(
+            'name' => $alias
+        );
+        $this->assertEquals($alias . '_v1', array_keys(self::$client->indices()->getAlias($params))[0]);
+    }
+
+    public function aliasDataProvider()
     {
         return [
             'latin-char' => ['myindextest'],


### PR DESCRIPTION
Hello,

I'm coming with the tests as we discussed in the PR #482. The problem is only when we create an index and an alias with some UTF-8 characters and after that we try to get the index by the alias or we want to verify if the given alias exists.

As a workaround, we can urlencode the alias before passed it to the client : 

```php
$params = array(
            'name' => urlencode($alias)
);
// return true even with UTF-8 char
$this->assertEquals($alias . '_v1', array_keys(self::$client->indices()->getAlias($params))[0]);
```

I run the following test with ElasticSearch 2.4 and 5.5.2