### PR TITLE
Fix #946 re-introducing  as optional param for getAliases()

### DIFF
--- a/src/Elasticsearch/Namespaces/IndicesNamespace.php
+++ b/src/Elasticsearch/Namespaces/IndicesNamespace.php
@@ -687,10 +687,10 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Alias function to getAlias()
      *
-     * @deprecated added to prevent BC break introduced in 7.2.0
+     * @deprecated added to prevent BC break introduced in 7.2.0 and 7.2.1
      * @see https://github.com/elastic/elasticsearch-php/issues/940
      */
-    public function getAliases(array $params)
+    public function getAliases(array $params = [])
     {
         return $this->getAlias($params);
     }


### PR DESCRIPTION
This PR fixes #946 re-introducing `$params` as optional parameter in `IndicesNamespace::getAliases()`.