### PR TITLE
fix SearchResponseIterator scroll first page twice (#595)

### DIFF
--- a/src/Elasticsearch/Helper/Iterators/SearchResponseIterator.php
+++ b/src/Elasticsearch/Helper/Iterators/SearchResponseIterator.php
@@ -128,15 +128,13 @@ class SearchResponseIterator implements Iterator
      */
     public function next()
     {
-        if ($this->current_key !== 0) {
-            $this->current_scrolled_response = $this->client->scroll(
-                array(
-                    'scroll_id' => $this->scroll_id,
-                    'scroll'    => $this->scroll_ttl
-                )
-            );
-            $this->scroll_id = $this->current_scrolled_response['_scroll_id'];
-        }
+        $this->current_scrolled_response = $this->client->scroll(
+            array(
+                'scroll_id' => $this->scroll_id,
+                'scroll'    => $this->scroll_ttl
+            )
+        );
+        $this->scroll_id = $this->current_scrolled_response['_scroll_id'];
         $this->current_key++;
     }
 


### PR DESCRIPTION
I have reproduced issue #595 on es5.5 and elasticsearch-php v5.3.2.
@biopowder create the issue but never submit a PR, the PR is totally based on his code in the issue description.
Hope you can merge this into branch 5.0 and check if there is same problem for other branch, thanks.