### PR TITLE
Backport #542 in branch 2.0

### DIFF
--- a/src/Elasticsearch/Endpoints/TermVectors.php
+++ b/src/Elasticsearch/Endpoints/TermVectors.php
@@ -63,15 +63,21 @@ class TermVectors extends AbstractEndpoint
                 'type is required for TermVector'
             );
         }
-        if (isset($this->id) !== true) {
-            throw new Exceptions\RuntimeException(
-                'id is required for TermVector'
-            );
+        if (isset($this->id) !== true && isset($this->body['doc']) !== true) {
+           throw new Exceptions\RuntimeException(
+               'id or doc is required for TermVectors'
+           );
         }
+
         $index = $this->index;
         $type = $this->type;
         $id = $this->id;
-        $uri = "/$index/$type/$id/_termvector" . ($this->shouldUseDeprecated ? '' : 's');
+
+        $uri = "/$index/$type/_termvector" . ($this->shouldUseDeprecated ? '' : 's');
+
+        if ($id !== null) {
+            $uri = "/$index/$type/$id/_termvector" . ($this->shouldUseDeprecated ? '' : 's');
+        }
 
         return $uri;
     }


### PR DESCRIPTION
Same as #542 that have already been merged in branches >= 5.x (make id param optionnal for termvectors requests when doc is set in the body).
For one of my project, I really need it to be also fixed in branch 2.x and a new release containing this patch (2.3.2).