### PR TITLE
Prep for 7.1.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,10 @@ matrix:
   include:
     - php: 7.1
       env: ES_VERSION="7.1.0"
-
     - php: 7.2
       env: ES_VERSION="7.1.0"
-
     - php: 7.3
       env: ES_VERSION="7.1.0"
-
   allow_failures:
     - php: 7.3
       env: ES_VERSION="7.2.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,16 +13,17 @@ matrix:
   fast_finish: true
   include:
     - php: 7.1
-      env: ES_VERSION="7.0.0"
+      env: ES_VERSION="7.1.0"
 
     - php: 7.2
-      env: ES_VERSION="7.0.0"
+      env: ES_VERSION="7.1.0"
 
     - php: 7.3
-      env: ES_VERSION="7.0.0"
+      env: ES_VERSION="7.1.0"
+
   allow_failures:
     - php: 7.3
-      env: ES_VERSION="7.1.0"
+      env: ES_VERSION="7.2.0"
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
       env: ES_VERSION="7.1.0"
     - php: 7.3
       env: ES_VERSION="7.1.0"
+    - php: 7.3
+      env: ES_VERSION="7.2.0"
   allow_failures:
     - php: 7.3
       env: ES_VERSION="7.2.0"

--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -283,6 +283,9 @@ class Connection implements ConnectionInterface
                 } else {
                     $connection->markAlive();
 
+                    if (isset($response['headers']['Warning'])) {
+                        $this->logWarning($request, $response);
+                    }
                     if (isset($response['body']) === true) {
                         $response['body'] = stream_get_contents($response['body']);
                         $this->lastRequest['response']['body'] = $response['body'];
@@ -340,6 +343,11 @@ class Connection implements ConnectionInterface
     public function getHeaders(): array
     {
         return $this->headers;
+    }
+
+    public function logWarning(array $request, array $response): void
+    {
+        $this->log->warning('Deprecation', $response['headers']['Warning']);
     }
 
     /**

--- a/tests/Elasticsearch/Tests/YamlRunnerTest.php
+++ b/tests/Elasticsearch/Tests/YamlRunnerTest.php
@@ -66,61 +66,26 @@ class YamlRunnerTest extends \PHPUnit\Framework\TestCase
     ];
 
     private static $skippedTests = [
-        'nodes.stats/30_discovery.yml#Discovery stats' => 'Failing on ES 6.1+: nodes.$master.discovery is an empty array, expected to have cluster_state_queue field in it',
-        'indices.stats/20_translog.yml#Translog retention' => 'Failing on ES 6.3+: Failed asserting that 495 is equal to <string:$creation_size> or is less than \'$creation_size\'',
-        'indices.shrink/30_copy_settings.yml#Copy settings during shrink index' => 'Failing on ES 6.4+: Failed to match in test "Copy settings during shrink index". Expected [\'4\'] does not match [false] ',
     ];
 
     private static $skippedTestsIfPhpLessThan = [
-        // Failing on ES 6.7+ only with PHP 7.0: Cannot access empty property
-        'indices.put_mapping/11_basic_with_types.yml#Create index with invalid mappings' => '7.1.0',
-        'indices.put_mapping/10_basic.yml#Create index with invalid mappings' => '7.1.0',
-        'indices.create/11_basic_with_types.yml#Create index with invalid mappings' => '7.1.0',
-        'indices.create/11_basic_with_types.yml#Create index with no type mappings' => '7.1.0',
-        'indices.create/10_basic.yml#Create index with invalid mappings' => '7.1.0',
     ];
     /**
      * @var array A list of skipped test with their reasons
      */
     private static $skippedFiles = [
-
         'cat.nodeattrs/10_basic.yml' => 'Using java regex fails in PHP',
-        'cat.nodeattrs/10_basic.yaml' => 'Using java regex fails in PHP',
-
         'cat.repositories/10_basic.yml' => 'Using java regex fails in PHP',
-        'cat.repositories/10_basic.yaml' => 'Using java regex fails in PHP',
-
-        'indices.shrink/10_basic.yml' => 'Shrink tests seem to require multiple nodes',
-        'indices.shrink/10_basic.yaml' => 'Shrink tests seem to require multiple nodes',
-
-        'indices.rollover/10_basic.yml' => 'Rollover test seems buggy atm',
-        'indices.rollover/10_basic.yaml' => 'Rollover test seems buggy atm',
-
-        'get_source/70_source_filtering.yml' => 'Expected [\'v1\'] does not match [false]',
-        'get_source/71_source_filtering_with_types.yml' => 'Expected [\'v1\'] does not match [false]',
+        'indices.rollover/10_basic.yml' => 'Rollover test seems buggy atm'
     ];
 
     /**
      * @var array A list of files to skip completely, due to fatal parsing errors
      */
     private static $fatalFiles = [
-        'indices.create/10_basic.yml' => 'Temporary: Yaml parser doesnt support "inline" empty keys',
-        'indices.create/10_basic.yaml' => 'Temporary: Yaml parser doesnt support "inline" empty keys',
-
-        'indices.put_mapping/10_basic.yml' => 'Temporary: Yaml parser doesnt support "inline" empty keys',
-        'indices.put_mapping/10_basic.yaml' => 'Temporary: Yaml parser doesnt support "inline" empty keys',
-
         'search/110_field_collapsing.yml' => 'Temporary: parse error, malformed inline yaml',
-        'search/110_field_collapsing.yaml' => 'Temporary: parse error, malformed inline yaml',
-        'range/10_basic.yml' => 'Temporary: parse error, malformed inline yaml',
-
-        'cat.nodes/10_basic.yml' => 'Temporary: parse error, something about $body: |',
-        'cat.nodes/10_basic.yaml' => 'Temporary: parse error, something about $body: |',
-        'search.aggregation/180_percentiles_tdigest_metric.yml' => 'array of objects, unclear how to fix',
-        'search.aggregation/190_percentiles_hdr_metric.yml' => 'array of objects, unclear how to fix',
         'search/190_index_prefix_search.yml' => 'bad yaml array syntax',
-        'search.aggregation/230_composite.yml' => 'bad yaml array syntax',
-        'search/30_limits.yml' => 'bad regex'
+        'search.aggregation/230_composite.yml' => 'bad yaml array syntax'
     ];
 
     /**
@@ -843,7 +808,7 @@ class YamlRunnerTest extends \PHPUnit\Framework\TestCase
         $finder->name('*.yml');
 
         // *.yaml files should be included until the library is ES 6.0+ only
-        $finder->name('*.yaml');
+        //$finder->name('*.yaml');
 
         $filter = getenv('TEST_CASE') !== false ? getenv('TEST_CASE') : null;
 
@@ -1080,22 +1045,6 @@ class YamlRunnerTest extends \PHPUnit\Framework\TestCase
         curl_close($ch);
 
         $ch = curl_init($host."/_template/*");
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "DELETE");
-        curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);
-
-        $response = curl_exec($ch);
-        curl_close($ch);
-
-        $ch = curl_init($host."/_snapshot/*/*");
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "DELETE");
-        curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);
-
-        $response = curl_exec($ch);
-        curl_close($ch);
-
-        $ch = curl_init($host."/_snapshot/*");
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "DELETE");
         curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);


### PR DESCRIPTION
This PR contains some changes/fix for 7.1.0 release:
- removed some of the skipped YAML tests (now there are "only" 6 tests skipped, compared with the previous 20);
- fixed `allow_failures` in travis;
- added a WARNING log when Elasticsearch respond with a `Warning` header (usually a deprecation notice);
- removed DELETE `/_snapshot/*/*` and `/_snapshot/*` calls in `YamlRunnerTest::clean()` (discovered also that the usage of wildcard `*` is not allowed anymore for DELETE).