### PR TITLE
Remove type hint in setBody method

### DIFF
--- a/src/Elasticsearch/Endpoints/Ingest/Pipeline/Put.php
+++ b/src/Elasticsearch/Endpoints/Ingest/Pipeline/Put.php
@@ -18,7 +18,7 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  */
 class Put extends AbstractEndpoint
 {
-    public function setBody(string $body): Put
+    public function setBody($body): Put
     {
         if (isset($body) !== true) {
             return $this;


### PR DESCRIPTION
Fix type hinting for setBody in `Elasticsearch\Endpoints\Ingest\Pipeline\Put;`, every `setBody` method  in other Endpoints doesn't have this type hinting.

Closes https://github.com/elastic/elasticsearch-php/issues/912