### PR TITLE
ClientBuilder: setLogger() and setTracer() only accept \Psr\Log\LoggerInterface

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,3 +7,6 @@ parameters:
         # because of \Elasticsearch\Tests\RegisteredNamespaceTest
         - '#Call to an undefined method Elasticsearch\\Client::foo\(\)#'
         - '#Call to an undefined method Elasticsearch\\Client::bar\(\)#'
+
+        # because of \Elasticsearch\Tests\ClientBuilderTest
+        - '#expects Psr\\Log\\LoggerInterface, Elasticsearch\\Tests\\ClientBuilder\\DummyLogger given.$#'

--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -307,6 +307,10 @@ class ClientBuilder
      */
     public function setLogger($logger)
     {
+        if (!$logger instanceof LoggerInterface) {
+            throw new InvalidArgumentException('$logger must implement \Psr\Log\LoggerInterface!');
+        }
+
         $this->logger = $logger;
 
         return $this;
@@ -318,6 +322,10 @@ class ClientBuilder
      */
     public function setTracer($tracer)
     {
+        if (!$tracer instanceof LoggerInterface) {
+            throw new InvalidArgumentException('$tracer must implement \Psr\Log\LoggerInterface!');
+        }
+
         $this->tracer = $tracer;
 
         return $this;

--- a/tests/Elasticsearch/Tests/ClientBuilder/DummyLogger.php
+++ b/tests/Elasticsearch/Tests/ClientBuilder/DummyLogger.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types = 1);
+
+namespace Elasticsearch\Tests\ClientBuilder;
+
+class DummyLogger
+{
+
+}

--- a/tests/Elasticsearch/Tests/ClientBuilderTest.php
+++ b/tests/Elasticsearch/Tests/ClientBuilderTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Elasticsearch\Tests;
+
+use Elasticsearch\ClientBuilder;
+use Elasticsearch\Common\Exceptions\InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class ClientBuilderTest extends TestCase
+{
+
+    public function testClientBuilderThrowsExceptionForIncorrectLoggerClass()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('$logger must implement \Psr\Log\LoggerInterface!');
+
+        ClientBuilder::create()->setLogger(new \Elasticsearch\Tests\ClientBuilder\DummyLogger());
+    }
+
+    public function testClientBuilderThrowsExceptionForIncorrectTracerClass()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('$tracer must implement \Psr\Log\LoggerInterface!');
+
+        ClientBuilder::create()->setTracer(new \Elasticsearch\Tests\ClientBuilder\DummyLogger());
+    }
+}


### PR DESCRIPTION
Partially supersedes #296.

This is a more verbose approach than directly adding typehints, but it
won't break the projects which may be extending ClientBuilder.
