### PR TITLE
The port should be specified in CURLOPT_PORT

### DIFF
--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -121,12 +121,14 @@ class Connection implements ConnectionInterface
             $connectionParams['client']['curl'][CURLOPT_USERPWD] = $hostDetails['user'].':'.$hostDetails['pass'];
         }
 
+        $connectionParams['client']['curl'][CURLOPT_PORT] = $hostDetails['port'];
+
         if (isset($connectionParams['client']['headers']) === true) {
             $this->headers = $connectionParams['client']['headers'];
             unset($connectionParams['client']['headers']);
         }
 
-        $host = $hostDetails['host'].':'.$hostDetails['port'];
+        $host = $hostDetails['host'];
         $path = null;
         if (isset($hostDetails['path']) === true) {
             $path = $hostDetails['path'];


### PR DESCRIPTION
Rather than including the port in the host, which also makes the host header include the port, the port should be assigned using the CURLOPT_PORT option.