### PR TITLE
Fixed non-working CLA link in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@ The process for contributing to any of the Elasticsearch repositories is similar
 
 1. Sign the contributor license agreement
 
-    Please make sure you have signed the [Contributor License Agreement](http://www.elasticsearch.org/contributor-agreement/). We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction. We ask this of all contributors in order to assure our users of the origin and continuing existence of the code. You only need to sign the CLA once.
+    Please make sure you have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/). We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction. We ask this of all contributors in order to assure our users of the origin and continuing existence of the code. You only need to sign the CLA once.
 
 2. Set up your fork for development
 


### PR DESCRIPTION
The URL http://www.elasticsearch.org/contributor-agreement/ redirects to the homepage https://www.elastic.co/

I checked the pull request template as well as All Things Code page, and I see that the correct URL should be https://www.elastic.co/contributor-agreement/ - this one works.