### PR TITLE
[DOCS] Fixes broken links to new anchors

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -89,7 +89,8 @@ scheme is `http`.
 
 === Authorization and Encryption
 
-For details about HTTP Authorization and SSL encryption, please see link:_security.html[Authorization and SSL].
+For details about HTTP Authorization and SSL encryption, see
+<<security,Authorization and SSL>>.
 
 === Set retries
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -243,7 +243,8 @@ $client = ClientBuilder::create()
             ->build();
 ----
 
-For more details, please see the dedicated page on link:_connection_pool.html[configuring connection pools].
+For more details, please see the dedicated page on 
+<<connection_pool,configuring connection pools>>.
 
 === Setting the Connection Selector
 
@@ -259,7 +260,8 @@ $client = ClientBuilder::create()
             ->build();
 ----
 
-For more details, please see the dedicated page on link:_selectors.html[configuring selectors].
+For more details, please see the dedicated page on
+<<selectors,configuring selectors>>.
 
 
 === Setting the Serializer
@@ -279,7 +281,8 @@ $client = ClientBuilder::create()
             ->build();
 ----
 
-For more details, please see the dedicated page on link:_serializers.html[configuring serializers].
+For more details, please see the dedicated page on
+<<serializers,configuring serializers>>.
 
 
 === Setting a custom ConnectionFactory

--- a/docs/per-request-configuration.asciidoc
+++ b/docs/per-request-configuration.asciidoc
@@ -269,11 +269,12 @@ $results = $future->wait();       // resolve the future
 ----
 
 Future mode supports two options: `true` or `'lazy'`.  For more details about how asynchronous execution functions, and
-how to work with the results, see the dedicated page on <<_future_mode>>.
+how to work with the results, see the dedicated page on <<future_mode>>.
 
 === SSL Encryption
 
-Normally, you will specify SSL configurations when you create the client (see <<_security>> for more details), since encryption typically
+Normally, you will specify SSL configurations when you create the client (see
+<<security>> for more details), since encryption typically
 applies to all requests. However, it is possible to configure on a per-request basis too if you need that functionality.
 For example, if you  need to use a self-signed cert on a specific request, you can specify it via the `verify` parameter
 in the client options:

--- a/docs/selectors.asciidoc
+++ b/docs/selectors.asciidoc
@@ -37,7 +37,7 @@ better to "stick" to a single connection for the duration of the script.
 By default, this selector will randomize the hosts upon initialization, which will still guarantee an even distribution
 of load across the cluster.  It changes the round-robin dynamics from per-request to per-script.
 
-If you are using <<_future_mode>>, the "sticky" behavior of this selector will be non-ideal, since all parallel requests
+If you are using <<future_mode>>, the "sticky" behavior of this selector will be non-ideal, since all parallel requests
 will go to the same node instead of multiple nodes in your cluster.  When using future mode, the default `RoundRobinSelector`
 should be preferred.
 


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch-php/pull/848

This PR cleans up links that were using the auto-generated URLs