### PR TITLE
Fix extractArgument iterable casting to array

### DIFF
--- a/src/Elasticsearch/Client.php
+++ b/src/Elasticsearch/Client.php
@@ -1275,7 +1275,9 @@ class Client
     {
         if (array_key_exists($arg, $params) === true) {
             $value = $params[$arg];
-            $value = is_object($value) ? (array) $value : $value;
+            $value = (is_object($value) && !is_iterable($value)) ?
+                (array) $value :
+                $value;
             unset($params[$arg]);
             return $value;
         } else {

--- a/tests/Elasticsearch/Tests/ClientTest.php
+++ b/tests/Elasticsearch/Tests/ClientTest.php
@@ -478,4 +478,16 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $result = $client->info($params);
         $this->assertInstanceOf(FutureArray::class, $result);
     }
+
+    public function testExtractArgumentIterable()
+    {
+        $client = Elasticsearch\ClientBuilder::create()->build();
+        // array iterator can be casted to array back, so make more real with IteratorIterator
+        $body = new \IteratorIterator(new \ArrayIterator([1, 2, 3]));
+        $params = ['body' => $body];
+        $argument = $client->extractArgument($params, 'body');
+        $this->assertEquals($body, $argument);
+        $this->assertCount(0, $params);
+        $this->assertInstanceOf(\IteratorIterator::class, $argument);
+    }
 }


### PR DESCRIPTION
Bulk API suports data as `itarable`, see ` \Elasticsearch\Endpoints\Bulk::setBody`.

It has been broken during refactoring, see  #56163ff.
