### PR TITLE
Removed unused Monolog in ClientBuilder

### DIFF
--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -24,9 +24,6 @@ use GuzzleHttp\Ring\Client\CurlMultiHandler;
 use GuzzleHttp\Ring\Client\Middleware;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use Monolog\Logger;
-use Monolog\Handler\StreamHandler;
-use Monolog\Processor\IntrospectionProcessor;
 
 /**
  * Class ClientBuilder


### PR DESCRIPTION
This PR fixes #813 issue, removing unused `Monolog` classes in `ClientBuilder`. Even if the use of `Monolog` is not in invoked in `ClientBuilder`, this can produce errors if you want to mock the class for testing.

**NOTE** this PR should also be merged in 6.x and 5.0 branches.