### PR TITLE
Update to Mockery 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   "require-dev": {
     "cpliakas/git-wrapper": "~1.0",
     "doctrine/inflector": "^1.1",
-    "mockery/mockery": "0.9.4",
+    "mockery/mockery": "^1.0",
     "phpstan/phpstan-shim": "0.8.3",
     "phpunit/phpunit": "6.3.0",
     "squizlabs/php_codesniffer": "3.0.2",


### PR DESCRIPTION
Updated `mockery/mockery` to [`^1.0`](https://github.com/mockery/mockery/releases/tag/1.0).