### PR TITLE
Fix for #906 + fixed travis allow_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,12 @@ matrix:
   include:
     - php: 7.1
       env: ES_VERSION="7.0.0"
-
     - php: 7.2
       env: ES_VERSION="7.0.0"
-
     - php: 7.3
       env: ES_VERSION="7.0.0"
+    - php: 7.3
+      env: ES_VERSION="7.1.0"
   allow_failures:
     - php: 7.3
       env: ES_VERSION="7.1.0"

--- a/src/Elasticsearch/Client.php
+++ b/src/Elasticsearch/Client.php
@@ -1026,7 +1026,6 @@ class Client
     {
         $scrollID = $this->extractArgument($params, 'scroll_id');
         $body = $this->extractArgument($params, 'body');
-        $scroll = $this->extractArgument($params, 'scroll');
 
         /**
  * @var callable $endpointBuilder


### PR DESCRIPTION
This PR fixes #906, removing the `extractArgument()` for `scroll`. This PR also fixes the allowed_failures feature of Travis CI.