### PR TITLE
Ports should be specified in CURLOPT_PORT, not in the host

### DIFF
--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -638,7 +638,7 @@ class ClientBuilder
             $host['scheme'] = 'http';
         }
         if (isset($host['port']) === false) {
-            $host['port'] = '9200';
+            $host['port'] = 9200;
         }
         return $host;
     }

--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -519,9 +519,6 @@ class Connection implements ConnectionInterface
     {
         return $this->host;
     }
-    
-    /**
-    
 
     /**
      * @return null|string

--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -58,6 +58,11 @@ class Connection implements ConnectionInterface
      * @var string|null
      */
     protected $path;
+    
+    /**
+    * @var int
+    */
+    protected $port;
 
     /**
      * @var LoggerInterface
@@ -133,8 +138,11 @@ class Connection implements ConnectionInterface
         if (isset($hostDetails['path']) === true) {
             $path = $hostDetails['path'];
         }
+        $port = $hostDetails['port'];
+        
         $this->host             = $host;
         $this->path             = $path;
+        $this->port             = $port;
         $this->log              = $log;
         $this->trace            = $trace;
         $this->connectionParams = $connectionParams;
@@ -511,6 +519,9 @@ class Connection implements ConnectionInterface
     {
         return $this->host;
     }
+    
+    /**
+    
 
     /**
      * @return null|string
@@ -529,6 +540,14 @@ class Connection implements ConnectionInterface
     public function getPath()
     {
         return $this->path;
+    }
+    
+    /**
+     * @return int
+     */
+    public function getPort()
+    {
+        return $this->port;
     }
 
     /**

--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -121,12 +121,14 @@ class Connection implements ConnectionInterface
             $connectionParams['client']['curl'][CURLOPT_USERPWD] = $hostDetails['user'].':'.$hostDetails['pass'];
         }
 
+        $connectionParams['client']['curl'][CURLOPT_PORT] = $hostDetails['port'];
+
         if (isset($connectionParams['client']['headers']) === true) {
             $this->headers = $connectionParams['client']['headers'];
             unset($connectionParams['client']['headers']);
         }
 
-        $host = $hostDetails['host'].':'.$hostDetails['port'];
+        $host = $hostDetails['host'];
         $path = null;
         if (isset($hostDetails['path']) === true) {
             $path = $hostDetails['path'];

--- a/src/Elasticsearch/Connections/ConnectionInterface.php
+++ b/src/Elasticsearch/Connections/ConnectionInterface.php
@@ -51,6 +51,13 @@ interface ConnectionInterface
     public function getHost();
 
     /**
+     * Get the port for this connection
+     *
+     * @return int
+     */
+    public function getPort();
+
+    /**
      * Get the username:password string for this connection, null if not set
      *
      * @return null|string

--- a/tests/Elasticsearch/Tests/ClientTest.php
+++ b/tests/Elasticsearch/Tests/ClientTest.php
@@ -277,6 +277,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         ])->build();
         $host = $client->transport->getConnection();
         $this->assertSame("localhost", $host->getHost());
+        $this->assertSame("9200", $host->getPort());
         $this->assertSame("http", $host->getTransportSchema());
 
 
@@ -285,6 +286,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         ])->build();
         $host = $client->transport->getConnection();
         $this->assertSame("localhost", $host->getHost());
+        $this->assertSame("9200", $host->getPort());
         $this->assertSame("http", $host->getTransportSchema());
 
         $client = Elasticsearch\ClientBuilder::create()->setHosts([
@@ -292,6 +294,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         ])->build();
         $host = $client->transport->getConnection();
         $this->assertSame("foo.com", $host->getHost());
+        $this->assertSame("9200", $host->getPort());
         $this->assertSame("http", $host->getTransportSchema());
 
         $client = Elasticsearch\ClientBuilder::create()->setHosts([
@@ -299,6 +302,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         ])->build();
         $host = $client->transport->getConnection();
         $this->assertSame("foo.com", $host->getHost());
+        $this->assertSame("9200", $host->getPort());
         $this->assertSame("https", $host->getTransportSchema());
 
 
@@ -307,6 +311,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         ])->build();
         $host = $client->transport->getConnection();
         $this->assertSame("foo.com", $host->getHost());
+        $this->assertSame("9200", $host->getPort());
         $this->assertSame("https", $host->getTransportSchema());
         $this->assertSame("user:pass", $host->getUserPass());
     }
@@ -322,6 +327,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         ])->build();
         $host = $client->transport->getConnection();
         $this->assertSame("localhost", $host->getHost());
+        $this->assertSame("9200", $host->getPort());
         $this->assertSame("http", $host->getTransportSchema());
 
 
@@ -334,6 +340,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         ])->build();
         $host = $client->transport->getConnection();
         $this->assertSame("foo.com", $host->getHost());
+        $this->assertSame("9200", $host->getPort());
         $this->assertSame("http", $host->getTransportSchema());
 
 
@@ -346,6 +353,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         ])->build();
         $host = $client->transport->getConnection();
         $this->assertSame("foo.com", $host->getHost());
+        $this->assertSame("9200", $host->getPort());
         $this->assertSame("https", $host->getTransportSchema());
 
 
@@ -357,6 +365,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         ])->build();
         $host = $client->transport->getConnection();
         $this->assertSame("foo.com", $host->getHost());
+        $this->assertSame("9200", $host->getPort());
         $this->assertSame("http", $host->getTransportSchema());
 
 
@@ -367,6 +376,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         ])->build();
         $host = $client->transport->getConnection();
         $this->assertSame("foo.com", $host->getHost());
+        $this->assertSame("9200", $host->getPort());
         $this->assertSame("http", $host->getTransportSchema());
 
 
@@ -379,6 +389,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         ])->build();
         $host = $client->transport->getConnection();
         $this->assertSame("foo.com", $host->getHost());
+        $this->assertSame("9500", $host->getPort());
         $this->assertSame("https", $host->getTransportSchema());
 
 
@@ -402,6 +413,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         ])->build();
         $host = $client->transport->getConnection();
         $this->assertSame("the_foo.com", $host->getHost());
+        $this->assertSame("9200", $host->getPort());
         $this->assertSame("http", $host->getTransportSchema());
 
 
@@ -415,6 +427,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         ])->build();
         $host = $client->transport->getConnection();
         $this->assertSame("foo.com", $host->getHost());
+        $this->assertSame("9200", $host->getPort());
         $this->assertSame("http", $host->getTransportSchema());
         $this->assertSame("user:abc#$@?%!abc", $host->getUserPass());
     }

--- a/tests/Elasticsearch/Tests/ClientTest.php
+++ b/tests/Elasticsearch/Tests/ClientTest.php
@@ -277,7 +277,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         ])->build();
         $host = $client->transport->getConnection();
         $this->assertSame("localhost", $host->getHost());
-        $this->assertSame("9200", $host->getPort());
+        $this->assertSame(9200, $host->getPort());
         $this->assertSame("http", $host->getTransportSchema());
 
 
@@ -286,7 +286,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         ])->build();
         $host = $client->transport->getConnection();
         $this->assertSame("localhost", $host->getHost());
-        $this->assertSame("9200", $host->getPort());
+        $this->assertSame(9200, $host->getPort());
         $this->assertSame("http", $host->getTransportSchema());
 
         $client = Elasticsearch\ClientBuilder::create()->setHosts([
@@ -294,7 +294,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         ])->build();
         $host = $client->transport->getConnection();
         $this->assertSame("foo.com", $host->getHost());
-        $this->assertSame("9200", $host->getPort());
+        $this->assertSame(9200, $host->getPort());
         $this->assertSame("http", $host->getTransportSchema());
 
         $client = Elasticsearch\ClientBuilder::create()->setHosts([
@@ -302,7 +302,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         ])->build();
         $host = $client->transport->getConnection();
         $this->assertSame("foo.com", $host->getHost());
-        $this->assertSame("9200", $host->getPort());
+        $this->assertSame(9200, $host->getPort());
         $this->assertSame("https", $host->getTransportSchema());
 
 
@@ -311,7 +311,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         ])->build();
         $host = $client->transport->getConnection();
         $this->assertSame("foo.com", $host->getHost());
-        $this->assertSame("9200", $host->getPort());
+        $this->assertSame(9200, $host->getPort());
         $this->assertSame("https", $host->getTransportSchema());
         $this->assertSame("user:pass", $host->getUserPass());
     }
@@ -327,7 +327,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         ])->build();
         $host = $client->transport->getConnection();
         $this->assertSame("localhost", $host->getHost());
-        $this->assertSame("9200", $host->getPort());
+        $this->assertSame(9200, $host->getPort());
         $this->assertSame("http", $host->getTransportSchema());
 
 
@@ -340,7 +340,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         ])->build();
         $host = $client->transport->getConnection();
         $this->assertSame("foo.com", $host->getHost());
-        $this->assertSame("9200", $host->getPort());
+        $this->assertSame(9200, $host->getPort());
         $this->assertSame("http", $host->getTransportSchema());
 
 
@@ -353,7 +353,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         ])->build();
         $host = $client->transport->getConnection();
         $this->assertSame("foo.com", $host->getHost());
-        $this->assertSame("9200", $host->getPort());
+        $this->assertSame(9200, $host->getPort());
         $this->assertSame("https", $host->getTransportSchema());
 
 
@@ -365,7 +365,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         ])->build();
         $host = $client->transport->getConnection();
         $this->assertSame("foo.com", $host->getHost());
-        $this->assertSame("9200", $host->getPort());
+        $this->assertSame(9200, $host->getPort());
         $this->assertSame("http", $host->getTransportSchema());
 
 
@@ -376,7 +376,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         ])->build();
         $host = $client->transport->getConnection();
         $this->assertSame("foo.com", $host->getHost());
-        $this->assertSame("9200", $host->getPort());
+        $this->assertSame(9200, $host->getPort());
         $this->assertSame("http", $host->getTransportSchema());
 
 
@@ -389,7 +389,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         ])->build();
         $host = $client->transport->getConnection();
         $this->assertSame("foo.com", $host->getHost());
-        $this->assertSame("9500", $host->getPort());
+        $this->assertSame(9500, $host->getPort());
         $this->assertSame("https", $host->getTransportSchema());
 
 
@@ -413,7 +413,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         ])->build();
         $host = $client->transport->getConnection();
         $this->assertSame("the_foo.com", $host->getHost());
-        $this->assertSame("9200", $host->getPort());
+        $this->assertSame(9200, $host->getPort());
         $this->assertSame("http", $host->getTransportSchema());
 
 
@@ -427,7 +427,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         ])->build();
         $host = $client->transport->getConnection();
         $this->assertSame("foo.com", $host->getHost());
-        $this->assertSame("9200", $host->getPort());
+        $this->assertSame(9200, $host->getPort());
         $this->assertSame("http", $host->getTransportSchema());
         $this->assertSame("user:abc#$@?%!abc", $host->getUserPass());
     }

--- a/tests/Elasticsearch/Tests/ClientTest.php
+++ b/tests/Elasticsearch/Tests/ClientTest.php
@@ -276,7 +276,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             'localhost:9200'
         ])->build();
         $host = $client->transport->getConnection();
-        $this->assertSame("localhost:9200", $host->getHost());
+        $this->assertSame("localhost", $host->getHost());
         $this->assertSame("http", $host->getTransportSchema());
 
 
@@ -284,21 +284,21 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             'http://localhost:9200'
         ])->build();
         $host = $client->transport->getConnection();
-        $this->assertSame("localhost:9200", $host->getHost());
+        $this->assertSame("localhost", $host->getHost());
         $this->assertSame("http", $host->getTransportSchema());
 
         $client = Elasticsearch\ClientBuilder::create()->setHosts([
             'http://foo.com:9200'
         ])->build();
         $host = $client->transport->getConnection();
-        $this->assertSame("foo.com:9200", $host->getHost());
+        $this->assertSame("foo.com", $host->getHost());
         $this->assertSame("http", $host->getTransportSchema());
 
         $client = Elasticsearch\ClientBuilder::create()->setHosts([
             'https://foo.com:9200'
         ])->build();
         $host = $client->transport->getConnection();
-        $this->assertSame("foo.com:9200", $host->getHost());
+        $this->assertSame("foo.com", $host->getHost());
         $this->assertSame("https", $host->getTransportSchema());
 
 
@@ -306,7 +306,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             'https://user:pass@foo.com:9200'
         ])->build();
         $host = $client->transport->getConnection();
-        $this->assertSame("foo.com:9200", $host->getHost());
+        $this->assertSame("foo.com", $host->getHost());
         $this->assertSame("https", $host->getTransportSchema());
         $this->assertSame("user:pass", $host->getUserPass());
     }
@@ -321,7 +321,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             ]
         ])->build();
         $host = $client->transport->getConnection();
-        $this->assertSame("localhost:9200", $host->getHost());
+        $this->assertSame("localhost", $host->getHost());
         $this->assertSame("http", $host->getTransportSchema());
 
 
@@ -333,7 +333,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             ]
         ])->build();
         $host = $client->transport->getConnection();
-        $this->assertSame("foo.com:9200", $host->getHost());
+        $this->assertSame("foo.com", $host->getHost());
         $this->assertSame("http", $host->getTransportSchema());
 
 
@@ -345,7 +345,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             ]
         ])->build();
         $host = $client->transport->getConnection();
-        $this->assertSame("foo.com:9200", $host->getHost());
+        $this->assertSame("foo.com", $host->getHost());
         $this->assertSame("https", $host->getTransportSchema());
 
 
@@ -356,7 +356,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             ]
         ])->build();
         $host = $client->transport->getConnection();
-        $this->assertSame("foo.com:9200", $host->getHost());
+        $this->assertSame("foo.com", $host->getHost());
         $this->assertSame("http", $host->getTransportSchema());
 
 
@@ -366,7 +366,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             ]
         ])->build();
         $host = $client->transport->getConnection();
-        $this->assertSame("foo.com:9200", $host->getHost());
+        $this->assertSame("foo.com", $host->getHost());
         $this->assertSame("http", $host->getTransportSchema());
 
 
@@ -378,7 +378,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             ]
         ])->build();
         $host = $client->transport->getConnection();
-        $this->assertSame("foo.com:9500", $host->getHost());
+        $this->assertSame("foo.com", $host->getHost());
         $this->assertSame("https", $host->getTransportSchema());
 
 
@@ -401,7 +401,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             ]
         ])->build();
         $host = $client->transport->getConnection();
-        $this->assertSame("the_foo.com:9200", $host->getHost());
+        $this->assertSame("the_foo.com", $host->getHost());
         $this->assertSame("http", $host->getTransportSchema());
 
 
@@ -414,7 +414,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             ]
         ])->build();
         $host = $client->transport->getConnection();
-        $this->assertSame("foo.com:9200", $host->getHost());
+        $this->assertSame("foo.com", $host->getHost());
         $this->assertSame("http", $host->getTransportSchema());
         $this->assertSame("user:abc#$@?%!abc", $host->getUserPass());
     }


### PR DESCRIPTION
Because the host is adding the port, the host header also has the port in it. Instead, the handler should be using CURLOPT_PORT to specify which port is the curl request is being sent on. 

This also affects unit tests that no longer need to verify that the port is in the host name.