### PR TITLE
Add missing leading slash for the put mapping endpoint (fixes #969)

### DIFF
--- a/src/Elasticsearch/Endpoints/Indices/PutMapping.php
+++ b/src/Elasticsearch/Endpoints/Indices/PutMapping.php
@@ -35,7 +35,7 @@ class PutMapping extends AbstractEndpoint
             return "/_mappings/$type";
         }
         if (isset($index)) {
-            return "$index/_mapping";
+            return "/$index/_mapping";
         }
         throw new RuntimeException('Missing parameter for the endpoint indices.put_mapping');
     }


### PR DESCRIPTION
Closes #969 

The omission of the leading slash causes an improper endpoint URL to be generated, as described in #969 
