### PR TITLE
Add verify as acceptable query string parameter for create repository

### DIFF
--- a/src/Elasticsearch/Endpoints/Snapshot/Repository/Create.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Repository/Create.php
@@ -81,6 +81,7 @@ class Create extends AbstractEndpoint
         return array(
             'master_timeout',
             'timeout',
+            'verify'
         );
     }
 


### PR DESCRIPTION
Addresses missing `verify` parameter issue in #659 