### PR TITLE
Update whitelists and docs according with param renaming

### DIFF
--- a/docs/build/Elasticsearch/Client.asciidoc
+++ b/docs/build/Elasticsearch/Client.asciidoc
@@ -118,8 +118,8 @@ $params['id']              = (string) The document ID (Required)
        ['refresh']         = (boolean) Refresh the shard containing the document before performing the operation
        ['routing']         = (string) Specific routing value
        ['_source']         = (list) True or false to return the _source field or not, or a list of fields to return
-       ['_source_exclude'] = (list) A list of fields to exclude from the returned _source field
-       ['_source_include'] = (list) A list of fields to extract and return from the _source field
+       ['_source_excludes'] = (list) A list of fields to exclude from the returned _source field
+       ['_source_includes'] = (list) A list of fields to extract and return from the _source field
        ['body']  = (array) Request body
 */
 
@@ -200,8 +200,8 @@ $response = $client->delete($params);
 ----
 /*
 $params['_source'] = (list) True or false to return the _source field or not, or a list of fields to return
-       ['_source_exclude'] = (array) A list of fields to exclude from the returned _source field
-       ['_source_include'] = (array) A list of fields to extract and return from the _source field
+       ['_source_excludes'] = (array) A list of fields to exclude from the returned _source field
+       ['_source_includes'] = (array) A list of fields to extract and return from the _source field
        ['allow_no_indices'] = (bool) Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
        ['analyze_wildcard'] = (bool) Specify whether wildcard and prefix queries should be analyzed (default: false)
        ['analyzer'] = (string) The analyzer to use for the query string
@@ -665,8 +665,8 @@ $params['id']                       = (string) The document ID (Required)
        ['routing']                  = (string) Specific routing value
        ['source']                   = (string) The URL-encoded query definition (instead of using the request body)
        ['_source']                  = (list) True or false to return the _source field or not, or a list of fields to return
-       ['_source_exclude']          = (list) A list of fields to exclude from the returned _source field
-       ['_source_include']          = (list) A list of fields to extract and return from the _source field
+       ['_source_excludes']          = (list) A list of fields to exclude from the returned _source field
+       ['_source_includes']          = (list) A list of fields to extract and return from the _source field
        ['body']                     = (string) The URL-encoded query definition (instead of using the request body)
        ['body']  = (array) Request body
 */
@@ -712,8 +712,8 @@ $params['index']                    = (list) A comma-separated list of index nam
        ['sort']                     = (list) A comma-separated list of <field>:<direction> pairs
        ['source']                   = (string) The URL-encoded request definition using the Query DSL (instead of using request body)
        ['_source']                  = (list) True or false to return the _source field or not, or a list of fields to return
-       ['_source_exclude']          = (list) A list of fields to exclude from the returned _source field
-       ['_source_include']          = (list) A list of fields to extract and return from the _source field
+       ['_source_excludes']          = (list) A list of fields to exclude from the returned _source field
+       ['_source_includes']          = (list) A list of fields to extract and return from the _source field
        ['stats']                    = (list) Specific 'tag' of the request for logging and statistical purposes
        ['suggest_field']            = (string) Specify which field to use for suggestions
        ['suggest_mode']             = (enum) Specify suggest mode

--- a/src/Elasticsearch/Client.php
+++ b/src/Elasticsearch/Client.php
@@ -167,8 +167,8 @@ class Client
      *        ['refresh']         = (boolean) Refresh the shard containing the document before performing the operation
      *        ['routing']         = (string) Specific routing value
      *        ['_source']         = (list) True or false to return the _source field or not, or a list of fields to return
-     *        ['_source_exclude'] = (list) A list of fields to exclude from the returned _source field
-     *        ['_source_include'] = (list) A list of fields to extract and return from the _source field
+     *        ['_source_excludes'] = (list) A list of fields to exclude from the returned _source field
+     *        ['_source_includes'] = (list) A list of fields to extract and return from the _source field
      *
      * @param array $params Associative array of parameters
      *
@@ -270,8 +270,8 @@ class Client
     /**
      *
      * $params['_source'] = (list) True or false to return the _source field or not, or a list of fields to return
-     *        ['_source_exclude'] = (array) A list of fields to exclude from the returned _source field
-     *        ['_source_include'] = (array) A list of fields to extract and return from the _source field
+     *        ['_source_excludes'] = (array) A list of fields to exclude from the returned _source field
+     *        ['_source_includes'] = (array) A list of fields to extract and return from the _source field
      *        ['allow_no_indices'] = (bool) Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
      *        ['analyze_wildcard'] = (bool) Specify whether wildcard and prefix queries should be analyzed (default: false)
      *        ['analyzer'] = (string) The analyzer to use for the query string
@@ -593,8 +593,8 @@ class Client
      *        ['routing']         = (string) Specific routing value
      *        ['body']            = (array) Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.
      *        ['_source']         = (list) True or false to return the _source field or not, or a list of fields to return
-     *        ['_source_exclude'] = (list) A list of fields to exclude from the returned _source field
-     *        ['_source_include'] = (list) A list of fields to extract and return from the _source field
+     *        ['_source_excludes'] = (list) A list of fields to exclude from the returned _source field
+     *        ['_source_includes'] = (list) A list of fields to extract and return from the _source field
      *
      * @param array $params Associative array of parameters
      *
@@ -865,8 +865,8 @@ class Client
      *        ['routing']                  = (string) Specific routing value
      *        ['source']                   = (string) The URL-encoded query definition (instead of using the request body)
      *        ['_source']                  = (list) True or false to return the _source field or not, or a list of fields to return
-     *        ['_source_exclude']          = (list) A list of fields to exclude from the returned _source field
-     *        ['_source_include']          = (list) A list of fields to extract and return from the _source field
+     *        ['_source_excludes']          = (list) A list of fields to exclude from the returned _source field
+     *        ['_source_includes']          = (list) A list of fields to extract and return from the _source field
      *        ['body']                     = (string) The URL-encoded query definition (instead of using the request body)
      *
      * @param array $params Associative array of parameters
@@ -919,8 +919,8 @@ class Client
      *        ['sort']                     = (list) A comma-separated list of <field>:<direction> pairs
      *        ['source']                   = (string) The URL-encoded request definition using the Query DSL (instead of using request body)
      *        ['_source']                  = (list) True or false to return the _source field or not, or a list of fields to return
-     *        ['_source_exclude']          = (list) A list of fields to exclude from the returned _source field
-     *        ['_source_include']          = (list) A list of fields to extract and return from the _source field
+     *        ['_source_excludes']          = (list) A list of fields to exclude from the returned _source field
+     *        ['_source_includes']          = (list) A list of fields to extract and return from the _source field
      *        ['stats']                    = (list) Specific 'tag' of the request for logging and statistical purposes
      *        ['suggest_field']            = (string) Specify which field to use for suggestions
      *        ['suggest_mode']             = (enum) Specify suggest mode
@@ -1151,8 +1151,8 @@ class Client
      *        ['sort']                     = (list) A comma-separated list of <field>:<direction> pairs
      *        ['_source']                  = (list) True or false to return the _source field or not, or a list of
      * fields to return
-     *        ['_source_exclude']          = (list) A list of fields to exclude from the returned _source field
-     *        ['_source_include']          = (list) A list of fields to extract and return from the _source field
+     *        ['_source_excludes']          = (list) A list of fields to exclude from the returned _source field
+     *        ['_source_includes']          = (list) A list of fields to extract and return from the _source field
      *        ['terminate_after']          = (number) The maximum number of documents to collect for each shard, upon
      * reaching which the query execution will terminate early.
      *        ['stats']                    = (list) Specific 'tag' of the request for logging and statistical purposes

--- a/src/Elasticsearch/Endpoints/Bulk.php
+++ b/src/Elasticsearch/Endpoints/Bulk.php
@@ -76,6 +76,8 @@ class Bulk extends AbstractEndpoint implements BulkEndpointInterface
             '_source',
             '_source_include',
             '_source_exclude',
+            '_source_includes',
+            '_source_excludes',
             'pipeline'
         );
     }

--- a/src/Elasticsearch/Endpoints/DeleteByQuery.php
+++ b/src/Elasticsearch/Endpoints/DeleteByQuery.php
@@ -63,6 +63,8 @@ class DeleteByQuery extends AbstractEndpoint
             '_source',
             '_source_exclude',
             '_source_include',
+            '_source_excludes',
+            '_source_includes',
             'allow_no_indices',
             'analyze_wildcard',
             'analyzer',

--- a/src/Elasticsearch/Endpoints/Explain.php
+++ b/src/Elasticsearch/Endpoints/Explain.php
@@ -88,6 +88,8 @@ class Explain extends AbstractEndpoint
             '_source',
             '_source_exclude',
             '_source_include',
+            '_source_excludes',
+            '_source_includes',
             'stored_fields'
         );
     }

--- a/src/Elasticsearch/Endpoints/Get.php
+++ b/src/Elasticsearch/Endpoints/Get.php
@@ -95,6 +95,8 @@ class Get extends AbstractEndpoint
             '_source',
             '_source_exclude',
             '_source_include',
+            '_source_excludes',
+            '_source_includes',
             'version',
             'version_type',
             'stored_fields'

--- a/src/Elasticsearch/Endpoints/Mget.php
+++ b/src/Elasticsearch/Endpoints/Mget.php
@@ -67,6 +67,8 @@ class Mget extends AbstractEndpoint
             '_source',
             '_source_exclude',
             '_source_include',
+            '_source_excludes',
+            '_source_includes',
             'routing',
             'stored_fields'
         );

--- a/src/Elasticsearch/Endpoints/Search.php
+++ b/src/Elasticsearch/Endpoints/Search.php
@@ -87,6 +87,8 @@ class Search extends AbstractEndpoint
             '_source',
             '_source_exclude',
             '_source_include',
+            '_source_excludes',
+            '_source_includes',
             'stats',
             'suggest_field',
             'suggest_mode',

--- a/src/Elasticsearch/Endpoints/Source/Get.php
+++ b/src/Elasticsearch/Endpoints/Source/Get.php
@@ -65,6 +65,8 @@ class Get extends AbstractEndpoint
             '_source',
             '_source_exclude',
             '_source_include',
+            '_source_excludes',
+            '_source_includes',
             'version',
             'version_type',
         );

--- a/src/Elasticsearch/Endpoints/UpdateByQuery.php
+++ b/src/Elasticsearch/Endpoints/UpdateByQuery.php
@@ -92,6 +92,8 @@ class UpdateByQuery extends AbstractEndpoint
             '_source',
             '_source_exclude',
             '_source_include',
+            '_source_excludes',
+            '_source_includes',
             'terminate_after',
             'stats',
             'suggest_field',


### PR DESCRIPTION
Updated some docs and white-list according to breaking changes in 
https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-6.6.html#_deprecate_literal__source_exclude_literal_and_literal__source_include_literal_url_parameters

