### PR TITLE
Remove deprecated redundant FILTER_VALIDATE_URL from ClientBuilder::prependMissingScheme

### DIFF
--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -671,7 +671,7 @@ class ClientBuilder
      */
     private function prependMissingScheme($host)
     {
-        if (!filter_var($host, FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED)) {
+        if (!filter_var($host, FILTER_VALIDATE_URL)) {
             $host = 'http://' . $host;
         }
 


### PR DESCRIPTION
The intent of this PR is to enable compatibility with php 7.3.
Fixes https://github.com/elastic/elasticsearch-php/issues/798