### PR TITLE
Fix prependMissingScheme with underscore

### DIFF
--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -686,7 +686,7 @@ class ClientBuilder
 
     private function prependMissingScheme(string $host): string
     {
-        if (!filter_var($host, FILTER_VALIDATE_URL)) {
+        if (!preg_match("/^https?:\/\//", $host)) {
             $host = 'http://' . $host;
         }
 

--- a/tests/Elasticsearch/Tests/ClientTest.php
+++ b/tests/Elasticsearch/Tests/ClientTest.php
@@ -312,6 +312,17 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(9200, $host->getPort());
         $this->assertSame("https", $host->getTransportSchema());
         $this->assertSame("user:pass", $host->getUserPass());
+        
+        $client = Elasticsearch\ClientBuilder::create()->setHosts(
+            [
+            'https://user:pass@the_foo.com:9200'
+            ]
+        )->build();
+        $host = $client->transport->getConnection();
+        $this->assertSame("the_foo.com", $host->getHost());
+        $this->assertSame(9200, $host->getPort());
+        $this->assertSame("https", $host->getTransportSchema());
+        $this->assertSame("user:pass", $host->getUserPass());
     }
 
     public function testExtendedHosts()
@@ -417,7 +428,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             // good
         }
 
-        // Underscore host, questionably legal, but inline method would break
+        // Underscore host, questionably legal
         $client = Elasticsearch\ClientBuilder::create()->setHosts(
             [
             [


### PR DESCRIPTION
While working with ElasticSearch in docker using docker-compose - hostname for my ES was `elasticsearch.myproject_default`. I tried to use it with this ES client - it failed to connect. 

I configured hostname to `http://elasticsearch.myproject_default:9200`. After changing to `elasticsearch.myproject_default:9200` my issue was fixed, but that wasn't expected at all

Deeper investigation showed that issue caused by incorrect URL validation. More info: https://stackoverflow.com/questions/39539468/php-filter-validate-url-not-finding-subdomains-with-underscore