### PR TITLE
Create empty object from array

### DIFF
--- a/docs/php_json_objects.asciidoc
+++ b/docs/php_json_objects.asciidoc
@@ -44,7 +44,7 @@ $params['body'] = array(
     ),
     'highlight' => array(
         'fields' => array(
-            'content' => new \stdClass() <1>
+            'content' => new \stdClass() //(object)[]<1>
         )
     )
 );


### PR DESCRIPTION
Cast empty array to object to create empty object (`{}`)