### PR TITLE
Fix for #993, added ClientBuilder::includePortInHostHeader()

### DIFF
--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -472,7 +472,6 @@ class ClientBuilder
 
     /**
      * Include the port in Host header
-     * 
      * @see https://github.com/elastic/elasticsearch-php/issues/993
      */
     public function includePortInHostHeader(bool $enable): ClientBuilder
@@ -523,7 +522,7 @@ class ClientBuilder
         }
 
         $this->connectionParams['client']['port_in_header'] = $this->includePortInHostHeader;
-        
+
         if (is_null($this->connectionFactory)) {
             if (is_null($this->connectionParams)) {
                 $this->connectionParams = [];

--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -128,6 +128,11 @@ class ClientBuilder
      */
     private $sslVerification = null;
 
+    /**
+     *  @var bool
+     */
+    private $includePortInHostHeader = false;
+
     public static function create(): ClientBuilder
     {
         return new static();
@@ -465,6 +470,18 @@ class ClientBuilder
         return $this;
     }
 
+    /**
+     * Include the port in Host header
+     * 
+     * @see https://github.com/elastic/elasticsearch-php/issues/993
+     */
+    public function includePortInHostHeader(bool $enable): ClientBuilder
+    {
+        $this->includePortInHostHeader = $enable;
+
+        return $this;
+    }
+
     public function build(): Client
     {
         $this->buildLoggers();
@@ -505,6 +522,8 @@ class ClientBuilder
             $this->serializer = new $this->serializer;
         }
 
+        $this->connectionParams['client']['port_in_header'] = $this->includePortInHostHeader;
+        
         if (is_null($this->connectionFactory)) {
             if (is_null($this->connectionParams)) {
                 $this->connectionParams = [];

--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -200,9 +200,7 @@ class Connection implements ConnectionInterface
 
         $host = $this->host;
         if (isset($this->connectionParams['client']['port_in_header']) && $this->connectionParams['client']['port_in_header']) {
-            if (!in_array((int) $this->port, [80,443])) {
-                $host .= ':' . $this->port;
-            }
+            $host .= ':' . $this->port;
         }
         
         $request = [

--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -168,6 +168,11 @@ class Connection implements ConnectionInterface
         }
         $port = $hostDetails['port'];
 
+        if (isset($connectionParams['client']['port_in_header']) && $connectionParams['client']['port_in_header']) {
+            if (!in_array((int) $port, [80,443])) {
+                $host .= ":$port";
+            }
+        }
         $this->host             = $host;
         $this->path             = $path;
         $this->port             = $port;
@@ -198,6 +203,7 @@ class Connection implements ConnectionInterface
             $this->headers = array_merge($this->headers, $options['client']['headers']);
         }
 
+        
         $request = [
             'http_method' => $method,
             'scheme'      => $this->transportSchema,

--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -168,11 +168,6 @@ class Connection implements ConnectionInterface
         }
         $port = $hostDetails['port'];
 
-        if (isset($connectionParams['client']['port_in_header']) && $connectionParams['client']['port_in_header']) {
-            if (!in_array((int) $port, [80,443])) {
-                $host .= ":$port";
-            }
-        }
         $this->host             = $host;
         $this->path             = $path;
         $this->port             = $port;
@@ -203,6 +198,12 @@ class Connection implements ConnectionInterface
             $this->headers = array_merge($this->headers, $options['client']['headers']);
         }
 
+        $host = $this->host;
+        if (isset($this->connectionParams['client']['port_in_header']) && $this->connectionParams['client']['port_in_header']) {
+            if (!in_array((int) $this->port, [80,443])) {
+                $host .= ':' . $this->port;
+            }
+        }
         
         $request = [
             'http_method' => $method,
@@ -211,7 +212,7 @@ class Connection implements ConnectionInterface
             'body'        => $body,
             'headers'     => array_merge(
                 [
-                'Host'  => [$this->host]
+                'Host'  => [$host]
                 ],
                 $this->headers
             )

--- a/tests/Elasticsearch/Tests/ClientBuilderTest.php
+++ b/tests/Elasticsearch/Tests/ClientBuilderTest.php
@@ -71,23 +71,13 @@ class ClientBuilderTest extends TestCase
         }
     }
 
-    public function getHttpPorts()
-    {
-        return [
-            [ 80, false ],  // not included since 80 is standard port for HTTP
-            [ 443, false ], // not included since 442 is standard port for HTTPS
-            [ 1234, true ]  // included since 1234 is not a standard port
-        ];
-    }
-
     /**
-     * @dataProvider getHttpPorts
      * @see https://github.com/elastic/elasticsearch-php/issues/993
      */
-    public function testIncludePortInHostHeader(int $port, bool $included)
+    public function testIncludePortInHostHeader()
     {
         $host = "localhost";
-        $url = "localhost:$port";
+        $url = "$host:1234";
         $params = [
             'client' => [
                 'verbose' => true
@@ -106,14 +96,14 @@ class ClientBuilderTest extends TestCase
         } catch (ElasticsearchException $e) {
             $request = $client->transport->getLastConnection()->getLastRequestInfo();
             $this->assertTrue(isset($request['request']['headers']['Host'][0]));
-            $this->assertEquals($included ? $url : $host, $request['request']['headers']['Host'][0]);
+            $this->assertEquals($url, $request['request']['headers']['Host'][0]);
         }
     }
 
     /**
      * @see https://github.com/elastic/elasticsearch-php/issues/993
      */
-    public function testNotIncludeStandardPortInHostHeaderAsDefault()
+    public function testNotIncludePortInHostHeaderAsDefault()
     {
         $host = "localhost";
         $url  = "$host:1234";
@@ -141,7 +131,7 @@ class ClientBuilderTest extends TestCase
     /**
      * @see https://github.com/elastic/elasticsearch-php/issues/993
      */
-    public function testNotIncludeStandardPortInHostHeader()
+    public function testNotIncludePortInHostHeader()
     {
         $host = "localhost";
         $url  = "$host:1234";

--- a/tests/Elasticsearch/Tests/ClientBuilderTest.php
+++ b/tests/Elasticsearch/Tests/ClientBuilderTest.php
@@ -82,7 +82,6 @@ class ClientBuilderTest extends TestCase
 
     /**
      * @dataProvider getHttpPorts
-     * 
      * @see https://github.com/elastic/elasticsearch-php/issues/993
      */
     public function testIncludePortInHostHeader(int $port, bool $included)

--- a/tests/Elasticsearch/Tests/ClientBuilderTest.php
+++ b/tests/Elasticsearch/Tests/ClientBuilderTest.php
@@ -70,4 +70,101 @@ class ClientBuilderTest extends TestCase
             $this->assertNotContains('gzip', $request['request']['client']['curl']);
         }
     }
+
+    public function getHttpPorts()
+    {
+        return [
+            [ 80, false ],  // not included since 80 is standard port for HTTP
+            [ 443, false ], // not included since 442 is standard port for HTTPS
+            [ 1234, true ]  // included since 1234 is not a standard port
+        ];
+    }
+
+    /**
+     * @dataProvider getHttpPorts
+     * 
+     * @see https://github.com/elastic/elasticsearch-php/issues/993
+     */
+    public function testIncludePortInHostHeader(int $port, bool $included)
+    {
+        $host = "localhost";
+        $url = "localhost:$port";
+        $params = [
+            'client' => [
+                'verbose' => true
+            ]
+        ];
+        $client = ClientBuilder::create()
+            ->setConnectionParams($params)
+            ->setHosts([$url])
+            ->includePortInHostHeader(true)
+            ->build();
+
+        $this->assertInstanceOf(Client::class, $client);
+
+        try {
+            $result = $client->info();
+        } catch (ElasticsearchException $e) {
+            $request = $client->transport->getLastConnection()->getLastRequestInfo();
+            $this->assertTrue(isset($request['request']['headers']['Host'][0]));
+            $this->assertEquals($included ? $url : $host, $request['request']['headers']['Host'][0]);
+        }
+    }
+
+    /**
+     * @see https://github.com/elastic/elasticsearch-php/issues/993
+     */
+    public function testNotIncludeStandardPortInHostHeaderAsDefault()
+    {
+        $host = "localhost";
+        $url  = "$host:1234";
+        $params = [
+            'client' => [
+                'verbose' => true
+            ]
+        ];
+        $client = ClientBuilder::create()
+            ->setConnectionParams($params)
+            ->setHosts([$url])
+            ->build();
+
+        $this->assertInstanceOf(Client::class, $client);
+
+        try {
+            $result = $client->info();
+        } catch (ElasticsearchException $e) {
+            $request = $client->transport->getLastConnection()->getLastRequestInfo();
+            $this->assertTrue(isset($request['request']['headers']['Host'][0]));
+            $this->assertEquals($host, $request['request']['headers']['Host'][0]);
+        }
+    }
+
+    /**
+     * @see https://github.com/elastic/elasticsearch-php/issues/993
+     */
+    public function testNotIncludeStandardPortInHostHeader()
+    {
+        $host = "localhost";
+        $url  = "$host:1234";
+        $params = [
+            'client' => [
+                'verbose' => true
+            ]
+        ];
+        $client = ClientBuilder::create()
+            ->setConnectionParams($params)
+            ->setHosts([$url])
+            ->includePortInHostHeader(false)
+            ->build();
+
+        $this->assertInstanceOf(Client::class, $client);
+
+        try {
+            $result = $client->info();
+        } catch (ElasticsearchException $e) {
+            $request = $client->transport->getLastConnection()->getLastRequestInfo();
+            $this->assertTrue(isset($request['request']['headers']['Host'][0]));
+            $this->assertEquals($host, $request['request']['headers']['Host'][0]);
+        }
+    }
 }


### PR DESCRIPTION
This PR fixes #993 adding a `ClientBuilder::includePortInHostHeader(bool $enable)`. Using this option the HTTP port will be added to `Host` header if it's not standard (80 for HTTP, 443 for HTTPS).

For instance, this configuration will build the header `Host: localhost:9200`.
```php
$host = 'localhost:9200';
$client = ClientBuilder::create()
    ->setHosts([$host])
    ->includePortInHostHeader(true)
    ->build();
```
If the port is standard (e.g. 80) even if `includePortInHostHeader(true)` will not include the port in the `Host` header.

By default (if you don't call `includePortInHostHeader(true)`), the port is not included for backward compatibility.