### PR TITLE
Fixed gzip compression when setting Cloud Id

### DIFF
--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -396,14 +396,10 @@ class ClientBuilder
             ]
         ]);
 
-        // Merge best practices for the connection
-        $this->setConnectionParams([
-            'client' => [
-                'curl' => [
-                    CURLOPT_ENCODING => 1,
-                ],
-            ]
-        ]);
+        if (!isset($this->connectionParams['client']['curl'][CURLOPT_ENCODING])) {
+            // Merge best practices for the connection (enable gzip)
+            $this->connectionParams['client']['curl'][CURLOPT_ENCODING] = 'gzip';
+        }
 
         return $this;
     }

--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -376,7 +376,7 @@ class Connection implements ConnectionInterface
             array(
                 'method'    => $request['http_method'],
                 'uri'       => $response['effective_url'],
-                'port'      => $response['transfer_stats']['primary_port'],
+                'port'      => $response['transfer_stats']['primary_port'] ?? '',
                 'headers'   => $request['headers'],
                 'HTTP code' => $response['status'],
                 'duration'  => $response['transfer_stats']['total_time'],

--- a/tests/Elasticsearch/Tests/ClientBuilderTest.php
+++ b/tests/Elasticsearch/Tests/ClientBuilderTest.php
@@ -4,9 +4,12 @@ declare(strict_types = 1);
 
 namespace Elasticsearch\Tests;
 
+use Elasticsearch\Client;
 use Elasticsearch\ClientBuilder;
+use Elasticsearch\Common\Exceptions\ElasticsearchException;
 use Elasticsearch\Common\Exceptions\InvalidArgumentException;
 use Elasticsearch\Tests\ClientBuilder\DummyLogger;
+use GuzzleHttp\Ring\Client\MockHandler;
 use PHPUnit\Framework\TestCase;
 
 class ClientBuilderTest extends TestCase
@@ -25,5 +28,46 @@ class ClientBuilderTest extends TestCase
     public function testClientBuilderThrowsExceptionForIncorrectTracerClass()
     {
         ClientBuilder::create()->setTracer(new DummyLogger);
+    }
+
+    public function testGzipEnabledWhenElasticCloudId()
+    {
+        $client = ClientBuilder::create()
+            ->setElasticCloudId('foo:' . base64_encode('localhost:9200$foo'))
+            ->build();
+
+        $this->assertInstanceOf(Client::class, $client);
+        
+        try {
+            $result = $client->info();
+        } catch (ElasticsearchException $e) {
+            $request = $client->transport->getLastConnection()->getLastRequestInfo();
+            $this->assertContains('gzip', $request['request']['client']['curl']);
+        }
+    }
+
+    public function testElasticCloudIdNotOverrideCurlEncoding()
+    {
+        $params = [
+            'client' => [
+                'curl' => [
+                    CURLOPT_ENCODING => 'deflate'
+                ]
+            ]
+        ];
+        $client = ClientBuilder::create()
+            ->setConnectionParams($params)
+            ->setElasticCloudId('foo:' . base64_encode('localhost:9200$foo'))
+            ->build();
+
+        $this->assertInstanceOf(Client::class, $client);
+        
+        try {
+            $result = $client->info();
+        } catch (ElasticsearchException $e) {
+            $request = $client->transport->getLastConnection()->getLastRequestInfo();
+            $this->assertContains('deflate', $request['request']['client']['curl']);
+            $this->assertNotContains('gzip', $request['request']['client']['curl']);
+        }
     }
 }

--- a/tests/Elasticsearch/Tests/ClientIntegrationTest.php
+++ b/tests/Elasticsearch/Tests/ClientIntegrationTest.php
@@ -4,7 +4,9 @@ declare(strict_types = 1);
 
 namespace Elasticsearch\Tests;
 
+use Elasticsearch\Client;
 use Elasticsearch\ClientBuilder;
+use Elasticsearch\Common\Exceptions\ElasticsearchException;
 use Elasticsearch\Common\Exceptions\Missing404Exception;
 use Elasticsearch\Tests\ClientBuilder\ArrayLogger;
 use Psr\Log\LogLevel;
@@ -19,7 +21,7 @@ use Psr\Log\LogLevel;
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link       http://elasticsearch.org
  */
-class ClientIntegrationTests extends \PHPUnit\Framework\TestCase
+class ClientIntegrationTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {


### PR DESCRIPTION
This PR fixes the `gzip` compression settings in CURL when Cloud Id is specified. The previous implementation had a wrong setting ([here](https://github.com/elastic/elasticsearch-php/commit/cb8559d3246306608c1f1ca252a106c6b851afba#r36742425)).
Moreover, this PR check if the `CURLOPT_ENCODING` is already set, in that case I don't change it when Cloud Id is specified.