### PR TITLE
Fix Snapshot::getURI() implementation

### DIFF
--- a/src/Elasticsearch/Endpoints/Snapshot/AbstractSnapshotEndpoint.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/AbstractSnapshotEndpoint.php
@@ -1,0 +1,121 @@
+<?php
+declare(strict_types = 1);
+
+namespace Elasticsearch\Endpoints\Snapshot;
+
+use Elasticsearch\Endpoints\AbstractEndpoint;
+use Elasticsearch\Common\Exceptions;
+
+/**
+ * Abstract cass for Snapshot operations
+ *
+ * @category Elasticsearch
+ * @package  Elasticsearch\Endpoints\Snapshot
+ * @author   Emanuele Panzeri <thepanz@gmail.com>
+ * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
+ * @link     http://elastic.co
+ */
+abstract class AbstractSnapshotEndpoint extends AbstractEndpoint
+{
+    /**
+     * @var string
+     */
+    protected $baseUrl = '/_snapshot/{repository}/{snapshot}';
+
+    /**
+     * The repository name
+     *
+     * @var string
+     */
+    protected $repository;
+
+    /**
+     * The snapshot name
+     *
+     * @var string
+     */
+    protected $snapshot;
+
+    /**
+     * @param string $repository
+     *
+     * @return $this
+     */
+    public function setRepository($repository): self
+    {
+        $this->repository = $repository;
+
+        return $this;
+    }
+
+    /**
+     * @param string $snapshot
+     *
+     * @return $this
+     */
+    public function setSnapshot($snapshot): self
+    {
+        $this->snapshot = $snapshot;
+
+        return $this;
+    }
+
+    /**
+     * @throws Exceptions\RuntimeException
+     * @return string
+     */
+    public function getURI()
+    {
+        $this->ensureRepositoryAndSnapshot();
+
+        return $this->buildUrl();
+    }
+
+    /**
+     * @throws Exceptions\RuntimeException
+     */
+    protected function ensureRepositoryAndSnapshot()
+    {
+        $this->ensureRepository();
+        $this->ensureSnapshot();
+    }
+
+    protected function buildUrlParameters(): array
+    {
+        return [
+            '{repository}' => $this->repository,
+            '{snapshot}' => $this->snapshot,
+        ];
+    }
+
+    protected function buildUrl(): string
+    {
+        $parameters = $this->buildUrlParameters();
+
+        return str_replace(array_keys($parameters), $parameters, $this->baseUrl);
+    }
+
+    /**
+     * @throws Exceptions\RuntimeException
+     */
+    protected function ensureRepository()
+    {
+        if (empty($this->repository)) {
+            throw new Exceptions\RuntimeException(
+                'The "repository" parameter is required'
+            );
+        }
+    }
+
+    /**
+     * @throws Exceptions\RuntimeException
+     */
+    protected function ensureSnapshot()
+    {
+        if (empty($this->snapshot)) {
+            throw new Exceptions\RuntimeException(
+                'The "snapshot" parameter is required'
+            );
+        }
+    }
+}

--- a/src/Elasticsearch/Endpoints/Snapshot/Create.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Create.php
@@ -4,11 +4,9 @@ declare(strict_types = 1);
 
 namespace Elasticsearch\Endpoints\Snapshot;
 
-use Elasticsearch\Endpoints\AbstractEndpoint;
-use Elasticsearch\Common\Exceptions;
-
 /**
- * Class Create
+ * Snapshot Create endpoint.
+ *
  *
  * @category Elasticsearch
  * @package  Elasticsearch\Endpoints\Snapshot
@@ -16,102 +14,19 @@ use Elasticsearch\Common\Exceptions;
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elastic.co
  */
-class Create extends AbstractEndpoint
+class Create extends AbstractSnapshotEndpoint
 {
-    /**
-     * A repository name
-     *
-     * @var string
-     */
-    private $repository;
-
-    /**
-     * A snapshot name
-     *
-     * @var string
-     */
-    private $snapshot;
-
-    /**
-     * @param array $body
-     *
-     * @throws \Elasticsearch\Common\Exceptions\InvalidArgumentException
-     * @return $this
-     */
-    public function setBody($body)
+    public function setBody($body): self
     {
-        if (isset($body) !== true) {
-            return $this;
-        }
-
         $this->body = $body;
 
         return $this;
     }
 
     /**
-     * @param string $repository
-     *
-     * @return $this
-     */
-    public function setRepository($repository)
-    {
-        if (isset($repository) !== true) {
-            return $this;
-        }
-
-        $this->repository = $repository;
-
-        return $this;
-    }
-
-    /**
-     * @param string $snapshot
-     *
-     * @return $this
-     */
-    public function setSnapshot($snapshot)
-    {
-        if (isset($snapshot) !== true) {
-            return $this;
-        }
-
-        $this->snapshot = $snapshot;
-
-        return $this;
-    }
-
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
-    {
-        if (isset($this->repository) !== true) {
-            throw new Exceptions\RuntimeException(
-                'repository is required for Create'
-            );
-        }
-        if (isset($this->snapshot) !== true) {
-            throw new Exceptions\RuntimeException(
-                'snapshot is required for Create'
-            );
-        }
-        $repository = $this->repository;
-        $snapshot = $this->snapshot;
-        $uri   = "/_snapshot/$repository/$snapshot";
-
-        if (isset($repository) === true && isset($snapshot) === true) {
-            $uri = "/_snapshot/$repository/$snapshot";
-        }
-
-        return $uri;
-    }
-
-    /**
      * @return string[]
      */
-    public function getParamWhitelist()
+    public function getParamWhitelist(): array
     {
         return array(
             'master_timeout',
@@ -119,10 +34,7 @@ class Create extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+    public function getMethod(): string
     {
         return 'PUT';
     }

--- a/src/Elasticsearch/Endpoints/Snapshot/Delete.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Delete.php
@@ -4,11 +4,8 @@ declare(strict_types = 1);
 
 namespace Elasticsearch\Endpoints\Snapshot;
 
-use Elasticsearch\Endpoints\AbstractEndpoint;
-use Elasticsearch\Common\Exceptions;
-
 /**
- * Class Delete
+ * Snapshot Delete endpoint.
  *
  * @category Elasticsearch
  * @package  Elasticsearch\Endpoints\Snapshot
@@ -16,81 +13,8 @@ use Elasticsearch\Common\Exceptions;
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elastic.co
  */
-class Delete extends AbstractEndpoint
+class Delete extends AbstractSnapshotEndpoint
 {
-    /**
-     * A repository name
-     *
-     * @var string
-     */
-    private $repository;
-
-    /**
-     * A snapshot name
-     *
-     * @var string
-     */
-    private $snapshot;
-
-    /**
-     * @param string $repository
-     *
-     * @return $this
-     */
-    public function setRepository($repository)
-    {
-        if (isset($repository) !== true) {
-            return $this;
-        }
-
-        $this->repository = $repository;
-
-        return $this;
-    }
-
-    /**
-     * @param string $snapshot
-     *
-     * @return $this
-     */
-    public function setSnapshot($snapshot)
-    {
-        if (isset($snapshot) !== true) {
-            return $this;
-        }
-
-        $this->snapshot = $snapshot;
-
-        return $this;
-    }
-
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
-    {
-        if (isset($this->repository) !== true) {
-            throw new Exceptions\RuntimeException(
-                'repository is required for Delete'
-            );
-        }
-        if (isset($this->snapshot) !== true) {
-            throw new Exceptions\RuntimeException(
-                'snapshot is required for Delete'
-            );
-        }
-        $repository = $this->repository;
-        $snapshot = $this->snapshot;
-        $uri   = "/_snapshot/$repository/$snapshot";
-
-        if (isset($repository) === true && isset($snapshot) === true) {
-            $uri = "/_snapshot/$repository/$snapshot";
-        }
-
-        return $uri;
-    }
-
     /**
      * @return string[]
      */
@@ -101,10 +25,7 @@ class Delete extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+    public function getMethod(): string
     {
         return 'DELETE';
     }

--- a/src/Elasticsearch/Endpoints/Snapshot/Get.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Get.php
@@ -4,11 +4,8 @@ declare(strict_types = 1);
 
 namespace Elasticsearch\Endpoints\Snapshot;
 
-use Elasticsearch\Endpoints\AbstractEndpoint;
-use Elasticsearch\Common\Exceptions;
-
 /**
- * Class Get
+ * Snapshot Get endpoint.
  *
  * @category Elasticsearch
  * @package  Elasticsearch\Endpoints\Snapshot
@@ -16,85 +13,12 @@ use Elasticsearch\Common\Exceptions;
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elastic.co
  */
-class Get extends AbstractEndpoint
+class Get extends AbstractSnapshotEndpoint
 {
-    /**
-     * A comma-separated list of repository names
-     *
-     * @var string
-     */
-    private $repository;
-
-    /**
-     * A comma-separated list of snapshot names
-     *
-     * @var string
-     */
-    private $snapshot;
-
-    /**
-     * @param string $repository
-     *
-     * @return $this
-     */
-    public function setRepository($repository)
-    {
-        if (isset($repository) !== true) {
-            return $this;
-        }
-
-        $this->repository = $repository;
-
-        return $this;
-    }
-
-    /**
-     * @param string $snapshot
-     *
-     * @return $this
-     */
-    public function setSnapshot($snapshot)
-    {
-        if (isset($snapshot) !== true) {
-            return $this;
-        }
-
-        $this->snapshot = $snapshot;
-
-        return $this;
-    }
-
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
-    {
-        if (isset($this->repository) !== true) {
-            throw new Exceptions\RuntimeException(
-                'repository is required for Get'
-            );
-        }
-        if (isset($this->snapshot) !== true) {
-            throw new Exceptions\RuntimeException(
-                'snapshot is required for Get'
-            );
-        }
-        $repository = $this->repository;
-        $snapshot = $this->snapshot;
-        $uri   = "/_snapshot/$repository/$snapshot";
-
-        if (isset($repository) === true && isset($snapshot) === true) {
-            $uri = "/_snapshot/$repository/$snapshot";
-        }
-
-        return $uri;
-    }
-
     /**
      * @return string[]
      */
-    public function getParamWhitelist()
+    public function getParamWhitelist(): array
     {
         return array(
             'master_timeout',
@@ -103,10 +27,7 @@ class Get extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Snapshot/Restore.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Restore.php
@@ -4,11 +4,8 @@ declare(strict_types = 1);
 
 namespace Elasticsearch\Endpoints\Snapshot;
 
-use Elasticsearch\Endpoints\AbstractEndpoint;
-use Elasticsearch\Common\Exceptions;
-
 /**
- * Class Restore
+ * Snapshot Restore endpoint.
  *
  * @category Elasticsearch
  * @package  Elasticsearch\Endpoints\Snapshot
@@ -16,101 +13,21 @@ use Elasticsearch\Common\Exceptions;
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elastic.co
  */
-class Restore extends AbstractEndpoint
+class Restore extends AbstractSnapshotEndpoint
 {
-    /**
-     * A repository name
-     *
-     * @var string
-     */
-    private $repository;
+    protected $baseUrl = '/_snapshot/{repository}/{snapshot}/_restore';
 
-    /**
-     * A snapshot name
-     *
-     * @var string
-     */
-    private $snapshot;
-
-    /**
-     * @param array $body
-     *
-     * @return $this
-     */
-    public function setBody($body)
+    public function setBody($body): self
     {
-        if (isset($body) !== true) {
-            return $this;
-        }
-
         $this->body = $body;
 
         return $this;
     }
 
     /**
-     * @param string $repository
-     *
-     * @return $this
-     */
-    public function setRepository($repository)
-    {
-        if (isset($repository) !== true) {
-            return $this;
-        }
-
-        $this->repository = $repository;
-
-        return $this;
-    }
-
-    /**
-     * @param string $snapshot
-     *
-     * @return $this
-     */
-    public function setSnapshot($snapshot)
-    {
-        if (isset($snapshot) !== true) {
-            return $this;
-        }
-
-        $this->snapshot = $snapshot;
-
-        return $this;
-    }
-
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
-    {
-        if (isset($this->repository) !== true) {
-            throw new Exceptions\RuntimeException(
-                'repository is required for Restore'
-            );
-        }
-        if (isset($this->snapshot) !== true) {
-            throw new Exceptions\RuntimeException(
-                'snapshot is required for Restore'
-            );
-        }
-        $repository = $this->repository;
-        $snapshot = $this->snapshot;
-        $uri   = "/_snapshot/$repository/$snapshot/_restore";
-
-        if (isset($repository) === true && isset($snapshot) === true) {
-            $uri = "/_snapshot/$repository/$snapshot/_restore";
-        }
-
-        return $uri;
-    }
-
-    /**
      * @return string[]
      */
-    public function getParamWhitelist()
+    public function getParamWhitelist(): array
     {
         return array(
             'master_timeout',
@@ -118,10 +35,7 @@ class Restore extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+    public function getMethod(): string
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Snapshot/Status.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Status.php
@@ -4,11 +4,10 @@ declare(strict_types = 1);
 
 namespace Elasticsearch\Endpoints\Snapshot;
 
-use Elasticsearch\Endpoints\AbstractEndpoint;
 use Elasticsearch\Common\Exceptions;
 
 /**
- * Class Status
+ * Snapshot Status endpoint.
  *
  * @category Elasticsearch
  * @package  Elasticsearch\Endpoints\Snapshot
@@ -16,83 +15,39 @@ use Elasticsearch\Common\Exceptions;
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elastic.co
  */
-class Status extends AbstractEndpoint
+class Status extends AbstractSnapshotEndpoint
 {
-    /**
-     * A comma-separated list of repository names
-     *
-     * @var string
-     */
-    private $repository;
+
+    protected $baseUrl = '/_snapshot/{repository}{snapshot}/_status';
 
     /**
-     * A comma-separated list of snapshot names
-     *
-     * @var string
+     * @throws Exceptions\RuntimeException
      */
-    private $snapshot;
-
-    /**
-     * @param string $repository
-     *
-     * @return $this
-     */
-    public function setRepository($repository)
+    public function getURI(): string
     {
-        if (isset($repository) !== true) {
-            return $this;
+        if (empty($this->repository) && empty($this->snapshot)) {
+            return '/_snapshot/_status';
         }
 
-        $this->repository = $repository;
+        $this->ensureRepository();
 
-        return $this;
+        return $this->buildUrl();
     }
 
-    /**
-     * @param string $snapshot
-     *
-     * @return $this
-     */
-    public function setSnapshot($snapshot)
+    protected function buildUrlParameters(): array
     {
-        if (isset($snapshot) !== true) {
-            return $this;
+        $parameters = parent::buildUrlParameters();
+        if (!empty($this->snapshot)) {
+            $parameters['{snapshot}'] = '/'.$parameters['{snapshot}'];
         }
 
-        $this->snapshot = $snapshot;
-
-        return $this;
-    }
-
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
-    {
-        if (isset($this->snapshot) === true && isset($this->repository) !== true) {
-            throw new Exceptions\RuntimeException(
-                'Repository param must be provided if snapshot param is set'
-            );
-        }
-
-        $repository = $this->repository;
-        $snapshot   = $this->snapshot;
-        $uri        = "/_snapshot/_status";
-
-        if (isset($repository) === true && isset($snapshot) === true) {
-            $uri = "/_snapshot/$repository/$snapshot/_status";
-        } elseif (isset($repository) === true) {
-            $uri = "/_snapshot/$repository/_status";
-        }
-
-        return $uri;
+        return $parameters;
     }
 
     /**
      * @return string[]
      */
-    public function getParamWhitelist()
+    public function getParamWhitelist(): array
     {
         return array(
             'master_timeout',
@@ -100,10 +55,7 @@ class Status extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+    public function getMethod(): string
     {
         return 'GET';
     }


### PR DESCRIPTION
- [x] the $uri is always returned, plus the repository and snapshot values are double checked
- [x] the isset() returns `true` even when the value is `null` or an empty string
- [x] avoid not setting $repository or $snapshot if the provided value is empty. It could cause errors if the endpoint class is reused