### PR TITLE
Wait for the future response

### DIFF
--- a/src/Elasticsearch/ConnectionPool/SniffingConnectionPool.php
+++ b/src/Elasticsearch/ConnectionPool/SniffingConnectionPool.php
@@ -124,7 +124,7 @@ class SniffingConnectionPool extends AbstractConnectionPool implements Connectio
         return true;
     }
 
-    private function parseClusterState(string $transportSchema, array $nodeInfo): array
+    private function parseClusterState(string $transportSchema, $nodeInfo): array
     {
         $pattern       = '/([^:]*):([0-9]+)/';
         $schemaAddress = $transportSchema . '_address';

--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -457,7 +457,9 @@ class Connection implements ConnectionInterface
             ]
         ];
 
-        return $this->performRequest('GET', '/_nodes/', null, null, $options);
+        $future = $this->performRequest('GET', '/_nodes/', null, null, $options);
+
+        return $future->wait();
     }
 
     public function isAlive(): bool

--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -448,7 +448,10 @@ class Connection implements ConnectionInterface
         }
     }
 
-    public function sniff(): array
+    /**
+     * @return array|\GuzzleHttp\Ring\Future\FutureArray
+     */
+    public function sniff()
     {
         $options = [
             'client' => [
@@ -457,9 +460,7 @@ class Connection implements ConnectionInterface
             ]
         ];
 
-        $future = $this->performRequest('GET', '/_nodes/', null, null, $options);
-
-        return $future->wait();
+        return $this->performRequest('GET', '/_nodes/', null, null, $options);
     }
 
     public function isAlive(): bool


### PR DESCRIPTION
The current `SniffingConnectionPool` uses the sniff method on the `Connection` class but this needs to return an array. The current implementation fails because a future request is returned.

This merge requests adds the wait function for the return.