### PR TITLE
Handle ServerErrorResponseException on promise failure

### DIFF
--- a/src/Elasticsearch/Transport.php
+++ b/src/Elasticsearch/Transport.php
@@ -119,7 +119,8 @@ class Transport
             //onFailure
             function ($response) {
                 // Ignore 400 level errors, as that means the server responded just fine
-                if (!(isset($response['code']) && $response['code'] >=400 && $response['code'] < 500)) {
+                if ((is_array($response) && !(isset($response['code']) && $response['code'] >= 400 && $response['code'] < 500))
+                    || ($response instanceof Exceptions\ServerErrorResponseException && !($response->getCode() >= 400 && $response -> getCode() < 500))) {
                     // Otherwise schedule a check
                     $this->connectionPool->scheduleCheck();
                 }


### PR DESCRIPTION
\Elasticsearch\Connections\Connection::process5xxError() throws exception which is passed to rejected promise as argument.
Then $response is no longer an array. The previous test triggered "Error: Cannot use object of type Elasticsearch\Common\Exceptions\ServerErrorResponseException as array".

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you signed [Contributor License Agreement](http://www.elasticsearch.org/contributor-agreement/)?
PR's (no matter how small) cannot be merged until the CLA has been signed.  It only needs to be signed once,
however.

- Have you read the [Contributing Guidelines](https://github.com/elastic/elasticsearch-php/blob/master/.github/CONTRIBUTING.md)?

If you answered yes to both, thanks for the PR and we'll get to it ASAP! :)

-->