### PR TITLE
Include .gitattributes to remove tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,13 @@
-# Ignore tests
+# Files to exclude when creating archive
 /tests export-ignore
+/.github export-ignore
+/.gitmodules export-ignore
+/.gitignore export-ignore
+/.php_cs export-ignore
+/.travis.yml export-ignore
+/.phpstan-src.neon export-ignore
+/.phpstan-tests.neon export-ignore
+/phpunit-integration.xml export-ignore
+/phpunit.xml export-ignore
+/ruleset.xml export-ignore
+/travis export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ignore tests
+/tests export-ignore


### PR DESCRIPTION
<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you signed [Contributor License Agreement](http://www.elasticsearch.org/contributor-agreement/)?
PR's (no matter how small) cannot be merged until the CLA has been signed.  It only needs to be signed once,
however.

- Have you read the [Contributing Guidelines](https://github.com/elastic/elasticsearch-php/blob/master/.github/CONTRIBUTING.md)?

If you answered yes to both, thanks for the PR and we'll get to it ASAP! :)

-->

Adds a .gitattributes file to allow users to pull down elasticsearch without the tests directory.

Issue reference: #838 