### PR TITLE
Add IndexClosedException

### DIFF
--- a/src/Elasticsearch/Common/Exceptions/IndexClosedException.php
+++ b/src/Elasticsearch/Common/Exceptions/IndexClosedException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Elasticsearch\Common\Exceptions;
+
+/**
+ * IndexClosedException
+ *
+ * @category Elasticsearch
+ * @package  Elasticsearch\Common\Exceptions
+ * @author   Daniel Pasch-Sannapiu <gempir.dev@gmail.com>
+ * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
+ * @link     http://elastic.co
+ */
+class IndexClosedException extends \Exception implements ElasticsearchException
+{
+}

--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -11,6 +11,7 @@ use Elasticsearch\Common\Exceptions\Curl\CouldNotConnectToHost;
 use Elasticsearch\Common\Exceptions\Curl\CouldNotResolveHostException;
 use Elasticsearch\Common\Exceptions\Curl\OperationTimeoutException;
 use Elasticsearch\Common\Exceptions\Forbidden403Exception;
+use Elasticsearch\Common\Exceptions\IndexClosedException;
 use Elasticsearch\Common\Exceptions\MaxRetriesException;
 use Elasticsearch\Common\Exceptions\Missing404Exception;
 use Elasticsearch\Common\Exceptions\NoDocumentsToGetException;
@@ -606,6 +607,8 @@ class Connection implements ConnectionInterface
 
         if ($statusCode === 400 && strpos($responseBody, "AlreadyExpiredException") !== false) {
             $exception = new AlreadyExpiredException($responseBody, $statusCode);
+        } elseif ($statusCode === 400 && strpos($responseBody, "index_closed_exception") !== false) {
+            $exception = new IndexClosedException($responseBody, $statusCode);
         } elseif ($statusCode === 403) {
             $exception = new Forbidden403Exception($responseBody, $statusCode);
         } elseif ($statusCode === 404) {


### PR DESCRIPTION
Added an IndexClosedException to catch this error more easily.

For reference this is a index_closed_exception response from elasticsearch.

```
{
  "error": {
    "root_cause": [
      {
        "type": "index_closed_exception",
        "reason": "closed",
        "index_uuid": "bNLHYp4UQNu3ZF-YSJ1awg",
        "index": "navigation_index_2"
      }
    ],
    "type": "index_closed_exception",
    "reason": "closed",
    "index_uuid": "bNLHYp4UQNu3ZF-YSJ1awg",
    "index": "navigation_index_2"
  },
  "status": 400
}
```

Sadly, I can't run tests locally right now (https://github.com/elastic/elasticsearch-php/issues/887) which makes it kinda hard to fix any broken tests.

Is there maybe someone who could explain how to correctlz run the tests, so I can fix any broken tests that are caused by my changes?