### PR TITLE
Fix #977: Handle the exception as structured even if the reason is null

### DIFF
--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -685,7 +685,6 @@ class Connection implements ConnectionInterface
                 // added json_encode to convert into a string
                 return new $errorClass(json_encode($response['body']), (int) $response['status']);
             }
-
             // 2.0 structured exceptions
             if (is_array($error['error']) && array_key_exists('reason', $error['error']) === true) {
                 // Try to use root cause first (only grabs the first root cause)
@@ -699,14 +698,31 @@ class Connection implements ConnectionInterface
                 }
                 // added json_encode to convert into a string
                 $original = new $errorClass(json_encode($response['body']), $response['status']);
-
                 return new $errorClass("$type: $cause", (int) $response['status'], $original);
             }
             // <2.0 semi-structured exceptions
             // added json_encode to convert into a string
             $original = new $errorClass(json_encode($response['body']), $response['status']);
-
             return new $errorClass($error['error'], (int) $response['status'], $original);
+            
+            // // 2.0 structured exceptions
+            // if (is_array($error['error'])) {
+            //     // Try to use root cause first (only grabs the first root cause)
+            //     $root = $error['error']['root_cause'];
+            //     if (isset($root) && isset($root[0])) {
+            //         $cause = $root[0]['reason'];
+            //         $type = $root[0]['type'];
+            //     } else {
+            //         $cause = $error['error']['reason'];
+            //         $type = $error['error']['type'];
+            //     }
+            // }
+            // // added json_encode to convert into a string
+            // $original = new $errorClass(json_encode($response['body']), $response['status']);
+
+            // return isset($cause) && isset($type) ?
+            //     new $errorClass("$type: $cause", (int) $response['status'], $original) : 
+            //     new $errorClass(json_encode($error['error']), (int) $response['status'], $original);
         }
 
         // if responseBody is not string, we convert it so it can be used as Exception message

--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -679,7 +679,7 @@ class Connection implements ConnectionInterface
     {
         $error = $this->serializer->deserialize($response['body'], $response['transfer_stats']);
         if (is_array($error) === true) {
-            if (isset($error['error']) === false){
+            if (isset($error['error']) === false) {
                 // <2.0 "i just blew up" nonstructured exception
                 // $error is an array but we don't know the format, reuse the response body instead
                 // added json_encode to convert into a string

--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -685,6 +685,7 @@ class Connection implements ConnectionInterface
                 // added json_encode to convert into a string
                 return new $errorClass(json_encode($response['body']), (int) $response['status']);
             }
+            
             // 2.0 structured exceptions
             if (is_array($error['error']) && array_key_exists('reason', $error['error']) === true) {
                 // Try to use root cause first (only grabs the first root cause)
@@ -698,31 +699,18 @@ class Connection implements ConnectionInterface
                 }
                 // added json_encode to convert into a string
                 $original = new $errorClass(json_encode($response['body']), $response['status']);
+
                 return new $errorClass("$type: $cause", (int) $response['status'], $original);
             }
             // <2.0 semi-structured exceptions
             // added json_encode to convert into a string
             $original = new $errorClass(json_encode($response['body']), $response['status']);
-            return new $errorClass($error['error'], (int) $response['status'], $original);
             
-            // // 2.0 structured exceptions
-            // if (is_array($error['error'])) {
-            //     // Try to use root cause first (only grabs the first root cause)
-            //     $root = $error['error']['root_cause'];
-            //     if (isset($root) && isset($root[0])) {
-            //         $cause = $root[0]['reason'];
-            //         $type = $root[0]['type'];
-            //     } else {
-            //         $cause = $error['error']['reason'];
-            //         $type = $error['error']['type'];
-            //     }
-            // }
-            // // added json_encode to convert into a string
-            // $original = new $errorClass(json_encode($response['body']), $response['status']);
-
-            // return isset($cause) && isset($type) ?
-            //     new $errorClass("$type: $cause", (int) $response['status'], $original) : 
-            //     new $errorClass(json_encode($error['error']), (int) $response['status'], $original);
+            $errorEncoded = $error['error'];
+            if (is_array($errorEncoded)) {
+                $errorEncoded = json_encode($errorEncoded);
+            }
+            return new $errorClass($errorEncoded, (int) $response['status'], $original);
         }
 
         // if responseBody is not string, we convert it so it can be used as Exception message

--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -679,8 +679,15 @@ class Connection implements ConnectionInterface
     {
         $error = $this->serializer->deserialize($response['body'], $response['transfer_stats']);
         if (is_array($error) === true) {
+            if (isset($error['error']) === false){
+                // <2.0 "i just blew up" nonstructured exception
+                // $error is an array but we don't know the format, reuse the response body instead
+                // added json_encode to convert into a string
+                return new $errorClass(json_encode($response['body']), (int) $response['status']);
+            }
+
             // 2.0 structured exceptions
-            if (isset($error['error']['reason']) === true) {
+            if (is_array($error['error']) && array_key_exists('reason', $error['error']) === true) {
                 // Try to use root cause first (only grabs the first root cause)
                 $root = $error['error']['root_cause'];
                 if (isset($root) && isset($root[0])) {
@@ -694,18 +701,12 @@ class Connection implements ConnectionInterface
                 $original = new $errorClass(json_encode($response['body']), $response['status']);
 
                 return new $errorClass("$type: $cause", (int) $response['status'], $original);
-            } elseif (isset($error['error']) === true) {
-                // <2.0 semi-structured exceptions
-                // added json_encode to convert into a string
-                $original = new $errorClass(json_encode($response['body']), $response['status']);
-
-                return new $errorClass($error['error'], (int) $response['status'], $original);
             }
-
-            // <2.0 "i just blew up" nonstructured exception
-            // $error is an array but we don't know the format, reuse the response body instead
+            // <2.0 semi-structured exceptions
             // added json_encode to convert into a string
-            return new $errorClass(json_encode($response['body']), (int) $response['status']);
+            $original = new $errorClass(json_encode($response['body']), $response['status']);
+
+            return new $errorClass($error['error'], (int) $response['status'], $original);
         }
 
         // if responseBody is not string, we convert it so it can be used as Exception message

--- a/tests/Elasticsearch/Tests/Connections/ConnectionTest.php
+++ b/tests/Elasticsearch/Tests/Connections/ConnectionTest.php
@@ -307,7 +307,7 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
         $tryDeserializeError->setAccessible(true);
 
         $body = '{"error":{"root_cause":[{"type":"master_not_discovered_exception","reason":null}],"type":"master_not_discovered_exception","reason":null},"status":503}';
-        $response = [ 
+        $response = [
             'transfer_stats' => [],
             'status' => 503,
             'body' => $body


### PR DESCRIPTION
Close #977
The case of the issue #977 is handling structured exception as semi-structured exception which only occurs before Elasticsearch 2.0.

Ordinal code checks whether `$error['error']['reason']` is set.
https://github.com/elastic/elasticsearch-php/blob/c65c1fb8789645c35896350ca86ee4d0ea9bcb4d/src/Elasticsearch/Connections/Connection.php#L683

Unfortunately, `master_not_discovered_exception` is thrown with blank error reason.
https://github.com/elastic/elasticsearch/blob/16bfdcacc0172264db9b32aa6edfa8b5c327f3b4/server/src/main/java/org/elasticsearch/discovery/MasterNotDiscoveredException.java#L31

To avoid the problem, use `array_key_exists()` alter `isset()`.
To make the logic simple, I refactored the if-statements.
Check whether the exception is structured or not first.
Then distinguish whether the exception is structured exception after Elasticsearch 2.0.