### PR TITLE
Added User-Agent

### DIFF
--- a/src/Elasticsearch/Client.php
+++ b/src/Elasticsearch/Client.php
@@ -34,6 +34,8 @@ use Elasticsearch\Namespaces\TasksNamespace;
  */
 class Client
 {
+    const VERSION = '7.0.0';
+
     /**
      * @var Transport
      */

--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Elasticsearch\Connections;
 
+use Elasticsearch\Client;
 use Elasticsearch\Common\Exceptions\AlreadyExpiredException;
 use Elasticsearch\Common\Exceptions\BadRequest400Exception;
 use Elasticsearch\Common\Exceptions\Conflict409Exception;
@@ -132,6 +133,15 @@ class Connection implements ConnectionInterface
             $this->headers = $connectionParams['client']['headers'];
             unset($connectionParams['client']['headers']);
         }
+
+        // Add the User-Agent using the format: <client-repo-name>/<client-version> (metadata-values)
+        $this->headers['User-Agent'] = [sprintf(
+            "elasticsearch-php/%s (%s %s, PHP %s)",
+            Client::VERSION,
+            php_uname("s"),
+            php_uname("r"),
+            phpversion()
+        )];
 
         $host = $hostDetails['host'].':'.$hostDetails['port'];
         $path = null;
@@ -315,6 +325,11 @@ class Connection implements ConnectionInterface
         }
 
         return $uri ?? '';
+    }
+
+    public function getHeaders(): array
+    {
+        return $this->headers;
     }
 
     /**

--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -136,7 +136,7 @@ class Connection implements ConnectionInterface
 
         // Add the User-Agent using the format: <client-repo-name>/<client-version> (metadata-values)
         $this->headers['User-Agent'] = [sprintf(
-            "elasticsearch-php/%s (%s %s, PHP %s)",
+            "elasticsearch-php/%s (%s %s; PHP %s)",
             Client::VERSION,
             php_uname("s"),
             php_uname("r"),

--- a/tests/Elasticsearch/Tests/Connections/ConnectionTest.php
+++ b/tests/Elasticsearch/Tests/Connections/ConnectionTest.php
@@ -31,7 +31,8 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
         ];
 
         $connection = new Connection(
-            function(){},
+            function () {
+            },
             $host,
             $params,
             $this->serializer,
@@ -50,7 +51,8 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
         ];
 
         $connection = new Connection(
-            function(){},
+            function () {
+            },
             $host,
             $params,
             $this->serializer,

--- a/tests/Elasticsearch/Tests/Connections/ConnectionTest.php
+++ b/tests/Elasticsearch/Tests/Connections/ConnectionTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Elasticsearch\Tests\Connections;
+
+use Elasticsearch\Client;
+use Elasticsearch\ClientBuilder;
+use Elasticsearch\Connections\Connection;
+use Elasticsearch\Serializers\SerializerInterface;
+use Psr\Log\LoggerInterface;
+
+class ConnectionTest extends \PHPUnit\Framework\TestCase
+{
+    private $logger;
+    private $trace;
+    private $serializer;
+
+    protected function setUp()
+    {
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->trace = $this->createMock(LoggerInterface::class);
+        $this->serializer = $this->createMock(SerializerInterface::class);
+    }
+
+    public function testConstructor()
+    {
+        $params = [];
+        $host = [
+            'host' => 'localhost'
+        ];
+
+        $connection = new Connection(
+            function(){},
+            $host,
+            $params,
+            $this->serializer,
+            $this->logger,
+            $this->trace
+        );
+
+        $this->assertInstanceOf(Connection::class, $connection);
+    }
+
+    public function testGetHeadersContainUserAgent()
+    {
+        $params = [];
+        $host = [
+            'host' => 'localhost'
+        ];
+
+        $connection = new Connection(
+            function(){},
+            $host,
+            $params,
+            $this->serializer,
+            $this->logger,
+            $this->trace
+        );
+
+        $headers =  $connection->getHeaders();
+
+        $this->assertArrayHasKey('User-Agent', $headers);
+        $this->assertContains('elasticsearch-php/'. Client::VERSION, $headers['User-Agent'][0]);
+    }
+
+    public function testUserAgentHeaderIsSent()
+    {
+        $params = [];
+        $host = [
+            'host' => 'localhost'
+        ];
+
+        $connection = new Connection(
+            ClientBuilder::defaultHandler(),
+            $host,
+            $params,
+            $this->serializer,
+            $this->logger,
+            $this->trace
+        );
+        $result = $connection->performRequest('GET', '/');
+        $request = $connection->getLastRequestInfo()['request'];
+        $this->assertArrayHasKey('User-Agent', $request['headers']);
+        $this->assertContains('elasticsearch-php/'. Client::VERSION, $request['headers']['User-Agent'][0]);
+    }
+}


### PR DESCRIPTION
This PR adds the `User-Agent` header in the HTTP request, with the format:
```
<client-repo-name>/<client-version> (metadata-values)
```
where as the `client-repo-name` defines the repository name of the client e.g. `elasticsearch-js` and the `client-version` the current version of this client.

`metadata-values` is a list of semicolon seperated key-values, that allow to add more data enclosed by brackets (`()`). Each key-value pair is separated by a whitespace, e.g. `PHP 7.3.6`
In case no metadata is appended at all, the brackets must be omited.