### PR TITLE
Fix: Method should return an array

### DIFF
--- a/src/Elasticsearch/Namespaces/IndicesNamespace.php
+++ b/src/Elasticsearch/Namespaces/IndicesNamespace.php
@@ -48,7 +48,7 @@ class IndicesNamespace extends AbstractNamespace
      *
      * @param $params array Associative array of parameters
      *
-     * @return bool
+     * @return array
      */
     public function get($params)
     {


### PR DESCRIPTION
This PR

* [x] fixes a return type specified in a DocBlock

💁‍♂ This method should clearly return an `array`.