### PR TITLE
Add declare(strict_types=1) to src/

### DIFF
--- a/src/Elasticsearch/Client.php
+++ b/src/Elasticsearch/Client.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch;
 
 use Elasticsearch\Common\Exceptions\BadMethodCallException;

--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch;
 
 use Elasticsearch\Common\Exceptions\InvalidArgumentException;

--- a/src/Elasticsearch/Common/EmptyLogger.php
+++ b/src/Elasticsearch/Common/EmptyLogger.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Common;
 
 use Psr\Log\AbstractLogger;

--- a/src/Elasticsearch/Common/Exceptions/AlreadyExpiredException.php
+++ b/src/Elasticsearch/Common/Exceptions/AlreadyExpiredException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Common\Exceptions;
 
 /**

--- a/src/Elasticsearch/Common/Exceptions/BadMethodCallException.php
+++ b/src/Elasticsearch/Common/Exceptions/BadMethodCallException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Common\Exceptions;
 
 /**

--- a/src/Elasticsearch/Common/Exceptions/BadRequest400Exception.php
+++ b/src/Elasticsearch/Common/Exceptions/BadRequest400Exception.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Common\Exceptions;
 
 /**

--- a/src/Elasticsearch/Common/Exceptions/ClientErrorResponseException.php
+++ b/src/Elasticsearch/Common/Exceptions/ClientErrorResponseException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Common\Exceptions;
 
 /**

--- a/src/Elasticsearch/Common/Exceptions/Conflict409Exception.php
+++ b/src/Elasticsearch/Common/Exceptions/Conflict409Exception.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Common\Exceptions;
 
 /**

--- a/src/Elasticsearch/Common/Exceptions/Curl/CouldNotConnectToHost.php
+++ b/src/Elasticsearch/Common/Exceptions/Curl/CouldNotConnectToHost.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Common\Exceptions\Curl;
 
 use Elasticsearch\Common\Exceptions\ElasticsearchException;

--- a/src/Elasticsearch/Common/Exceptions/Curl/CouldNotResolveHostException.php
+++ b/src/Elasticsearch/Common/Exceptions/Curl/CouldNotResolveHostException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Common\Exceptions\Curl;
 
 use Elasticsearch\Common\Exceptions\ElasticsearchException;

--- a/src/Elasticsearch/Common/Exceptions/Curl/OperationTimeoutException.php
+++ b/src/Elasticsearch/Common/Exceptions/Curl/OperationTimeoutException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Common\Exceptions\Curl;
 
 use Elasticsearch\Common\Exceptions\ElasticsearchException;

--- a/src/Elasticsearch/Common/Exceptions/ElasticsearchException.php
+++ b/src/Elasticsearch/Common/Exceptions/ElasticsearchException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Common\Exceptions;
 
 /**

--- a/src/Elasticsearch/Common/Exceptions/Forbidden403Exception.php
+++ b/src/Elasticsearch/Common/Exceptions/Forbidden403Exception.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Common\Exceptions;
 
 /**

--- a/src/Elasticsearch/Common/Exceptions/InvalidArgumentException.php
+++ b/src/Elasticsearch/Common/Exceptions/InvalidArgumentException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Common\Exceptions;
 
 /**

--- a/src/Elasticsearch/Common/Exceptions/MaxRetriesException.php
+++ b/src/Elasticsearch/Common/Exceptions/MaxRetriesException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Common\Exceptions;
 
 /**

--- a/src/Elasticsearch/Common/Exceptions/Missing404Exception.php
+++ b/src/Elasticsearch/Common/Exceptions/Missing404Exception.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Common\Exceptions;
 
 /**

--- a/src/Elasticsearch/Common/Exceptions/NoDocumentsToGetException.php
+++ b/src/Elasticsearch/Common/Exceptions/NoDocumentsToGetException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Common\Exceptions;
 
 /**

--- a/src/Elasticsearch/Common/Exceptions/NoNodesAvailableException.php
+++ b/src/Elasticsearch/Common/Exceptions/NoNodesAvailableException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Common\Exceptions;
 
 /**

--- a/src/Elasticsearch/Common/Exceptions/NoShardAvailableException.php
+++ b/src/Elasticsearch/Common/Exceptions/NoShardAvailableException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Common\Exceptions;
 
 /**

--- a/src/Elasticsearch/Common/Exceptions/RequestTimeout408Exception.php
+++ b/src/Elasticsearch/Common/Exceptions/RequestTimeout408Exception.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Common\Exceptions;
 
 /**

--- a/src/Elasticsearch/Common/Exceptions/RoutingMissingException.php
+++ b/src/Elasticsearch/Common/Exceptions/RoutingMissingException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Common\Exceptions;
 
 /**

--- a/src/Elasticsearch/Common/Exceptions/RuntimeException.php
+++ b/src/Elasticsearch/Common/Exceptions/RuntimeException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Common\Exceptions;
 
 /**

--- a/src/Elasticsearch/Common/Exceptions/ScriptLangNotSupportedException.php
+++ b/src/Elasticsearch/Common/Exceptions/ScriptLangNotSupportedException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Common\Exceptions;
 
 /**

--- a/src/Elasticsearch/Common/Exceptions/Serializer/JsonErrorException.php
+++ b/src/Elasticsearch/Common/Exceptions/Serializer/JsonErrorException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Common\Exceptions\Serializer;
 
 use Elasticsearch\Common\Exceptions\ElasticsearchException;

--- a/src/Elasticsearch/Common/Exceptions/ServerErrorResponseException.php
+++ b/src/Elasticsearch/Common/Exceptions/ServerErrorResponseException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Common\Exceptions;
 
 /**

--- a/src/Elasticsearch/Common/Exceptions/TransportException.php
+++ b/src/Elasticsearch/Common/Exceptions/TransportException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Common\Exceptions;
 
 /**

--- a/src/Elasticsearch/Common/Exceptions/Unauthorized401Exception.php
+++ b/src/Elasticsearch/Common/Exceptions/Unauthorized401Exception.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Common\Exceptions;
 
 /**

--- a/src/Elasticsearch/Common/Exceptions/UnexpectedValueException.php
+++ b/src/Elasticsearch/Common/Exceptions/UnexpectedValueException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Common\Exceptions;
 
 /**

--- a/src/Elasticsearch/ConnectionPool/AbstractConnectionPool.php
+++ b/src/Elasticsearch/ConnectionPool/AbstractConnectionPool.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\ConnectionPool;
 
 use Elasticsearch\Common\Exceptions\InvalidArgumentException;

--- a/src/Elasticsearch/ConnectionPool/ConnectionPoolInterface.php
+++ b/src/Elasticsearch/ConnectionPool/ConnectionPoolInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\ConnectionPool;
 
 use Elasticsearch\Connections\ConnectionInterface;

--- a/src/Elasticsearch/ConnectionPool/Selectors/RandomSelector.php
+++ b/src/Elasticsearch/ConnectionPool/Selectors/RandomSelector.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\ConnectionPool\Selectors;
 
 use Elasticsearch\Connections\ConnectionInterface;

--- a/src/Elasticsearch/ConnectionPool/Selectors/RoundRobinSelector.php
+++ b/src/Elasticsearch/ConnectionPool/Selectors/RoundRobinSelector.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\ConnectionPool\Selectors;
 
 use Elasticsearch\Connections\ConnectionInterface;

--- a/src/Elasticsearch/ConnectionPool/Selectors/SelectorInterface.php
+++ b/src/Elasticsearch/ConnectionPool/Selectors/SelectorInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\ConnectionPool\Selectors;
 
 /**

--- a/src/Elasticsearch/ConnectionPool/Selectors/StickyRoundRobinSelector.php
+++ b/src/Elasticsearch/ConnectionPool/Selectors/StickyRoundRobinSelector.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\ConnectionPool\Selectors;
 
 use Elasticsearch\Connections\ConnectionInterface;

--- a/src/Elasticsearch/ConnectionPool/SimpleConnectionPool.php
+++ b/src/Elasticsearch/ConnectionPool/SimpleConnectionPool.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\ConnectionPool;
 
 use Elasticsearch\ConnectionPool\Selectors\SelectorInterface;

--- a/src/Elasticsearch/ConnectionPool/SniffingConnectionPool.php
+++ b/src/Elasticsearch/ConnectionPool/SniffingConnectionPool.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\ConnectionPool;
 
 use Elasticsearch\Common\Exceptions\Curl\OperationTimeoutException;

--- a/src/Elasticsearch/ConnectionPool/StaticConnectionPool.php
+++ b/src/Elasticsearch/ConnectionPool/StaticConnectionPool.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\ConnectionPool;
 
 use Elasticsearch\Common\Exceptions\NoNodesAvailableException;

--- a/src/Elasticsearch/ConnectionPool/StaticNoPingConnectionPool.php
+++ b/src/Elasticsearch/ConnectionPool/StaticNoPingConnectionPool.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\ConnectionPool;
 
 use Elasticsearch\Common\Exceptions\NoNodesAvailableException;

--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Connections;
 
 use Elasticsearch\Common\Exceptions\AlreadyExpiredException;

--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -543,13 +543,13 @@ class Connection implements ConnectionInterface
         $exception = new MaxRetriesException($message);
         switch ($response['curl']['errno']) {
             case 6:
-                $exception = new CouldNotResolveHostException($message, null, $exception);
+                $exception = new CouldNotResolveHostException($message, 0, $exception);
                 break;
             case 7:
-                $exception = new CouldNotConnectToHost($message, null, $exception);
+                $exception = new CouldNotConnectToHost($message, 0, $exception);
                 break;
             case 28:
-                $exception = new OperationTimeoutException($message, null, $exception);
+                $exception = new OperationTimeoutException($message, 0, $exception);
                 break;
         }
 
@@ -599,6 +599,11 @@ class Connection implements ConnectionInterface
 
         if (array_search($response['status'], $ignore) !== false) {
             return;
+        }
+
+        // if responseBody is not string, we convert it so it can be used as Exception message
+        if (!is_string($responseBody)) {
+            $responseBody = json_encode($responseBody);
         }
 
         if ($statusCode === 400 && strpos($responseBody, "AlreadyExpiredException") !== false) {
@@ -718,7 +723,13 @@ class Connection implements ConnectionInterface
             return new $errorClass($response['body'], $response['status']);
         }
 
+        // if responseBody is not string, we convert it so it can be used as Exception message
+        $responseBody = $response['body'];
+        if (!is_string($responseBody)) {
+            $responseBody = json_encode($responseBody);
+        }
+
         // <2.0 "i just blew up" nonstructured exception
-        return new $errorClass($response['body']);
+        return new $errorClass($responseBody);
     }
 }

--- a/src/Elasticsearch/Connections/ConnectionFactory.php
+++ b/src/Elasticsearch/Connections/ConnectionFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Connections;
 
 use Elasticsearch\Serializers\SerializerInterface;

--- a/src/Elasticsearch/Connections/ConnectionFactoryInterface.php
+++ b/src/Elasticsearch/Connections/ConnectionFactoryInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Connections;
 
 use Elasticsearch\Serializers\SerializerInterface;

--- a/src/Elasticsearch/Connections/ConnectionInterface.php
+++ b/src/Elasticsearch/Connections/ConnectionInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Connections;
 
 use Elasticsearch\Serializers\SerializerInterface;

--- a/src/Elasticsearch/Endpoints/AbstractEndpoint.php
+++ b/src/Elasticsearch/Endpoints/AbstractEndpoint.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 use Elasticsearch\Common\Exceptions\UnexpectedValueException;

--- a/src/Elasticsearch/Endpoints/AbstractEndpoint.php
+++ b/src/Elasticsearch/Endpoints/AbstractEndpoint.php
@@ -166,6 +166,10 @@ abstract class AbstractEndpoint
             return $this;
         }
 
+        if (is_int($docID)) {
+            $docID = (string) $docID;
+        }
+
         $this->id = urlencode($docID);
 
         return $this;

--- a/src/Elasticsearch/Endpoints/Bulk.php
+++ b/src/Elasticsearch/Endpoints/Bulk.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 use Elasticsearch\Serializers\SerializerInterface;

--- a/src/Elasticsearch/Endpoints/BulkEndpointInterface.php
+++ b/src/Elasticsearch/Endpoints/BulkEndpointInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 use Elasticsearch\Serializers\SerializerInterface;

--- a/src/Elasticsearch/Endpoints/Cat/Aliases.php
+++ b/src/Elasticsearch/Endpoints/Cat/Aliases.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cat;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Cat/Allocation.php
+++ b/src/Elasticsearch/Endpoints/Cat/Allocation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cat;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Cat/Count.php
+++ b/src/Elasticsearch/Endpoints/Cat/Count.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cat;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Cat/Fielddata.php
+++ b/src/Elasticsearch/Endpoints/Cat/Fielddata.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cat;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Cat/Health.php
+++ b/src/Elasticsearch/Endpoints/Cat/Health.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cat;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Cat/Help.php
+++ b/src/Elasticsearch/Endpoints/Cat/Help.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cat;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Cat/Indices.php
+++ b/src/Elasticsearch/Endpoints/Cat/Indices.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cat;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Cat/Master.php
+++ b/src/Elasticsearch/Endpoints/Cat/Master.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cat;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Cat/NodeAttrs.php
+++ b/src/Elasticsearch/Endpoints/Cat/NodeAttrs.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cat;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Cat/Nodes.php
+++ b/src/Elasticsearch/Endpoints/Cat/Nodes.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cat;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Cat/PendingTasks.php
+++ b/src/Elasticsearch/Endpoints/Cat/PendingTasks.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cat;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Cat/Plugins.php
+++ b/src/Elasticsearch/Endpoints/Cat/Plugins.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cat;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Cat/Recovery.php
+++ b/src/Elasticsearch/Endpoints/Cat/Recovery.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cat;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Cat/Repositories.php
+++ b/src/Elasticsearch/Endpoints/Cat/Repositories.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cat;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Cat/Segments.php
+++ b/src/Elasticsearch/Endpoints/Cat/Segments.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types = 1);
 /**
  * User: zach
  * Date: 01/12/2015

--- a/src/Elasticsearch/Endpoints/Cat/Shards.php
+++ b/src/Elasticsearch/Endpoints/Cat/Shards.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cat;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Cat/Snapshots.php
+++ b/src/Elasticsearch/Endpoints/Cat/Snapshots.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cat;
 
 use Elasticsearch\Common\Exceptions\RuntimeException;

--- a/src/Elasticsearch/Endpoints/Cat/Tasks.php
+++ b/src/Elasticsearch/Endpoints/Cat/Tasks.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cat;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Cat/Templates.php
+++ b/src/Elasticsearch/Endpoints/Cat/Templates.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cat;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Cat/ThreadPool.php
+++ b/src/Elasticsearch/Endpoints/Cat/ThreadPool.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cat;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/ClearScroll.php
+++ b/src/Elasticsearch/Endpoints/ClearScroll.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 use Elasticsearch\Common\Exceptions;

--- a/src/Elasticsearch/Endpoints/Cluster/AllocationExplain.php
+++ b/src/Elasticsearch/Endpoints/Cluster/AllocationExplain.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cluster;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Cluster/Health.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Health.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cluster;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Cluster/Nodes/AbstractNodesEndpoint.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Nodes/AbstractNodesEndpoint.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cluster\Nodes;
 
 use Elasticsearch\Common\Exceptions\InvalidArgumentException;

--- a/src/Elasticsearch/Endpoints/Cluster/Nodes/HotThreads.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Nodes/HotThreads.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cluster\Nodes;
 
 /**

--- a/src/Elasticsearch/Endpoints/Cluster/Nodes/Info.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Nodes/Info.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cluster\Nodes;
 
 /**

--- a/src/Elasticsearch/Endpoints/Cluster/Nodes/Shutdown.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Nodes/Shutdown.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cluster\Nodes;
 
 /**

--- a/src/Elasticsearch/Endpoints/Cluster/Nodes/Stats.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Nodes/Stats.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cluster\Nodes;
 
 /**

--- a/src/Elasticsearch/Endpoints/Cluster/PendingTasks.php
+++ b/src/Elasticsearch/Endpoints/Cluster/PendingTasks.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cluster;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Cluster/RemoteInfo.php
+++ b/src/Elasticsearch/Endpoints/Cluster/RemoteInfo.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cluster;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Cluster/Reroute.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Reroute.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cluster;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Cluster/Settings/Get.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Settings/Get.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cluster\Settings;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Cluster/Settings/Put.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Settings/Put.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cluster\Settings;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Cluster/State.php
+++ b/src/Elasticsearch/Endpoints/Cluster/State.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cluster;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Cluster/Stats.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Stats.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Cluster;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Count.php
+++ b/src/Elasticsearch/Endpoints/Count.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 use Elasticsearch\Common\Exceptions;

--- a/src/Elasticsearch/Endpoints/CountPercolate.php
+++ b/src/Elasticsearch/Endpoints/CountPercolate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 use Elasticsearch\Common\Exceptions;

--- a/src/Elasticsearch/Endpoints/Create.php
+++ b/src/Elasticsearch/Endpoints/Create.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 use Elasticsearch\Common\Exceptions;

--- a/src/Elasticsearch/Endpoints/Delete.php
+++ b/src/Elasticsearch/Endpoints/Delete.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 use Elasticsearch\Common\Exceptions;

--- a/src/Elasticsearch/Endpoints/DeleteByQuery.php
+++ b/src/Elasticsearch/Endpoints/DeleteByQuery.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 use Elasticsearch\Common\Exceptions;

--- a/src/Elasticsearch/Endpoints/Exists.php
+++ b/src/Elasticsearch/Endpoints/Exists.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 use Elasticsearch\Common\Exceptions;

--- a/src/Elasticsearch/Endpoints/Explain.php
+++ b/src/Elasticsearch/Endpoints/Explain.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 use Elasticsearch\Common\Exceptions;

--- a/src/Elasticsearch/Endpoints/FieldCaps.php
+++ b/src/Elasticsearch/Endpoints/FieldCaps.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 use Elasticsearch\Common\Exceptions\InvalidArgumentException;

--- a/src/Elasticsearch/Endpoints/FieldStats.php
+++ b/src/Elasticsearch/Endpoints/FieldStats.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 use Elasticsearch\Common\Exceptions;

--- a/src/Elasticsearch/Endpoints/Get.php
+++ b/src/Elasticsearch/Endpoints/Get.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 use Elasticsearch\Common\Exceptions;

--- a/src/Elasticsearch/Endpoints/Index.php
+++ b/src/Elasticsearch/Endpoints/Index.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 use Elasticsearch\Common\Exceptions;

--- a/src/Elasticsearch/Endpoints/Indices/Alias/AbstractAliasEndpoint.php
+++ b/src/Elasticsearch/Endpoints/Indices/Alias/AbstractAliasEndpoint.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices\Alias;
 
 use Elasticsearch\Common\Exceptions\InvalidArgumentException;

--- a/src/Elasticsearch/Endpoints/Indices/Alias/Delete.php
+++ b/src/Elasticsearch/Endpoints/Indices/Alias/Delete.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices\Alias;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Alias/Exists.php
+++ b/src/Elasticsearch/Endpoints/Indices/Alias/Exists.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices\Alias;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Alias/Get.php
+++ b/src/Elasticsearch/Endpoints/Indices/Alias/Get.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices\Alias;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Alias/Put.php
+++ b/src/Elasticsearch/Endpoints/Indices/Alias/Put.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices\Alias;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Aliases/Update.php
+++ b/src/Elasticsearch/Endpoints/Indices/Aliases/Update.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices\Aliases;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Analyze.php
+++ b/src/Elasticsearch/Endpoints/Indices/Analyze.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Cache/Clear.php
+++ b/src/Elasticsearch/Endpoints/Indices/Cache/Clear.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices\Cache;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/ClearCache.php
+++ b/src/Elasticsearch/Endpoints/Indices/ClearCache.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Close.php
+++ b/src/Elasticsearch/Endpoints/Indices/Close.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Create.php
+++ b/src/Elasticsearch/Endpoints/Indices/Create.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Delete.php
+++ b/src/Elasticsearch/Endpoints/Indices/Delete.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Exists.php
+++ b/src/Elasticsearch/Endpoints/Indices/Exists.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Exists/Types.php
+++ b/src/Elasticsearch/Endpoints/Indices/Exists/Types.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices\Exists;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Field/Get.php
+++ b/src/Elasticsearch/Endpoints/Indices/Field/Get.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices\Field;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Flush.php
+++ b/src/Elasticsearch/Endpoints/Indices/Flush.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/ForceMerge.php
+++ b/src/Elasticsearch/Endpoints/Indices/ForceMerge.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Gateway/Snapshot.php
+++ b/src/Elasticsearch/Endpoints/Indices/Gateway/Snapshot.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices\Gateway;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Get.php
+++ b/src/Elasticsearch/Endpoints/Indices/Get.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Mapping/Delete.php
+++ b/src/Elasticsearch/Endpoints/Indices/Mapping/Delete.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices\Mapping;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Mapping/Get.php
+++ b/src/Elasticsearch/Endpoints/Indices/Mapping/Get.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices\Mapping;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Mapping/GetField.php
+++ b/src/Elasticsearch/Endpoints/Indices/Mapping/GetField.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices\Mapping;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Mapping/Put.php
+++ b/src/Elasticsearch/Endpoints/Indices/Mapping/Put.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices\Mapping;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Open.php
+++ b/src/Elasticsearch/Endpoints/Indices/Open.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Recovery.php
+++ b/src/Elasticsearch/Endpoints/Indices/Recovery.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Refresh.php
+++ b/src/Elasticsearch/Endpoints/Indices/Refresh.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Rollover.php
+++ b/src/Elasticsearch/Endpoints/Indices/Rollover.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Seal.php
+++ b/src/Elasticsearch/Endpoints/Indices/Seal.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Segments.php
+++ b/src/Elasticsearch/Endpoints/Indices/Segments.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Settings/Get.php
+++ b/src/Elasticsearch/Endpoints/Indices/Settings/Get.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices\Settings;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Settings/Put.php
+++ b/src/Elasticsearch/Endpoints/Indices/Settings/Put.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices\Settings;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/ShardStores.php
+++ b/src/Elasticsearch/Endpoints/Indices/ShardStores.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Shrink.php
+++ b/src/Elasticsearch/Endpoints/Indices/Shrink.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Snapshotindex.php
+++ b/src/Elasticsearch/Endpoints/Indices/Snapshotindex.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Stats.php
+++ b/src/Elasticsearch/Endpoints/Indices/Stats.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Status.php
+++ b/src/Elasticsearch/Endpoints/Indices/Status.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Template/AbstractTemplateEndpoint.php
+++ b/src/Elasticsearch/Endpoints/Indices/Template/AbstractTemplateEndpoint.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices\Template;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Template/Delete.php
+++ b/src/Elasticsearch/Endpoints/Indices/Template/Delete.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices\Template;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Template/Exists.php
+++ b/src/Elasticsearch/Endpoints/Indices/Template/Exists.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices\Template;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Template/Get.php
+++ b/src/Elasticsearch/Endpoints/Indices/Template/Get.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices\Template;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Template/Put.php
+++ b/src/Elasticsearch/Endpoints/Indices/Template/Put.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices\Template;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Type/Exists.php
+++ b/src/Elasticsearch/Endpoints/Indices/Type/Exists.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices\Type;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/Upgrade/Get.php
+++ b/src/Elasticsearch/Endpoints/Indices/Upgrade/Get.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types = 1);
 /**
  * User: zach
  * Date: 01/20/2014

--- a/src/Elasticsearch/Endpoints/Indices/Upgrade/Post.php
+++ b/src/Elasticsearch/Endpoints/Indices/Upgrade/Post.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types = 1);
 /**
  * User: zach
  * Date: 01/20/2014

--- a/src/Elasticsearch/Endpoints/Indices/Validate/Query.php
+++ b/src/Elasticsearch/Endpoints/Indices/Validate/Query.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices\Validate;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Indices/ValidateQuery.php
+++ b/src/Elasticsearch/Endpoints/Indices/ValidateQuery.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Indices;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Info.php
+++ b/src/Elasticsearch/Endpoints/Info.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 /**

--- a/src/Elasticsearch/Endpoints/Ingest/Pipeline/Delete.php
+++ b/src/Elasticsearch/Endpoints/Ingest/Pipeline/Delete.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Ingest\Pipeline;
 
 use Elasticsearch\Common\Exceptions;

--- a/src/Elasticsearch/Endpoints/Ingest/Pipeline/Get.php
+++ b/src/Elasticsearch/Endpoints/Ingest/Pipeline/Get.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Ingest\Pipeline;
 
 use Elasticsearch\Common\Exceptions;

--- a/src/Elasticsearch/Endpoints/Ingest/Pipeline/ProcessorGrok.php
+++ b/src/Elasticsearch/Endpoints/Ingest/Pipeline/ProcessorGrok.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Ingest\Pipeline;
 
 use Elasticsearch\Common\Exceptions;

--- a/src/Elasticsearch/Endpoints/Ingest/Pipeline/Put.php
+++ b/src/Elasticsearch/Endpoints/Ingest/Pipeline/Put.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Ingest\Pipeline;
 
 use Elasticsearch\Common\Exceptions;

--- a/src/Elasticsearch/Endpoints/Ingest/Simulate.php
+++ b/src/Elasticsearch/Endpoints/Ingest/Simulate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Ingest;
 
 use Elasticsearch\Common\Exceptions;

--- a/src/Elasticsearch/Endpoints/MPercolate.php
+++ b/src/Elasticsearch/Endpoints/MPercolate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 use Elasticsearch\Serializers\SerializerInterface;

--- a/src/Elasticsearch/Endpoints/MTermVectors.php
+++ b/src/Elasticsearch/Endpoints/MTermVectors.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 use Elasticsearch\Common\Exceptions;

--- a/src/Elasticsearch/Endpoints/Mget.php
+++ b/src/Elasticsearch/Endpoints/Mget.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 use Elasticsearch\Common\Exceptions;

--- a/src/Elasticsearch/Endpoints/Msearch.php
+++ b/src/Elasticsearch/Endpoints/Msearch.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 use Elasticsearch\Common\Exceptions;

--- a/src/Elasticsearch/Endpoints/MsearchTemplate.php
+++ b/src/Elasticsearch/Endpoints/MsearchTemplate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 use Elasticsearch\Common\Exceptions;

--- a/src/Elasticsearch/Endpoints/Percolate.php
+++ b/src/Elasticsearch/Endpoints/Percolate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 use Elasticsearch\Common\Exceptions;

--- a/src/Elasticsearch/Endpoints/Ping.php
+++ b/src/Elasticsearch/Endpoints/Ping.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 /**

--- a/src/Elasticsearch/Endpoints/Reindex.php
+++ b/src/Elasticsearch/Endpoints/Reindex.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 /**

--- a/src/Elasticsearch/Endpoints/Remote/Info.php
+++ b/src/Elasticsearch/Endpoints/Remote/Info.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Remote;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/RenderSearchTemplate.php
+++ b/src/Elasticsearch/Endpoints/RenderSearchTemplate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Script/Delete.php
+++ b/src/Elasticsearch/Endpoints/Script/Delete.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Script;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Script/Get.php
+++ b/src/Elasticsearch/Endpoints/Script/Get.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Script;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Script/Put.php
+++ b/src/Elasticsearch/Endpoints/Script/Put.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Script;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Scroll.php
+++ b/src/Elasticsearch/Endpoints/Scroll.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 use Elasticsearch\Common\Exceptions;

--- a/src/Elasticsearch/Endpoints/Search.php
+++ b/src/Elasticsearch/Endpoints/Search.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 use Elasticsearch\Common\Exceptions\InvalidArgumentException;

--- a/src/Elasticsearch/Endpoints/SearchShards.php
+++ b/src/Elasticsearch/Endpoints/SearchShards.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 /**

--- a/src/Elasticsearch/Endpoints/SearchTemplate.php
+++ b/src/Elasticsearch/Endpoints/SearchTemplate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 use Elasticsearch\Common\Exceptions\InvalidArgumentException;

--- a/src/Elasticsearch/Endpoints/Snapshot/Create.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Create.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Snapshot;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Snapshot/Delete.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Delete.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Snapshot;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Snapshot/Get.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Get.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Snapshot;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Snapshot/Repository/Create.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Repository/Create.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Snapshot\Repository;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Snapshot/Repository/Delete.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Repository/Delete.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Snapshot\Repository;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Snapshot/Repository/Get.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Repository/Get.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Snapshot\Repository;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Snapshot/Repository/Verify.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Repository/Verify.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Snapshot\Repository;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Snapshot/Restore.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Restore.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Snapshot;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Snapshot/Status.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Status.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Snapshot;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Source/Get.php
+++ b/src/Elasticsearch/Endpoints/Source/Get.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Source;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Suggest.php
+++ b/src/Elasticsearch/Endpoints/Suggest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 use Elasticsearch\Common\Exceptions;

--- a/src/Elasticsearch/Endpoints/Tasks/Cancel.php
+++ b/src/Elasticsearch/Endpoints/Tasks/Cancel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Tasks;
 
 use Elasticsearch\Common\Exceptions;

--- a/src/Elasticsearch/Endpoints/Tasks/Get.php
+++ b/src/Elasticsearch/Endpoints/Tasks/Get.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Tasks;
 
 use Elasticsearch\Common\Exceptions;

--- a/src/Elasticsearch/Endpoints/Tasks/TasksList.php
+++ b/src/Elasticsearch/Endpoints/Tasks/TasksList.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Tasks;
 
 use Elasticsearch\Common\Exceptions;

--- a/src/Elasticsearch/Endpoints/Template/Delete.php
+++ b/src/Elasticsearch/Endpoints/Template/Delete.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Template;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/Template/Get.php
+++ b/src/Elasticsearch/Endpoints/Template/Get.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints\Template;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Endpoints/TermVectors.php
+++ b/src/Elasticsearch/Endpoints/TermVectors.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 use Elasticsearch\Common\Exceptions;

--- a/src/Elasticsearch/Endpoints/Update.php
+++ b/src/Elasticsearch/Endpoints/Update.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 use Elasticsearch\Common\Exceptions;

--- a/src/Elasticsearch/Endpoints/UpdateByQuery.php
+++ b/src/Elasticsearch/Endpoints/UpdateByQuery.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Endpoints;
 
 use Elasticsearch\Common\Exceptions;

--- a/src/Elasticsearch/Helper/Iterators/SearchHitIterator.php
+++ b/src/Elasticsearch/Helper/Iterators/SearchHitIterator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Helper\Iterators;
 
 use Iterator;

--- a/src/Elasticsearch/Helper/Iterators/SearchResponseIterator.php
+++ b/src/Elasticsearch/Helper/Iterators/SearchResponseIterator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Helper\Iterators;
 
 use ElasticSearch\Client;

--- a/src/Elasticsearch/Namespaces/AbstractNamespace.php
+++ b/src/Elasticsearch/Namespaces/AbstractNamespace.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Namespaces;
 
 use Elasticsearch\Endpoints\AbstractEndpoint;

--- a/src/Elasticsearch/Namespaces/BooleanRequestWrapper.php
+++ b/src/Elasticsearch/Namespaces/BooleanRequestWrapper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Namespaces;
 
 use Elasticsearch\Common\Exceptions\Missing404Exception;

--- a/src/Elasticsearch/Namespaces/CatNamespace.php
+++ b/src/Elasticsearch/Namespaces/CatNamespace.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Namespaces;
 
 /**

--- a/src/Elasticsearch/Namespaces/ClusterNamespace.php
+++ b/src/Elasticsearch/Namespaces/ClusterNamespace.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Namespaces;
 
 /**

--- a/src/Elasticsearch/Namespaces/IndicesNamespace.php
+++ b/src/Elasticsearch/Namespaces/IndicesNamespace.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Namespaces;
 
 /**

--- a/src/Elasticsearch/Namespaces/IngestNamespace.php
+++ b/src/Elasticsearch/Namespaces/IngestNamespace.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Namespaces;
 
 use Elasticsearch\Endpoints\Ingest\Pipeline\Delete;

--- a/src/Elasticsearch/Namespaces/NamespaceBuilderInterface.php
+++ b/src/Elasticsearch/Namespaces/NamespaceBuilderInterface.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types = 1);
 /**
  * Class RegisteredNamespaceInterface
  *

--- a/src/Elasticsearch/Namespaces/NodesNamespace.php
+++ b/src/Elasticsearch/Namespaces/NodesNamespace.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Namespaces;
 
 /**

--- a/src/Elasticsearch/Namespaces/RemoteNamespace.php
+++ b/src/Elasticsearch/Namespaces/RemoteNamespace.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Namespaces;
 
 use Elasticsearch\Endpoints\Remote\Info;

--- a/src/Elasticsearch/Namespaces/SnapshotNamespace.php
+++ b/src/Elasticsearch/Namespaces/SnapshotNamespace.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Namespaces;
 
 /**

--- a/src/Elasticsearch/Namespaces/TasksNamespace.php
+++ b/src/Elasticsearch/Namespaces/TasksNamespace.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Namespaces;
 
 use Elasticsearch\Endpoints\Tasks\Cancel;

--- a/src/Elasticsearch/Serializers/ArrayToJSONSerializer.php
+++ b/src/Elasticsearch/Serializers/ArrayToJSONSerializer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Serializers;
 
 use Elasticsearch\Common\Exceptions\RuntimeException;

--- a/src/Elasticsearch/Serializers/EverythingToJSONSerializer.php
+++ b/src/Elasticsearch/Serializers/EverythingToJSONSerializer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Serializers;
 
 use Elasticsearch\Common\Exceptions\RuntimeException;

--- a/src/Elasticsearch/Serializers/SerializerInterface.php
+++ b/src/Elasticsearch/Serializers/SerializerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Serializers;
 
 /**

--- a/src/Elasticsearch/Serializers/SmartSerializer.php
+++ b/src/Elasticsearch/Serializers/SmartSerializer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch\Serializers;
 
 use Elasticsearch\Common\Exceptions;

--- a/src/Elasticsearch/Transport.php
+++ b/src/Elasticsearch/Transport.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Elasticsearch;
 
 use Elasticsearch\Common\Exceptions;


### PR DESCRIPTION
This PR adds `declare(strict_types = 1);` to all classes in `src/`.

It it a potencial BC break for users that were passing incorrect types as parameters to something in `elasticsearch-php`. But I think that reporting the potential bugs (caused by by unintentional type conversion) is good anyway.