### PR TITLE
Add note about separate X-Pack library to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ elasticsearch-php
 
 Official low-level client for Elasticsearch. Its goal is to provide common ground for all Elasticsearch-related code in PHP; because of this it tries to be opinion-free and very extendable.
 
-To maintain consistency across all the low-level clients (Ruby, Python, etc), clients accept simple associative arrays as parameters.  All parameters, from the URI to the document body, are defined in the associative array.
+To maintain consistency across all the low-level clients (Ruby, Python, etc.), clients accept simple associative arrays as parameters.  All parameters, from the URI to the document body, are defined in the associative array.
 
 
 Features
@@ -18,7 +18,7 @@ Features
  - Load balancing (with pluggable selection strategy) across all available nodes. Defaults to round-robin
  - Pluggable connection pools to offer different connection strategies
  - Generalized, pluggable architecture - most components can be replaced with your own custom class if specialized behavior is required
- - Option to use asyncronous future, which enables parallel execution of curl requests to multiple nodes
+ - Option to use asynchronous future, which enables parallel execution of curl requests to multiple nodes
 
 Version Matrix
 --------------
@@ -35,7 +35,7 @@ Version Matrix
  - If you are using Elasticsearch 5.x , use Elasticsearch-PHP 5.0 branch.
  - If you are using Elasticsearch 1.x or 2.x, prefer using the Elasticsearch-PHP 2.0 branch.  The 1.0 branch is compatible however.
  - If you are using a version older than 1.0, you must install the `0.4` Elasticsearch-PHP branch. Since ES 0.90.x and below is now EOL, the corresponding `0.4` branch will not receive any more development or bugfixes.  Please upgrade.
- - You should never use Elasticsearch-PHP Master branch, as it tracks Elasticearch master and may contain incomplete features or breaks in backwards compat.  Only use ES-PHP master if you are developing against ES master for some reason.
+ - You should never use Elasticsearch-PHP Master branch, as it tracks Elasticsearch master and may contain incomplete features or breaks in backwards compatibility. Only use ES-PHP master if you are developing against ES master for some reason.
 
 Documentation
 --------------
@@ -45,7 +45,7 @@ Installation via Composer
 -------------------------
 The recommended method to install _Elasticsearch-PHP_ is through [Composer](http://getcomposer.org).
 
-1. Add ``elasticsearch/elasticsearch`` as a dependency in your project's ``composer.json`` file (change version to suit your version of Elasticsearch):
+1. Add `elasticsearch/elasticsearch` as a dependency in your project's `composer.json` file (change version to suit your version of Elasticsearch):
 
     ```json
         {
@@ -69,7 +69,7 @@ The recommended method to install _Elasticsearch-PHP_ is through [Composer](http
 
 4. Require Composer's autoloader
 
-    Composer also prepares an autoload file that's capable of autoloading all of the classes in any of the libraries that it downloads. To use it, just add the following line to your code's bootstrap process:
+    Composer also prepares an autoload file that's capable of autoloading all the classes in any of the libraries that it downloads. To use it, just add the following line to your code's bootstrap process:
 
     ```php
         <?php
@@ -149,7 +149,7 @@ $response = $client->get($params);
 print_r($response);
 ```
 
-The response contains some metadata (index, type, etc) as well as a `_source` field...this is the original document
+The response contains some metadata (index, type, etc.) as well as a `_source` field...this is the original document
 that you sent to Elasticsearch.
 
 ```php
@@ -202,7 +202,7 @@ $response = $client->search($params);
 print_r($response);
 ```
 
-The response is a little different from the previous responses.  We see some metadata (`took`, `timed_out`, etc) and
+The response is a little different from the previous responses.  We see some metadata (`took`, `timed_out`, etc.) and
 an array named `hits`.  This represents your search results.  Inside of `hits` is another array named `hits`, which contains
 individual search results:
 
@@ -345,9 +345,9 @@ $client = $builder->build();
 Wrap up
 =======
 
-That was just a crash-course overview of the client and it's syntax.  If you are familiar with elasticsearch, you'll notice that the methods are named just like REST endpoints.
+That was just a crash-course overview of the client and its syntax.  If you are familiar with Elasticsearch, you'll notice that the methods are named just like REST endpoints.
 
-You'll also notice that the client is configured in a manner that facilitates easy discovery via the IDE.  All core actions are available under the `$client` object (indexing, searching, getting, etc).  Index and cluster management are located under the `$client->indices()` and `$client->cluster()` objects, respectively.
+You'll also notice that the client is configured in a manner that facilitates easy discovery via the IDE.  All core actions are available under the `$client` object (indexing, searching, getting, etc.).  Index and cluster management are located under the `$client->indices()` and `$client->cluster()` objects, respectively.
 
 Check out the rest of the [Documentation](http://www.elasticsearch.org/guide/en/elasticsearch/client/php-api/current/index.html) to see how the entire client works.
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Features
  - Pluggable connection pools to offer different connection strategies
  - Generalized, pluggable architecture - most components can be replaced with your own custom class if specialized behavior is required
  - Option to use asynchronous future, which enables parallel execution of curl requests to multiple nodes
+ 
+ 
+**Note:** If you want to use X-Pack API, you need to install an optional extension [elasticsearch/xpack](https://github.com/elastic/elasticsearch-x-pack-php). 
+
 
 Version Matrix
 --------------


### PR DESCRIPTION
As mentioned in https://github.com/elastic/elasticsearch-php/pull/691#issuecomment-348980615, there is a [standalone XPack plugin](https://github.com/elastic/elasticsearch-x-pack-php). It should be written down in the README, so the users can discover it easily.




(I also fixed some README typos in the first commit)