### PR TITLE
fix phpdoc about versioning in update() and delete()

### DIFF
--- a/src/Elasticsearch/Client.php
+++ b/src/Elasticsearch/Client.php
@@ -236,6 +236,7 @@ class Client
      *        ['replication']  = (enum) Specific replication type
      *        ['routing']      = (string) Specific routing value
      *        ['timeout']      = (time) Explicit operation timeout
+     *        ['version']      = (number) Explicit version number for concurrency control
      *        ['version_type'] = (enum) Specific version type
      *
      * @param $params array Associative array of parameters
@@ -1080,7 +1081,7 @@ class Client
      *        ['timeout']           = (time) Explicit operation timeout
      *        ['timestamp']         = (time) Explicit timestamp for the document
      *        ['ttl']               = (duration) Expiration time for the document
-     *        ['version_type']      = (number) Explicit version number for concurrency control
+     *        ['version']           = (number) Explicit version number for concurrency control
      *        ['body']              = (array) The request definition using either `script` or partial `doc`
      *
      * @param $params array Associative array of parameters


### PR DESCRIPTION
Based on the final note in https://www.elastic.co/guide/en/elasticsearch/reference/2.2/docs-update.html, I am sending this to 5.0, which can be cerry picked to 6.0 and master as well.

Also 'version_type' can be removed from Update::getParamWhitelist() in master.
