### PR TITLE
Fix #940 adding getAliases() proxy to getAlias()

### DIFF
--- a/src/Elasticsearch/Namespaces/IndicesNamespace.php
+++ b/src/Elasticsearch/Namespaces/IndicesNamespace.php
@@ -685,6 +685,17 @@ class IndicesNamespace extends AbstractNamespace
     }
 
     /**
+     * Alias function to getAlias()
+     *
+     * @deprecated added to prevent BC break introduced in 7.2.0
+     * @see https://github.com/elastic/elasticsearch-php/issues/940
+     */
+    public function getAliases(array $params)
+    {
+        return $this->getAlias($params);
+    }
+
+    /**
      * Endpoint: indices.get_alias
      *
      * @see http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html


### PR DESCRIPTION
This PR fixes #940 adding a proxy function `getAliases()` to getAlias() in `Elasticsearch\Namespaces\IndicesNamespace` to prevent BC breaks for 7.2.0.