### PR TITLE
WIP: Update dev dependencies to specific version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
     "phpstan/phpstan-shim": "0.9.1",
     "phpunit/phpunit": "6.5.5",
     "squizlabs/php_codesniffer": "3.2.2",
-    "symfony/finder": "2.8.32",
-    "symfony/yaml": "2.8.32"
+    "symfony/finder": "3.4.1",
+    "symfony/yaml": "3.4.1"
   },
   "suggest": {
     "ext-curl": "*",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "cpliakas/git-wrapper": "1.7.0",
     "doctrine/inflector": "1.2.0",
     "mockery/mockery": "1.0",
-    "phpstan/phpstan-shim": "0.9.1",
+    "phpstan/phpstan-shim": "0.9.2",
     "phpunit/phpunit": "6.5.5",
     "squizlabs/php_codesniffer": "3.2.2",
     "symfony/finder": "3.4.1",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "mockery/mockery": "0.9.4",
     "phpstan/phpstan-shim": "0.9.1",
     "phpunit/phpunit": "6.5.5",
-    "squizlabs/php_codesniffer": "3.0.2",
+    "squizlabs/php_codesniffer": "3.2.2",
     "symfony/finder": "2.8.32",
     "symfony/yaml": "2.8.32"
   },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   "require-dev": {
     "cpliakas/git-wrapper": "1.7.0",
     "doctrine/inflector": "1.2.0",
-    "mockery/mockery": "0.9.4",
+    "mockery/mockery": "1.0",
     "phpstan/phpstan-shim": "0.9.1",
     "phpunit/phpunit": "6.5.5",
     "squizlabs/php_codesniffer": "3.2.2",

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
     "psr/log": "~1.0"
   },
   "require-dev": {
-    "cpliakas/git-wrapper": "~1.0",
-    "doctrine/inflector": "^1.1",
+    "cpliakas/git-wrapper": "1.7.0",
+    "doctrine/inflector": "1.2.0",
     "mockery/mockery": "0.9.4",
     "phpstan/phpstan-shim": "0.9.1",
     "phpunit/phpunit": "6.3.0",
     "squizlabs/php_codesniffer": "3.0.2",
-    "symfony/finder": "^2.8",
-    "symfony/yaml": "^2.8"
+    "symfony/finder": "2.8.32",
+    "symfony/yaml": "2.8.32"
   },
   "suggest": {
     "ext-curl": "*",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "doctrine/inflector": "1.2.0",
     "mockery/mockery": "0.9.4",
     "phpstan/phpstan-shim": "0.9.1",
-    "phpunit/phpunit": "6.3.0",
+    "phpunit/phpunit": "6.5.5",
     "squizlabs/php_codesniffer": "3.0.2",
     "symfony/finder": "2.8.32",
     "symfony/yaml": "2.8.32"

--- a/phpstan-tests.neon
+++ b/phpstan-tests.neon
@@ -1,6 +1,6 @@
 parameters:
     ignoreErrors:
-        - '#Mockery\\MockInterface::shouldReceive\(\)#'
+        - '#Mockery\\ExpectationInterface#'
         - '#Mockery\\MockInterface given#'
 
         # because of \Elasticsearch\Tests\RegisteredNamespaceTest

--- a/tests/Elasticsearch/Tests/YamlRunnerTest.php
+++ b/tests/Elasticsearch/Tests/YamlRunnerTest.php
@@ -947,7 +947,7 @@ class YamlRunnerTest extends \PHPUnit\Framework\TestCase
         foreach ($documents as $documentString) {
             try {
                 if (!$setupSkip) {
-                    $documentParsed = $this->yaml->parse($documentString, false, false, true);
+                    $documentParsed = $this->yaml->parse($documentString, Yaml::PARSE_OBJECT_FOR_MAP);
                     $skip = false;
                 }
             } catch (ParseException $exception) {


### PR DESCRIPTION
From my point of view, it is best to use specific versions of dev-dependencies so that they won't break the build unexpectedly. So I changed them in the first commit.

In the other commits, I've updated the other dependencies.

---

Closes #680
  