### PR TITLE
[WIP] Upgrade Master with include_type_name (ES7)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ matrix:
       env: ES_VERSION="6.6.0"
     - php: 7.3
       env: ES_VERSION="6.7.0"
+    - php: 7.3
+      env: ES_VERSION="7.0.0"
+
 
 
 env:

--- a/src/Elasticsearch/Endpoints/Indices/Create.php
+++ b/src/Elasticsearch/Endpoints/Indices/Create.php
@@ -65,7 +65,8 @@ class Create extends AbstractEndpoint
             'timeout',
             'master_timeout',
             'update_all_types',
-            'wait_for_active_shards'
+            'wait_for_active_shards',
+            'include_type_name'
         );
     }
 

--- a/src/Elasticsearch/Endpoints/Indices/Delete.php
+++ b/src/Elasticsearch/Endpoints/Indices/Delete.php
@@ -41,8 +41,7 @@ class Delete extends AbstractEndpoint
             'timeout',
             'master_timeout',
             'ignore_unavailable',
-            'allow_no_indices',
-            'include_type_name'
+            'allow_no_indices'
         );
     }
 

--- a/src/Elasticsearch/Endpoints/Indices/Delete.php
+++ b/src/Elasticsearch/Endpoints/Indices/Delete.php
@@ -41,7 +41,8 @@ class Delete extends AbstractEndpoint
             'timeout',
             'master_timeout',
             'ignore_unavailable',
-            'allow_no_indices'
+            'allow_no_indices',
+            'include_type_name'
         );
     }
 

--- a/src/Elasticsearch/Endpoints/Indices/Get.php
+++ b/src/Elasticsearch/Endpoints/Indices/Get.php
@@ -67,7 +67,8 @@ class Get extends AbstractEndpoint
             'ignore_unavailable',
             'allow_no_indices',
             'expand_wildcards',
-            'human'
+            'human',
+            'include_type_name'
         );
     }
 

--- a/src/Elasticsearch/Endpoints/Indices/Mapping/Get.php
+++ b/src/Elasticsearch/Endpoints/Indices/Mapping/Get.php
@@ -48,6 +48,7 @@ class Get extends AbstractEndpoint
             'expand_wildcards',
             'wildcard_expansion',
             'local',
+            'include_type_name'
         );
     }
 

--- a/src/Elasticsearch/Endpoints/Indices/Mapping/Put.php
+++ b/src/Elasticsearch/Endpoints/Indices/Mapping/Put.php
@@ -71,7 +71,8 @@ class Put extends AbstractEndpoint
             'ignore_unavailable',
             'allow_no_indices',
             'expand_wildcards',
-            'update_all_types'
+            'update_all_types',
+            'include_type_name'
         );
     }
 

--- a/src/Elasticsearch/Endpoints/Indices/Template/Put.php
+++ b/src/Elasticsearch/Endpoints/Indices/Template/Put.php
@@ -89,7 +89,8 @@ class Put extends AbstractEndpoint
             'timeout',
             'master_timeout',
             'flat_settings',
-            'create'
+            'create',
+            'include_type_name'
         );
     }
 


### PR DESCRIPTION
HI @ezimuel and @polyfractal I'm one of the collaborators of the [Elastica project](https://github.com/ruflin/Elastica)
we have a [PR open](https://github.com/ruflin/Elastica/pull/1563) for upgrading to Elasticsearch 7.0

Referencing also an [issue opened some days ago](https://github.com/elastic/elasticsearch-php/issues/865) on elasticsearch-php It would be great if the elasticsearch-php would have these params available on master. 

Our master branch (Elastica) is receiving update for new releases, the 7.0 right now, and we would like to start testing the library asap on ES7. 

The quickest way would be adding these paramas on Elasticsearch-php, the longer would be removing completely the Type from Elastica, or at least type mapping during index creation.

I've prepared a PR in order to clarify what to do here, feel free to comment, or to do urself the update. Thank you a lot guys!