### PR TITLE
Enable the Client to keep requests

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -376,6 +376,38 @@ Obviously, by doing this you take responsibility that all existing endpoints sti
 assume the responsibility of correctly wiring the Transport and Serializer into each endpoint.
 
 
+=== Keep Requests
+
+Notice: This is mainly used for debugging purposes.
+
+By default the client will only keep the latest request made to ElasticSearch saved in the latest connection. By enabling
+the Keep Requests part of the Client, the client will keep a record of all requests made during its lifecycle.
+This can be useful if you are interested in logging the requests and responses different from the default way this
+library logs the requests.
+
+If you wish to enable to client to keep requests you can use the setKeepRequests(true):
+
+[source,php]
+----------------------------
+
+$client = ClientBuilder::create()
+                    ->setKeepRequests(true)
+                    ->build();
+----------------------------
+
+Once the client has been built using the setKeepRequests(true), you can retrieve the requests using:
+
+[source,php]
+----------------------------
+
+$requests = $client->transport->getKeptRequests();
+
+//or
+
+$requests = $client->transport->keptRequests;
+----------------------------
+
+
 === Building the client from a configuration hash
 
 To help ease automated building of the client, all configurations can be provided in a setting

--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -82,6 +82,9 @@ class ClientBuilder
     /** @var bool */
     private $sniffOnStart = false;
 
+    /** @var bool */
+    private $keepRequests = false;
+
     /** @var null|array  */
     private $sslCert = null;
 
@@ -388,6 +391,17 @@ class ClientBuilder
     }
 
     /**
+     * @param boolean $keepRequests
+     * @return $this
+     */
+    public function setKeepRequests($keepRequests)
+    {
+        $this->keepRequests = $keepRequests;
+
+        return $this;
+    }
+
+    /**
      * @param string $cert The name of a file containing a PEM formatted certificate.
      * @param null|string $password
      * @return $this
@@ -570,7 +584,7 @@ class ClientBuilder
         }
 
         if (is_null($this->transport)) {
-            $this->transport = new Transport($this->retries, $this->sniffOnStart, $this->connectionPool, $this->logger);
+            $this->transport = new Transport($this->retries, $this->sniffOnStart, $this->keepRequests, $this->connectionPool, $this->logger);
         }
     }
 

--- a/src/Elasticsearch/Transport.php
+++ b/src/Elasticsearch/Transport.php
@@ -38,6 +38,12 @@ class Transport
     /** @var  Connection */
     public $lastConnection;
 
+    /** @var bool */
+    public $keepRequests = false;
+
+    /** @var array */
+    public $keptRequests = [];
+
     /** @var int  */
     public $retries;
 
@@ -47,18 +53,20 @@ class Transport
      *
      * @param int $retries
      * @param bool $sniffOnStart
+     * @param bool $keepRequests
      * @param ConnectionPool\AbstractConnectionPool $connectionPool
      * @param \Psr\Log\LoggerInterface $log    Monolog logger object
      */
 	// @codingStandardsIgnoreStart
 	// "Arguments with default values must be at the end of the argument list" - cannot change the interface
-    public function __construct($retries, $sniffOnStart = false, AbstractConnectionPool $connectionPool, LoggerInterface $log)
+    public function __construct($retries, $sniffOnStart = false, $keepRequests = false, AbstractConnectionPool $connectionPool, LoggerInterface $log)
     {
 	    // @codingStandardsIgnoreEnd
 
         $this->log            = $log;
         $this->connectionPool = $connectionPool;
         $this->retries        = $retries;
+        $this->keepRequests   = $keepRequests;
 
         if ($sniffOnStart === true) {
             $this->log->notice('Sniff on Start.');
@@ -177,5 +185,16 @@ class Transport
     public function getLastConnection()
     {
         return $this->lastConnection;
+    }
+
+    /**
+     * Returns the array of requests performed from the client.  Mainly
+     * for debugging/testing purposes.
+     *
+     * @return array
+     */
+    public function getKeptRequests()
+    {
+        return $this->keptRequests;
     }
 }


### PR DESCRIPTION
<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you signed [Contributor License Agreement](https://www.elastic.co/contributor-agreement)?
PR's (no matter how small) cannot be merged until the CLA has been signed.  It only needs to be signed once,
however.

- Have you read the [Contributing Guidelines](https://github.com/elastic/elasticsearch-php/blob/master/.github/CONTRIBUTING.md)?

If you answered yes to both, thanks for the PR and we'll get to it ASAP! :)

-->

Currently the Client only saves the latest request made using the Client, but if you are interested in seeing all the requests made by the client in its lifetime, there is no real way of getting this data, without enabling the logger, which logs the requests and responses in the way that this library has specified.

With this Pull-Request, you can enable the client to keep an array of requests made using the Client. This will be useful for debugging and testing purposes mainly, or for profiling purposes. 

Please let me know what you think about this :) 

Feel free to comment, review and edit if needed.

Regards,
Emil G.
