### PR TITLE
Update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 elasticsearch-php
 =================
 
-[![Build Status](https://travis-ci.org/elastic/elasticsearch-php.svg?branch=master)](https://travis-ci.org/elastic/elasticsearch-php)
+[![Build Status](https://travis-ci.org/elastic/elasticsearch-php.svg?branch=master)](https://travis-ci.org/elastic/elasticsearch-php) [![Latest Stable Version](https://poser.pugx.org/elasticsearch/elasticsearch/v/stable)](https://packagist.org/packages/elasticsearch/elasticsearch) [![Total Downloads](https://poser.pugx.org/elasticsearch/elasticsearch/downloads)](https://packagist.org/packages/elasticsearch/elasticsearch)
 
 
 Official low-level client for Elasticsearch. Its goal is to provide common ground for all Elasticsearch-related code in PHP; because of this it tries to be opinion-free and very extendable.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 elasticsearch-php
 =================
 
-[![Build Status](https://img.shields.io/travis/elastic/elasticsearch-php.svg?style=flat-square)](https://travis-ci.org/elastic/elasticsearch-php)
+[![Build Status](https://travis-ci.org/elastic/elasticsearch-php.svg?branch=master)](https://travis-ci.org/elastic/elasticsearch-php)
 
 
 Official low-level client for Elasticsearch. Its goal is to provide common ground for all Elasticsearch-related code in PHP; because of this it tries to be opinion-free and very extendable.


### PR DESCRIPTION
I've changed the README badges:

- TravisCI badge uses the official one
- TravisCI badge show the status of the master branch (instead of the last build) <- **that's the reason for the PR**
- New: Latest version badge
- New: Downloads badge

You can see them live in https://github.com/mhujer/elasticsearch-php/tree/mh-readme-badges