### PR TITLE
Fix #902 Incorrect return typehint when using async requests

### DIFF
--- a/src/Elasticsearch/Client.php
+++ b/src/Elasticsearch/Client.php
@@ -1550,9 +1550,9 @@ class Client
     }
 
     /**
-     * @throws \Exception
+     * @return callable|array
      */
-    private function performRequest(AbstractEndpoint $endpoint): array
+    private function performRequest(AbstractEndpoint $endpoint)
     {
         $promise =  $this->transport->performRequest(
             $endpoint->getMethod(),


### PR DESCRIPTION
This PR fixes #902 removing the typehint array from `Client::performRequest()`. 
It includes also a unit test for reproduction the issue.