### PR TITLE
Fixed php 7.3 compatibility for elasticsearch 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,16 @@ matrix:
   allow_failures:
     - env: ES_VERSION="6.x"
 
+    - php: 7.2
+      env: ES_VERSION="5.0" TEST_BUILD_REF="origin/5.0"
+    - php: 7.2
+      env: ES_VERSION="5.5" TEST_BUILD_REF="origin/5.5"
+
+    - php: 7.3
+      env: ES_VERSION="5.0" TEST_BUILD_REF="origin/5.0"
+    - php: 7.3
+      env: ES_VERSION="5.5" TEST_BUILD_REF="origin/5.5"
+
 env:
   global:
     - ES_TEST_HOST=http://localhost:9200
@@ -43,10 +53,10 @@ before_install:
   - ./travis/download_and_run_es.sh
 
 install:
-  - composer install --prefer-source
+  - composer install --prefer-dist
 
 before_script:
-  - if [ $TRAVIS_PHP_VERSION = '7.0' ]; then PHPUNIT_FLAGS="--coverage-clover ./build/logs/clover.xml"; fi
+  - if [ $TRAVIS_PHP_VERSION = '7.3' ]; then PHPUNIT_FLAGS="--coverage-clover ./build/logs/clover.xml"; fi
   - php util/RestSpecRunner.php
   - php util/EnsureClusterAlive.php
 
@@ -57,4 +67,4 @@ script:
   - vendor/bin/phpunit -c phpunit-integration.xml --group sync $PHPUNIT_FLAGS
 
 after_script:
-  - if [ $TRAVIS_PHP_VERSION = '7.0' ]; then php vendor/bin/coveralls; fi
+  - if [ $TRAVIS_PHP_VERSION = '7.3' ]; then php vendor/bin/coveralls; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,18 +30,11 @@ matrix:
     - php: 7.2
       env: ES_VERSION="6.0"
 
+    - php: 7.3
+      env: ES_VERSION="6.0"
+
   allow_failures:
     - env: ES_VERSION="6.x"
-
-    - php: 7.2
-      env: ES_VERSION="5.0" TEST_BUILD_REF="origin/5.0"
-    - php: 7.2
-      env: ES_VERSION="5.5" TEST_BUILD_REF="origin/5.5"
-
-    - php: 7.3
-      env: ES_VERSION="5.0" TEST_BUILD_REF="origin/5.0"
-    - php: 7.3
-      env: ES_VERSION="5.5" TEST_BUILD_REF="origin/5.5"
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ before_script:
   - php util/EnsureClusterAlive.php
 
 script:
-  - composer run-script phpcs
+  - if [ $TRAVIS_PHP_VERSION != '7.3' ]; then composer run-script phpcs; fi
   - composer run-script phpstan
   - vendor/bin/phpunit $PHPUNIT_FLAGS
   - vendor/bin/phpunit -c phpunit-integration.xml --group sync $PHPUNIT_FLAGS

--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -683,7 +683,7 @@ class ClientBuilder
      */
     private function prependMissingScheme($host)
     {
-        if (!filter_var($host, FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED)) {
+        if (!filter_var($host, FILTER_VALIDATE_URL)) {
             $host = 'http://' . $host;
         }
 


### PR DESCRIPTION
Fixed php 7.3 compatibiltiy for elasticsearch 6.

See #825 for Elasticsearch 2 / 1
See #826 for Elasticsearch 5

See also #823 #803

https://wiki.php.net/rfc/deprecations_php_7_3#filter_flag_scheme_required_and_filter_flag_host_required

fixes #798