### PR TITLE
Cast empty array to object

### DIFF
--- a/docs/php_json_objects.asciidoc
+++ b/docs/php_json_objects.asciidoc
@@ -44,7 +44,7 @@ $params['body'] = array(
     ),
     'highlight' => array(
         'fields' => array(
-            'content' => new \stdClass() <1>
+            'content' => new \stdClass() //(object)[]<1>
         )
     )
 );
@@ -53,7 +53,7 @@ $results = $client->search($params);
 <1> We use the generic PHP stdClass object to represent an empty object.  The JSON will now encode correctly.
 
 By using an explicit stdClass object, we can force the `json_encode` parser to correctly output an empty object, instead
-of an empty array.  Sadly, this verbose solution is the only way to acomplish the goal in PHP...there is no "short"
+of an empty array.  This verbose solution and `(object)[]` are the only way to acomplish the goal in PHP...there is no "short"
 version of an empty object.
 
 === Arrays of Objects


### PR DESCRIPTION
Except new stdClass() used can cast empty array to object:
`(object)[]` -  the result is the same: `{"content":{}}`

