### PR TITLE
Fix/rejection handler failed

### DIFF
--- a/src/Elasticsearch/Transport.php
+++ b/src/Elasticsearch/Transport.php
@@ -194,7 +194,7 @@ class Transport
      *
      * @return bool
      */
-    protected function ignoreTheError(?int $errorCode): bool
+    protected function ignoreTheError($errorCode = null): bool
     {
         if (null === $errorCode) {
             return false;


### PR DESCRIPTION
FIX [Error: Cannot use object of type Elasticsearch\Common\Exceptions\Missing404Exception as array](https://github.com/elastic/elasticsearch-php/issues/831)