### PR TITLE
Added the HTTP port in the log messages

### DIFF
--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -374,6 +374,7 @@ class Connection implements ConnectionInterface
             array(
                 'method'    => $request['http_method'],
                 'uri'       => $response['effective_url'],
+                'port'      => $response['transfer_stats']['primary_port'],
                 'headers'   => $request['headers'],
                 'HTTP code' => $response['status'],
                 'duration'  => $response['transfer_stats']['total_time'],
@@ -408,11 +409,13 @@ class Connection implements ConnectionInterface
     public function logRequestFail(array $request, array $response, \Exception $exception): void
     {
         $this->log->debug('Request Body', array($request['body']));
+        
         $this->log->warning(
             'Request Failure:',
             array(
                 'method'    => $request['http_method'],
                 'uri'       => $response['effective_url'],
+                'port'      => $response['transfer_stats']['primary_port'],
                 'headers'   => $request['headers'],
                 'HTTP code' => $response['status'],
                 'duration'  => $response['transfer_stats']['total_time'],

--- a/tests/Elasticsearch/Tests/ClientBuilder/ArrayLogger.php
+++ b/tests/Elasticsearch/Tests/ClientBuilder/ArrayLogger.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types = 1);
+
+namespace Elasticsearch\Tests\ClientBuilder;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+
+class ArrayLogger implements LoggerInterface
+{
+    public $output = [];
+
+    public function emergency($message, array $context = array())
+    {
+        $this->log(LogLevel::EMERGENCY, $message, $context);
+    }
+
+    public function alert($message, array $context = array())
+    {
+        $this->log(LogLevel::ALERT, $message, $context);
+    }
+
+    public function critical($message, array $context = array())
+    {
+        $this->log(LogLevel::CRITICAL, $message, $context);
+    }
+
+    public function error($message, array $context = array())
+    {
+        $this->log(LogLevel::ERROR, $message, $context);
+    }
+
+    public function warning($message, array $context = array())
+    {
+        $this->log(LogLevel::WARNING, $message, $context);
+    }
+
+    public function notice($message, array $context = array())
+    {
+        $this->log(LogLevel::NOTICE, $message, $context);
+    }
+
+    public function info($message, array $context = array())
+    {
+        $this->log(LogLevel::INFO, $message, $context);
+    }
+
+    public function debug($message, array $context = array())
+    {
+        $this->log(LogLevel::DEBUG, $message, $context);
+    }
+
+    public function log($level, $message, array $context = array())
+    {
+        $this->output[] = sprintf("%s: %s %s", $level, $message, json_encode($context));
+    }
+}

--- a/tests/Elasticsearch/Tests/ClientBuilder/DummyLogger.php
+++ b/tests/Elasticsearch/Tests/ClientBuilder/DummyLogger.php
@@ -3,55 +3,7 @@ declare(strict_types = 1);
 
 namespace Elasticsearch\Tests\ClientBuilder;
 
-use Psr\Log\LoggerInterface;
-use Psr\Log\LogLevel;
-
-class DummyLogger implements LoggerInterface
+class DummyLogger
 {
-    public $output = [];
-
-    public function emergency($message, array $context = array())
-    {
-        $this->log(LogLevel::EMERGENCY, $message, $context);
-    }
-
-    public function alert($message, array $context = array())
-    {
-        $this->log(LogLevel::ALERT, $message, $context);
-    }
-
-    public function critical($message, array $context = array())
-    {
-        $this->log(LogLevel::CRITICAL, $message, $context);
-    }
-
-    public function error($message, array $context = array())
-    {
-        $this->log(LogLevel::ERROR, $message, $context);
-    }
-
-    public function warning($message, array $context = array())
-    {
-        $this->log(LogLevel::WARNING, $message, $context);
-    }
-
-    public function notice($message, array $context = array())
-    {
-        $this->log(LogLevel::NOTICE, $message, $context);
-    }
-
-    public function info($message, array $context = array())
-    {
-        $this->log(LogLevel::INFO, $message, $context);
-    }
-
-    public function debug($message, array $context = array())
-    {
-        $this->log(LogLevel::DEBUG, $message, $context);
-    }
-
-    public function log($level, $message, array $context = array())
-    {
-        $this->output[] = sprintf("%s: %s %s", $level, $message, json_encode($context));
-    }
+    
 }

--- a/tests/Elasticsearch/Tests/ClientBuilder/DummyLogger.php
+++ b/tests/Elasticsearch/Tests/ClientBuilder/DummyLogger.php
@@ -3,7 +3,55 @@ declare(strict_types = 1);
 
 namespace Elasticsearch\Tests\ClientBuilder;
 
-class DummyLogger
-{
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 
+class DummyLogger implements LoggerInterface
+{
+    public $output = [];
+
+    public function emergency($message, array $context = array())
+    {
+        $this->log(LogLevel::EMERGENCY, $message, $context);
+    }
+
+    public function alert($message, array $context = array())
+    {
+        $this->log(LogLevel::ALERT, $message, $context);
+    }
+
+    public function critical($message, array $context = array())
+    {
+        $this->log(LogLevel::CRITICAL, $message, $context);
+    }
+
+    public function error($message, array $context = array())
+    {
+        $this->log(LogLevel::ERROR, $message, $context);
+    }
+
+    public function warning($message, array $context = array())
+    {
+        $this->log(LogLevel::WARNING, $message, $context);
+    }
+
+    public function notice($message, array $context = array())
+    {
+        $this->log(LogLevel::NOTICE, $message, $context);
+    }
+
+    public function info($message, array $context = array())
+    {
+        $this->log(LogLevel::INFO, $message, $context);
+    }
+
+    public function debug($message, array $context = array())
+    {
+        $this->log(LogLevel::DEBUG, $message, $context);
+    }
+
+    public function log($level, $message, array $context = array())
+    {
+        $this->output[] = sprintf("%s: %s %s", $level, $message, json_encode($context));
+    }
 }

--- a/tests/Elasticsearch/Tests/ClientIntegrationTests.php
+++ b/tests/Elasticsearch/Tests/ClientIntegrationTests.php
@@ -6,7 +6,7 @@ namespace Elasticsearch\Tests;
 
 use Elasticsearch\ClientBuilder;
 use Elasticsearch\Common\Exceptions\Missing404Exception;
-use Elasticsearch\Tests\ClientBuilder\DummyLogger;
+use Elasticsearch\Tests\ClientBuilder\ArrayLogger;
 use Psr\Log\LogLevel;
 
 /**
@@ -26,40 +26,38 @@ class ClientIntegrationTests extends \PHPUnit\Framework\TestCase
         if (empty(getenv('ES_TEST_HOST'))) {
             $this->markTestSkipped('I cannot execute integration test without ES_TEST_HOST env');
         }
+        $this->logger = new ArrayLogger();
     }
 
     public function testLogRequestSuccessHasInfoNotEmpty()
     {
-        $logger = new DummyLogger();
         $client = ClientBuilder::create()
             ->setHosts([getenv('ES_TEST_HOST')])
-            ->setLogger($logger)
+            ->setLogger($this->logger)
             ->build();
 
         $result = $client->info();
 
-        $this->assertNotEmpty($this->getLevelOutput(LogLevel::INFO, $logger->output));
+        $this->assertNotEmpty($this->getLevelOutput(LogLevel::INFO, $this->logger->output));
     }
 
     public function testLogRequestSuccessHasPortInInfo()
     {
-        $logger = new DummyLogger();
         $client = ClientBuilder::create()
             ->setHosts([getenv('ES_TEST_HOST')])
-            ->setLogger($logger)
+            ->setLogger($this->logger)
             ->build();
 
         $result = $client->info();
 
-        $this->assertContains('"port"', $this->getLevelOutput(LogLevel::INFO, $logger->output));
+        $this->assertContains('"port"', $this->getLevelOutput(LogLevel::INFO, $this->logger->output));
     }
 
     public function testLogRequestFailHasWarning()
     {
-        $logger = new DummyLogger();
         $client = ClientBuilder::create()
             ->setHosts([getenv('ES_TEST_HOST')])
-            ->setLogger($logger)
+            ->setLogger($this->logger)
             ->build();
 
         try {
@@ -68,7 +66,7 @@ class ClientIntegrationTests extends \PHPUnit\Framework\TestCase
                 'id' => 'bar'
             ]);
         } catch (Missing404Exception $e) {
-            $this->assertNotEmpty($this->getLevelOutput(LogLevel::WARNING, $logger->output));
+            $this->assertNotEmpty($this->getLevelOutput(LogLevel::WARNING, $this->logger->output));
         }
     }
 


### PR DESCRIPTION
This PR adds the HTTP port in `Connection::logRequestSuccess()` and `Connection::logRequestFail()`. It solves the issue #925.