### PR TITLE
Added note in doc block regarding non-whitelisted params for search()

### DIFF
--- a/src/Elasticsearch/Client.php
+++ b/src/Elasticsearch/Client.php
@@ -929,6 +929,10 @@ class Client
      *        ['version']                  = (boolean) Specify whether to return document version as part of a hit
      *        ['body']                     = (array|string) The search definition using the Query DSL
      *
+     * Note: Some Search API parameters, such as `search_after`, are not
+     * whitelisted for the top-level of of the $params array. They can be
+     * passed along within $params['body']
+     *
      * @param $params array Associative array of parameters
      *
      * @return array


### PR DESCRIPTION
Currently, the params for `Client->search()` are whitelisted, and that whitelisting doesn't clearly match the expectations laid out in the Search APIs documentation for Elasticsearch (e.g. https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-request-search-after.html). This PR adds some documentation explaining usage for some of those params which are not documented elsewhere, and which throw errors which make it seem that those params are not supported by this library.

Related issues:
https://github.com/elastic/elasticsearch-php/issues/702
https://github.com/elastic/elasticsearch-php/issues/556