### PR TITLE
Adding 'pipeline' to UpdateByQuery.php whitelist

### DIFF
--- a/src/Elasticsearch/Endpoints/UpdateByQuery.php
+++ b/src/Elasticsearch/Endpoints/UpdateByQuery.php
@@ -107,6 +107,7 @@ class UpdateByQuery extends AbstractEndpoint
             'consistency',
             'scroll_size',
             'wait_for_completion',
+            'pipeline',
         ];
     }
 


### PR DESCRIPTION
Elasticsearch Update By Query supports the pipeline parameter.  This allows the parameter to be used.

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you signed [Contributor License Agreement](http://www.elasticsearch.org/contributor-agreement/)?
PR's (no matter how small) cannot be merged until the CLA has been signed.  It only needs to be signed once,
however.

- Have you read the [Contributing Guidelines](https://github.com/elastic/elasticsearch-php/blob/master/.github/CONTRIBUTING.md)?

If you answered yes to both, thanks for the PR and we'll get to it ASAP! :)

-->