### PR TITLE
Mutator for X-Opaque-Id Header

### DIFF
--- a/docs/per-request-configuration.asciidoc
+++ b/docs/per-request-configuration.asciidoc
@@ -4,6 +4,32 @@
 There are several configurations that can be set on a per-request basis, rather than at a connection- or client-level.
 These are specified as part of the request associative array.
 
+
+=== Request Identification
+
+You can enrich your requests against Elasticsearch with an identifier string, that allows you to discover this identifier
+in https://www.elastic.co/guide/en/elasticsearch/reference/7.4/logging.html#deprecation-logging[deprecation logs], to support you with
+https://www.elastic.co/guide/en/elasticsearch/reference/7.4/index-modules-slowlog.html#_identifying_search_slow_log_origin[identifying search slow log origin]
+or to help with https://www.elastic.co/guide/en/elasticsearch/reference/current/tasks.html#_identifying_running_tasks[identifying running tasks].
+
+
+[source,php]
+----
+$client = ClientBuilder::create()->build();
+
+$params = [
+    'index' => 'test',
+    'id'    => 1,
+    'client' => [
+        'opaqueId' => 'app17@dc06.eu_user1234', <1>
+    ]
+];
+$response = $client->get($params);
+
+----
+<1> This will populate the `X-Opaque-Id` header with the value `app17@dc06_user1234_1234`
+
+
 === Ignoring exceptions
 The library attempts to throw exceptions for common problems.  These exceptions match the HTTP response code provided
 by Elasticsearch.  For example, attempting to GET a nonexistent document will throw a `MissingDocument404Exception`.

--- a/docs/per-request-configuration.asciidoc
+++ b/docs/per-request-configuration.asciidoc
@@ -27,7 +27,7 @@ $params = [
 $response = $client->get($params);
 
 ----
-<1> This will populate the `X-Opaque-Id` header with the value `app17@dc06_user1234_1234`
+<1> This will populate the `X-Opaque-Id` header with the value `app17@dc06.eu_user1234`
 
 
 === Ignoring exceptions

--- a/src/Elasticsearch/Endpoints/AbstractEndpoint.php
+++ b/src/Elasticsearch/Endpoints/AbstractEndpoint.php
@@ -225,7 +225,7 @@ abstract class AbstractEndpoint
 
         $whitelist = array_merge(
             $this->getParamWhitelist(),
-            [ 'pretty', 'human', 'error_trace', 'source', 'filter_path' ]
+            [ 'pretty', 'human', 'error_trace', 'source', 'filter_path', 'opaqueId' ]
         );
 
         $invalid = array_diff(array_keys($params), $whitelist);
@@ -261,6 +261,15 @@ abstract class AbstractEndpoint
             } else {
                 $this->options['client']['ignore'] = [$ignore];
             }
+        }
+
+        // Check if the opaqueId is populated and add the header
+        if (isset($params['opaqueId']) === true) {
+            if (isset($this->options['client']['headers']) === false) {
+                $this->options['client']['headers'] = [];
+            }
+            $this->options['client']['headers']['x-opaque-id'] = [trim($params['opaqueId'])];
+            unset($params['opaqueId']);
         }
     }
 

--- a/src/Elasticsearch/Endpoints/AbstractEndpoint.php
+++ b/src/Elasticsearch/Endpoints/AbstractEndpoint.php
@@ -249,6 +249,15 @@ abstract class AbstractEndpoint
     {
         // Extract out client options, then start transforming
         if (isset($params['client']) === true) {
+            // Check if the opaqueId is populated and add the header
+            if (isset($params['client']['opaqueId']) === true) {
+                if (isset($params['client']['headers']) === false) {
+                    $params['client']['headers'] = [];
+                }
+                $params['client']['headers']['x-opaque-id'] = [trim($params['client']['opaqueId'])];
+                unset($params['client']['opaqueId']);
+            }
+
             $this->options['client'] = $params['client'];
             unset($params['client']);
         }
@@ -261,15 +270,6 @@ abstract class AbstractEndpoint
             } else {
                 $this->options['client']['ignore'] = [$ignore];
             }
-        }
-
-        // Check if the opaqueId is populated and add the header
-        if (isset($params['opaqueId']) === true) {
-            if (isset($this->options['client']['headers']) === false) {
-                $this->options['client']['headers'] = [];
-            }
-            $this->options['client']['headers']['x-opaque-id'] = [trim($params['opaqueId'])];
-            unset($params['opaqueId']);
         }
     }
 

--- a/tests/Elasticsearch/Tests/Endpoints/AbstractEndpointTest.php
+++ b/tests/Elasticsearch/Tests/Endpoints/AbstractEndpointTest.php
@@ -10,6 +10,11 @@ class AbstractEndpointTest extends \PHPUnit\Framework\TestCase
 {
     private $endpoint;
 
+    protected function setUp()
+    {
+        $this->endpoint = $this->getMockForAbstractClass(AbstractEndpoint::class);
+    }
+
     public static function invalidParameters(): array
     {
         return [
@@ -20,6 +25,8 @@ class AbstractEndpointTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @dataProvider invalidParameters
+     *
+     * @covers AbstractEndpoint::setParams
      */
     public function testInvalidParamsCauseErrorsWhenProvidedToSetParams(array $params)
     {
@@ -32,8 +39,22 @@ class AbstractEndpointTest extends \PHPUnit\Framework\TestCase
         $this->endpoint->setParams($params);
     }
 
-    protected function setUp()
+    /**
+     * @covers AbstractEndpoint::setParams
+     * @covers AbstractEndpoint::extractOptions
+     * @covers AbstractEndpoint::getOptions
+     */
+    public function testOpaqueIdInHeaders()
     {
-        $this->endpoint = $this->getMockForAbstractClass(AbstractEndpoint::class);
+        $params = ['opaqueId' => 'test_id_' . rand(1000, 9999)];
+        $this->endpoint->setParams($params);
+
+        $options = $this->endpoint->getOptions();
+        $this->assertArrayHasKey('client', $options);
+        $this->assertArrayHasKey('headers', $options['client']);
+        $this->assertArrayHasKey('x-opaque-id', $options['client']['headers']);
+        $this->assertNotEmpty($options['client']['headers']['x-opaque-id']);
+        $this->assertEquals($params['opaqueId'], $options['client']['headers']['x-opaque-id'][0]);
     }
+
 }

--- a/tests/Elasticsearch/Tests/Endpoints/AbstractEndpointTest.php
+++ b/tests/Elasticsearch/Tests/Endpoints/AbstractEndpointTest.php
@@ -46,7 +46,7 @@ class AbstractEndpointTest extends \PHPUnit\Framework\TestCase
      */
     public function testOpaqueIdInHeaders()
     {
-        $params = ['opaqueId' => 'test_id_' . rand(1000, 9999)];
+        $params = ['client' => ['opaqueId' => 'test_id_' . rand(1000, 9999)]];
         $this->endpoint->setParams($params);
 
         $options = $this->endpoint->getOptions();
@@ -54,7 +54,7 @@ class AbstractEndpointTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey('headers', $options['client']);
         $this->assertArrayHasKey('x-opaque-id', $options['client']['headers']);
         $this->assertNotEmpty($options['client']['headers']['x-opaque-id']);
-        $this->assertEquals($params['opaqueId'], $options['client']['headers']['x-opaque-id'][0]);
+        $this->assertEquals($params['client']['opaqueId'], $options['client']['headers']['x-opaque-id'][0]);
     }
 
 }

--- a/tests/Elasticsearch/Tests/Endpoints/AbstractEndpointTest.php
+++ b/tests/Elasticsearch/Tests/Endpoints/AbstractEndpointTest.php
@@ -56,5 +56,4 @@ class AbstractEndpointTest extends \PHPUnit\Framework\TestCase
         $this->assertNotEmpty($options['client']['headers']['x-opaque-id']);
         $this->assertEquals($params['client']['opaqueId'], $options['client']['headers']['x-opaque-id'][0]);
     }
-
 }


### PR DESCRIPTION
This PR adds support for simplified access to the `X-Opaque-Id` header.