### PR TITLE
Added the suppress error operator for @trigger_error()

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,8 +10,6 @@
 >
     <php>
         <env name="ES_TEST_HOST" value=""/>
-        <!-- Disable E_USER_DEPRECATED setting E_ALL & ~E_USER_DEPRECATED-->
-        <ini name="error_reporting" value="16383"/>
     </php>
     <testsuites>
         <testsuite name="Tests">

--- a/src/Elasticsearch/Endpoints/Bulk.php
+++ b/src/Elasticsearch/Endpoints/Bulk.php
@@ -31,7 +31,7 @@ class Bulk extends AbstractEndpoint
         $index = $this->index ?? null;
         $type = $this->type ?? null;
         if (isset($type)) {
-            trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
+            @trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
         }
 
         if (isset($index) && isset($type)) {

--- a/src/Elasticsearch/Endpoints/ClearScroll.php
+++ b/src/Elasticsearch/Endpoints/ClearScroll.php
@@ -24,7 +24,7 @@ class ClearScroll extends AbstractEndpoint
     {
         $scroll_id = $this->scroll_id ?? null;
         if (isset($scroll_id)) {
-            trigger_error('A scroll id can be quite large and should be specified as part of the body', E_USER_DEPRECATED);
+            @trigger_error('A scroll id can be quite large and should be specified as part of the body', E_USER_DEPRECATED);
         }
 
         if (isset($scroll_id)) {

--- a/src/Elasticsearch/Endpoints/Count.php
+++ b/src/Elasticsearch/Endpoints/Count.php
@@ -24,7 +24,7 @@ class Count extends AbstractEndpoint
         $index = $this->index ?? null;
         $type = $this->type ?? null;
         if (isset($type)) {
-            trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
+            @trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
         }
 
         if (isset($index) && isset($type)) {

--- a/src/Elasticsearch/Endpoints/Create.php
+++ b/src/Elasticsearch/Endpoints/Create.php
@@ -36,7 +36,7 @@ class Create extends AbstractEndpoint
         $index = $this->index;
         $type = $this->type ?? null;
         if (isset($type)) {
-            trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
+            @trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
         }
 
         if (isset($type)) {

--- a/src/Elasticsearch/Endpoints/Delete.php
+++ b/src/Elasticsearch/Endpoints/Delete.php
@@ -36,7 +36,7 @@ class Delete extends AbstractEndpoint
         $index = $this->index;
         $type = $this->type ?? null;
         if (isset($type)) {
-            trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
+            @trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
         }
 
         if (isset($type)) {

--- a/src/Elasticsearch/Endpoints/DeleteByQuery.php
+++ b/src/Elasticsearch/Endpoints/DeleteByQuery.php
@@ -30,7 +30,7 @@ class DeleteByQuery extends AbstractEndpoint
         $index = $this->index;
         $type = $this->type ?? null;
         if (isset($type)) {
-            trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
+            @trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
         }
 
         if (isset($type)) {

--- a/src/Elasticsearch/Endpoints/Exists.php
+++ b/src/Elasticsearch/Endpoints/Exists.php
@@ -36,7 +36,7 @@ class Exists extends AbstractEndpoint
         $index = $this->index;
         $type = $this->type ?? null;
         if (isset($type)) {
-            trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
+            @trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
         }
 
         if (isset($type)) {

--- a/src/Elasticsearch/Endpoints/ExistsSource.php
+++ b/src/Elasticsearch/Endpoints/ExistsSource.php
@@ -36,7 +36,7 @@ class ExistsSource extends AbstractEndpoint
         $index = $this->index;
         $type = $this->type ?? null;
         if (isset($type)) {
-            trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
+            @trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
         }
 
         if (isset($type)) {

--- a/src/Elasticsearch/Endpoints/Explain.php
+++ b/src/Elasticsearch/Endpoints/Explain.php
@@ -36,7 +36,7 @@ class Explain extends AbstractEndpoint
         $index = $this->index;
         $type = $this->type ?? null;
         if (isset($type)) {
-            trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
+            @trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
         }
 
         if (isset($type)) {

--- a/src/Elasticsearch/Endpoints/Get.php
+++ b/src/Elasticsearch/Endpoints/Get.php
@@ -36,7 +36,7 @@ class Get extends AbstractEndpoint
         $index = $this->index;
         $type = $this->type ?? null;
         if (isset($type)) {
-            trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
+            @trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
         }
 
         if (isset($type)) {

--- a/src/Elasticsearch/Endpoints/GetSource.php
+++ b/src/Elasticsearch/Endpoints/GetSource.php
@@ -36,7 +36,7 @@ class GetSource extends AbstractEndpoint
         $index = $this->index;
         $type = $this->type ?? null;
         if (isset($type)) {
-            trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
+            @trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
         }
 
         if (isset($type)) {

--- a/src/Elasticsearch/Endpoints/Index.php
+++ b/src/Elasticsearch/Endpoints/Index.php
@@ -31,7 +31,7 @@ class Index extends AbstractEndpoint
         $id = $this->id ?? null;
         $type = $this->type ?? null;
         if (isset($type)) {
-            trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
+            @trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
         }
 
         if (isset($type) && isset($id)) {

--- a/src/Elasticsearch/Endpoints/Indices/ExistsType.php
+++ b/src/Elasticsearch/Endpoints/Indices/ExistsType.php
@@ -25,7 +25,7 @@ class ExistsType extends AbstractEndpoint
         $index = $this->index ?? null;
         $type = $this->type ?? null;
         if (isset($type)) {
-            trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
+            @trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
         }
 
         if (isset($index) && isset($type)) {

--- a/src/Elasticsearch/Endpoints/Indices/GetFieldMapping.php
+++ b/src/Elasticsearch/Endpoints/Indices/GetFieldMapping.php
@@ -32,7 +32,7 @@ class GetFieldMapping extends AbstractEndpoint
         $index = $this->index ?? null;
         $type = $this->type ?? null;
         if (isset($type)) {
-            trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
+            @trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
         }
 
         if (isset($index) && isset($type)) {

--- a/src/Elasticsearch/Endpoints/Indices/GetMapping.php
+++ b/src/Elasticsearch/Endpoints/Indices/GetMapping.php
@@ -24,7 +24,7 @@ class GetMapping extends AbstractEndpoint
         $index = $this->index ?? null;
         $type = $this->type ?? null;
         if (isset($type)) {
-            trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
+            @trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
         }
 
         if (isset($index) && isset($type)) {

--- a/src/Elasticsearch/Endpoints/Indices/PutMapping.php
+++ b/src/Elasticsearch/Endpoints/Indices/PutMapping.php
@@ -25,7 +25,7 @@ class PutMapping extends AbstractEndpoint
         $index = $this->index ?? null;
         $type = $this->type ?? null;
         if (isset($type)) {
-            trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
+            @trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
         }
 
         if (isset($index) && isset($type)) {

--- a/src/Elasticsearch/Endpoints/Indices/ValidateQuery.php
+++ b/src/Elasticsearch/Endpoints/Indices/ValidateQuery.php
@@ -24,7 +24,7 @@ class ValidateQuery extends AbstractEndpoint
         $index = $this->index ?? null;
         $type = $this->type ?? null;
         if (isset($type)) {
-            trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
+            @trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
         }
 
         if (isset($index) && isset($type)) {

--- a/src/Elasticsearch/Endpoints/MTermVectors.php
+++ b/src/Elasticsearch/Endpoints/MTermVectors.php
@@ -24,7 +24,7 @@ class MTermVectors extends AbstractEndpoint
         $index = $this->index ?? null;
         $type = $this->type ?? null;
         if (isset($type)) {
-            trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
+            @trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
         }
 
         if (isset($index) && isset($type)) {

--- a/src/Elasticsearch/Endpoints/Mget.php
+++ b/src/Elasticsearch/Endpoints/Mget.php
@@ -24,7 +24,7 @@ class Mget extends AbstractEndpoint
         $index = $this->index ?? null;
         $type = $this->type ?? null;
         if (isset($type)) {
-            trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
+            @trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
         }
 
         if (isset($index) && isset($type)) {

--- a/src/Elasticsearch/Endpoints/Msearch.php
+++ b/src/Elasticsearch/Endpoints/Msearch.php
@@ -31,7 +31,7 @@ class Msearch extends AbstractEndpoint
         $index = $this->index ?? null;
         $type = $this->type ?? null;
         if (isset($type)) {
-            trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
+            @trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
         }
 
         if (isset($index) && isset($type)) {

--- a/src/Elasticsearch/Endpoints/MsearchTemplate.php
+++ b/src/Elasticsearch/Endpoints/MsearchTemplate.php
@@ -31,7 +31,7 @@ class MsearchTemplate extends AbstractEndpoint
         $index = $this->index ?? null;
         $type = $this->type ?? null;
         if (isset($type)) {
-            trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
+            @trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
         }
 
         if (isset($index) && isset($type)) {

--- a/src/Elasticsearch/Endpoints/Scroll.php
+++ b/src/Elasticsearch/Endpoints/Scroll.php
@@ -24,7 +24,7 @@ class Scroll extends AbstractEndpoint
     {
         $scroll_id = $this->scroll_id ?? null;
         if (isset($scroll_id)) {
-            trigger_error('A scroll id can be quite large and should be specified as part of the body', E_USER_DEPRECATED);
+            @trigger_error('A scroll id can be quite large and should be specified as part of the body', E_USER_DEPRECATED);
         }
 
         if (isset($scroll_id)) {

--- a/src/Elasticsearch/Endpoints/Search.php
+++ b/src/Elasticsearch/Endpoints/Search.php
@@ -24,7 +24,7 @@ class Search extends AbstractEndpoint
         $index = $this->index ?? null;
         $type = $this->type ?? null;
         if (isset($type)) {
-            trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
+            @trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
         }
 
         if (isset($index) && isset($type)) {

--- a/src/Elasticsearch/Endpoints/SearchTemplate.php
+++ b/src/Elasticsearch/Endpoints/SearchTemplate.php
@@ -24,7 +24,7 @@ class SearchTemplate extends AbstractEndpoint
         $index = $this->index ?? null;
         $type = $this->type ?? null;
         if (isset($type)) {
-            trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
+            @trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
         }
 
         if (isset($index) && isset($type)) {

--- a/src/Elasticsearch/Endpoints/TermVectors.php
+++ b/src/Elasticsearch/Endpoints/TermVectors.php
@@ -31,7 +31,7 @@ class TermVectors extends AbstractEndpoint
         $id = $this->id ?? null;
         $type = $this->type ?? null;
         if (isset($type)) {
-            trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
+            @trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
         }
 
         if (isset($type) && isset($id)) {

--- a/src/Elasticsearch/Endpoints/Update.php
+++ b/src/Elasticsearch/Endpoints/Update.php
@@ -36,7 +36,7 @@ class Update extends AbstractEndpoint
         $index = $this->index;
         $type = $this->type ?? null;
         if (isset($type)) {
-            trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
+            @trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
         }
 
         if (isset($type)) {

--- a/src/Elasticsearch/Endpoints/UpdateByQuery.php
+++ b/src/Elasticsearch/Endpoints/UpdateByQuery.php
@@ -30,7 +30,7 @@ class UpdateByQuery extends AbstractEndpoint
         $index = $this->index;
         $type = $this->type ?? null;
         if (isset($type)) {
-            trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
+            @trigger_error('Specifying types in urls has been deprecated', E_USER_DEPRECATED);
         }
 
         if (isset($type)) {

--- a/util/template/deprecated
+++ b/util/template/deprecated
@@ -1,3 +1,3 @@
         if (isset($:part)) {
-            trigger_error(':msg', E_USER_DEPRECATED);
+            @trigger_error(':msg', E_USER_DEPRECATED);
         }


### PR DESCRIPTION
This PR mitigate the usage of `trigger_error()` for E_USER_DEPRECATED using the `@` [suppress error operator](https://www.php.net/manual/en/language.operators.errorcontrol.php). 

The `@` operator suppress the error message but it's still possible to catch it using a custom error handler, e.g. as follows:
```php
set_error_handler(function ($errno, $errstr) {
    var_dump($errstr);
}, E_USER_DEPRECATED);

@trigger_error('Deprecation message here', E_USER_DEPRECATED);
```

Using this approach, we can give time to update the code related to the deprecation without breaking existing code (see https://github.com/babenkoivan/scout-elasticsearch-driver/issues/297 issue).

This is the same approach used by Symfony framework [here](https://symfony.com/doc/current/contributing/code/conventions.html#deprecating-code).