### PR TITLE
[travis] use very specific ES version for build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,20 +18,20 @@ matrix:
   fast_finish: true
   include:
     - php: 7.0
-      env: ES_VERSION="6.0"
+      env: ES_VERSION="6.0.1"
     - php: 7.0
-      env: ES_VERSION="6.x"
+      env: ES_VERSION="6.1.1"
 
     - php: 7.1
-      env: ES_VERSION="6.0"
+      env: ES_VERSION="6.0.1"
     - php: 7.1
-      env: ES_VERSION="6.x"
+      env: ES_VERSION="6.1.1"
 
     - php: 7.2
-      env: ES_VERSION="6.0"
+      env: ES_VERSION="6.0.1"
 
   allow_failures:
-    - env: ES_VERSION="6.x"
+    - env: ES_VERSION="6.1.1"
 
 env:
   global:

--- a/travis/download_and_run_es.sh
+++ b/travis/download_and_run_es.sh
@@ -10,12 +10,14 @@ which java
 java -version
 
 
-echo "Downloading Elasticsearch v${ES_VERSION}-SNAPSHOT..."
+echo "Downloading Elasticsearch v${ES_VERSION}..."
 
-ES_URL=$(curl -sS "https://esvm-props.kibana.rocks/builds" | jq -r ".branches[\"$ES_VERSION\"].zip")
+ES_URL=$(curl -sS "https://esvm-props.kibana.rocks/builds" | jq -r ".releases[\"$ES_VERSION\"].zip")
 
-curl -L -o elasticsearch-latest-SNAPSHOT.zip $ES_URL
-unzip "elasticsearch-latest-SNAPSHOT.zip"
+echo "Downloading from ${ES_URL}"
+
+curl -L -o elasticsearch-latest.zip $ES_URL
+unzip "elasticsearch-latest.zip"
 
 echo "Adding repo to config..."
 find . -name "elasticsearch.yml" | while read TXT ; do echo 'repositories.url.allowed_urls: ["http://*"]' >> $TXT ; done


### PR DESCRIPTION
This changes the Travis build, so it uses ES releases for builds instead of snapshots.

It started to fail because for some reason, commit from which the snapshot was build, was not available in the ES repository anymore ([See the Travis log](https://travis-ci.org/mhujer/elasticsearch-php/jobs/322340609))