### PR TITLE
Build also against ES 6.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ matrix:
     - php: 7.2
       env: ES_VERSION="6.2"
     - php: 7.2
+      env: ES_VERSION="6.3"
+    - php: 7.2
       env: ES_VERSION="6.x"
 
   allow_failures:


### PR DESCRIPTION
Let's see if the build passes.

ES 6.3 was released yesterday: https://www.elastic.co/blog/elasticsearch-6-3-0-released

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you signed [Contributor License Agreement](http://www.elasticsearch.org/contributor-agreement/)?
PR's (no matter how small) cannot be merged until the CLA has been signed.  It only needs to be signed once,
however.

- Have you read the [Contributing Guidelines](https://github.com/elastic/elasticsearch-php/blob/master/.github/CONTRIBUTING.md)?

If you answered yes to both, thanks for the PR and we'll get to it ASAP! :)

-->