### PR TITLE
[DOCS] Adds anchor IDs

### DIFF
--- a/docs/breaking-changes.asciidoc
+++ b/docs/breaking-changes.asciidoc
@@ -1,3 +1,4 @@
+[[breaking_changes]]
 == Breaking changes from 5.x
 
 None! :)

--- a/docs/community.asciidoc
+++ b/docs/community.asciidoc
@@ -1,4 +1,4 @@
-
+[[community_dsls]]
 == Community DSLs
 
 === ElasticsearchDSL

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1,4 +1,4 @@
-
+[[configuration]]
 == Configuration
 
 Almost every aspect of the client is configurable.  Most users will only need to configure a few parameters to suit

--- a/docs/connection-pool.asciidoc
+++ b/docs/connection-pool.asciidoc
@@ -1,4 +1,4 @@
-
+[[connection_pool]]
 == Connection Pool
 
 The connection pool is an object inside the client that is responsible for maintaining the current list of nodes.

--- a/docs/crud.asciidoc
+++ b/docs/crud.asciidoc
@@ -1,4 +1,4 @@
-
+[[indexing_documents]]
 == Indexing Documents
 
 When you add documents to Elasticsearch, you index JSON documents.  This maps naturally to PHP associative arrays, since
@@ -129,6 +129,7 @@ if (!empty($params['body'])) {
 }
 ----
 
+[[getting_documents]]
 == Getting Documents
 
 Elasticsearch provides realtime GETs of documents.  This means that as soon as the document has been indexed and your
@@ -148,6 +149,7 @@ $response = $client->get($params);
 ----
 {zwsp} +
 
+[[updating_documents]]
 == Updating Documents
 
 Updating a document allows you to either completely replace the contents of the existing document, or perform a partial
@@ -228,7 +230,7 @@ $response = $client->update($params);
 ----
 {zwsp} +
 
-
+[[deleting_documents]]
 == Deleting documents
 
 Finally, you can delete documents by specifying their full `/index/type/id` path:

--- a/docs/futures.asciidoc
+++ b/docs/futures.asciidoc
@@ -1,4 +1,4 @@
-
+[[future_mode]]
 == Future Mode
 
 The client offers a mode called "future" or "async" mode.  This allows batch processing of requests (sent in parallel

--- a/docs/index-operations.asciidoc
+++ b/docs/index-operations.asciidoc
@@ -1,4 +1,4 @@
-
+[[index_management]]
 == Index Management Operations
 
 Index management operations allow you to manage the indices in your Elasticsearch cluster, such as creating, deleting and

--- a/docs/installation.asciidoc
+++ b/docs/installation.asciidoc
@@ -1,3 +1,4 @@
+[[installation]]
 == Installation
 
 Elasticsearch-php only has a three requirements that you need to worry about:

--- a/docs/namespaces.asciidoc
+++ b/docs/namespaces.asciidoc
@@ -1,4 +1,4 @@
-
+[[namespaces]]
 == Namespaces
 
 The client has a number of "namespaces", which generally expose administrative

--- a/docs/overview.asciidoc
+++ b/docs/overview.asciidoc
@@ -1,3 +1,4 @@
+[[overview]]
 == Overview
 
 This is the official PHP client for Elasticsearch.  It is designed to be a very low-level client that does not stray from the REST API.

--- a/docs/per-request-configuration.asciidoc
+++ b/docs/per-request-configuration.asciidoc
@@ -1,4 +1,4 @@
-
+[[per_request_configuration]]
 == Per-request configuration
 
 There are several configurations that can be set on a per-request basis, rather than at a connection- or client-level.

--- a/docs/php-version-requirement.asciidoc
+++ b/docs/php-version-requirement.asciidoc
@@ -1,3 +1,4 @@
+[[php_version_requirement]]
 == PHP Version Requirement
 
 Version 5.0 of Elasticsearch-PHP requires PHP version 5.6.6 or higher. In addition, it requires the native JSON

--- a/docs/quickstart.asciidoc
+++ b/docs/quickstart.asciidoc
@@ -1,4 +1,4 @@
-
+[[quickstart]]
 == Quickstart
 
 This section will give you a quick overview of the client and how the major functions work.

--- a/docs/search-operations.asciidoc
+++ b/docs/search-operations.asciidoc
@@ -1,3 +1,4 @@
+[[search_operations]]
 == Search Operations
 
 Well...it isn't called elasticsearch for nothing!  Let's talk about search operations in the client.

--- a/docs/security.asciidoc
+++ b/docs/security.asciidoc
@@ -1,4 +1,4 @@
-
+[[security]]
 == Security
 
 The Elasticsearch-PHP client supports two security features: HTTP Authentication and SSL encryption.

--- a/docs/selectors.asciidoc
+++ b/docs/selectors.asciidoc
@@ -1,4 +1,4 @@
-
+[[selectors]]
 == Selectors
 
 The connection pool maintains the list of connections, and decides when nodes should transition from alive to dead (and

--- a/docs/serializers.asciidoc
+++ b/docs/serializers.asciidoc
@@ -1,4 +1,4 @@
-
+[[serializers]]
 == Serializers
 
 The client has three serializers available.  You will most likely never need


### PR DESCRIPTION
Related to https://github.com/elastic/docs/pull/690

This PR adds explicit anchor IDs for each page in the Elasticsearch-PHP Client documentation (https://www.elastic.co/guide/en/elasticsearch/client/php-api/master/index.html)
