### PR TITLE
Fixed php 7.3 compatibiltiy for elasticsearch 2 / 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ branches:
 sudo: false
 
 php:
+  - 7.3
+  - 7.2
+  - 7.1
   - 7.0
   - 5.6
   - 5.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
   - ./travis/download_and_run_es.sh
 
 install:
-  - composer install --prefer-source
+  - composer install --prefer-dist
 
 before_script:
   - if [ $TRAVIS_PHP_VERSION = '7.0' ]; then PHPUNIT_FLAGS="--coverage-clover ./build/logs/clover.xml"; fi

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
   "repositories": [
     {
       "type": "vcs",
-      "url": "https://github.com/polyfractal/Yaml"
+      "url": "https://github.com/polyfractal/Yaml.git"
     }
   ]
 }

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
   "repositories": [
     {
       "type": "vcs",
-      "url": "https://github.com/polyfractal/Yaml.git"
+      "url": "https://github.com/polyfractal/Yaml"
     }
   ]
 }

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
   },
   "repositories": [
     {
-      "type": "vcs",
+      "type": "git",
       "url": "https://github.com/polyfractal/Yaml"
     }
   ]

--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -602,7 +602,7 @@ class ClientBuilder
      */
     private function prependMissingScheme($host)
     {
-        if (!filter_var($host, FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED)) {
+        if (!filter_var($host, FILTER_VALIDATE_URL)) {
             $host = 'http://' . $host;
         }
 


### PR DESCRIPTION
Fixed php 7.3 compatibiltiy for elasticsearch 2 / 1 and fix travis ci problems with forked symfony yaml.

See #826 for Elasticsearch 5
See  #827   for Elasticsearch 6

See also #823 #803

https://wiki.php.net/rfc/deprecations_php_7_3#filter_flag_scheme_required_and_filter_flag_host_required

fixes #798