### PR TITLE
Trim trailing slashes from hosts when passed as a string.

### DIFF
--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -610,6 +610,7 @@ class ClientBuilder
         foreach ($hosts as $host) {
             if (is_string($host)) {
                 $host = $this->prependMissingScheme($host);
+                $host = $this->removeTrailingSlashes($host);
                 $host = $this->extractURIParts($host);
             } elseif (is_array($host)) {
                 $host = $this->normalizeExtendedHost($host);
@@ -676,5 +677,15 @@ class ClientBuilder
         }
 
         return $host;
+    }
+
+    /**
+     * @param string $host
+     *
+     * @return string
+     */
+    private function removeTrailingSlashes($host)
+    {
+        return rtrim($host, '/');
     }
 }


### PR DESCRIPTION
When a host contains trailing slashes this might lead to issues when requesting the path `/`,
as this might lead to the uri `//`. This is an invalid uri - `parse_url()` will return `false`
on this uri.

This PR only removes trailing slashes from hosts that are passed as a string. Rationale behind
this decision is that, when passed as an array, the path is a separate entry in that array.

Maybe this should be handled by the code that calls the `ClientBuilder` or maybe the handler
where this issue presented itself in this scenario, but I think by sanitizing the uri by
proactively removing the trailing slashes this library will become more robust.

This PR fixes #869 