### PR TITLE
Fix/rejection handler failed

### DIFF
--- a/src/Elasticsearch/Transport.php
+++ b/src/Elasticsearch/Transport.php
@@ -119,9 +119,9 @@ class Transport
                 // Note, this could be a 4xx or 5xx error
             },
             //onFailure
-            function ($response) {
+            function (Throwable $response) {
                 // Ignore 400 level errors, as that means the server responded just fine
-                if (!(isset($response['code']) && $response['code'] >=400 && $response['code'] < 500)) {
+                if ($response->getCode() < 400 || $response->getCode() >= 500) {
                     // Otherwise schedule a check
                     $this->connectionPool->scheduleCheck();
                 }

--- a/src/Elasticsearch/Transport.php
+++ b/src/Elasticsearch/Transport.php
@@ -10,6 +10,7 @@ use Elasticsearch\Connections\Connection;
 use Elasticsearch\Connections\ConnectionInterface;
 use GuzzleHttp\Ring\Future\FutureArrayInterface;
 use Psr\Log\LoggerInterface;
+use Throwable;
 
 /**
  * Class Transport


### PR DESCRIPTION
[Error: Cannot use object of type Elasticsearch\Common\Exceptions\Missing404Exception as array](https://github.com/elastic/elasticsearch-php/issues/831)