### PR TITLE
fix DeleteByQuery param white list

### DIFF
--- a/src/Elasticsearch/Endpoints/DeleteByQuery.php
+++ b/src/Elasticsearch/Endpoints/DeleteByQuery.php
@@ -73,6 +73,7 @@ class DeleteByQuery extends AbstractEndpoint
             'lenient',
             'preference',
             'query',
+            'q',
             'refresh',
             'request_cache',
             'requests_per_second',


### PR DESCRIPTION
method delete_by_query can use the q parameter in the same way as the search api