### PR TITLE
[DOCS] Fix broken link to scroll docs

### DIFF
--- a/docs/search-operations.asciidoc
+++ b/docs/search-operations.asciidoc
@@ -225,7 +225,7 @@ This window allows consistent paging even if there is background indexing/updati
 request with `scroll` enabled.  This returns a "page" of documents, and a scroll_id which is used to continue
 paginating through the hits.
 
-More details about scrolling can be found in the https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html[Link: reference documentation].
+More details about scrolling can be found in the https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#request-body-search-scroll[Link: reference documentation].
 
 This is an example which can be used as a template for more advanced operations:
 


### PR DESCRIPTION
Fixes a broken link to the Elasticsearch scroll documentation.

This broken link was causing a docs build failure.