### PR TITLE
Enhancement: Cache dependencies installed with composer between builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: php
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 services:
   - docker
 


### PR DESCRIPTION
This PR

* [x] caches dependencies as installed with `composer` between builds on Travis