### PR TITLE
[DOCS] Fine-tunes the overview section of the PHP client book

### DIFF
--- a/docs/overview.asciidoc
+++ b/docs/overview.asciidoc
@@ -1,9 +1,16 @@
 [[overview]]
 == Overview
 
-This is the official PHP client for Elasticsearch.  It is designed to be a very low-level client that does not stray from the REST API.
+This is the official PHP client for {es}. It is designed to be a low-level 
+client that does not stray from the REST API.
 
-All methods closely match the REST API, and furthermore, match the method structure of other language clients (ruby, python, etc).  We hope that this consistency makes it easy to get started with a client, and to seamlessly switch from one language to the next with minimal effort.
+All methods closely match the REST API, and furthermore, match the method 
+structure of other language clients (Ruby, Python, etc). We hope that this 
+consistency makes it easy to get started with a client and to seamlessly switch 
+from one language to the next with minimal effort.
 
-The client is designed to be "unopinionated".  There are a few universal niceties added to the client (cluster state sniffing, round-robin requests, etc) but largely it is very barebones.  This was intentional.  We want a common base that more sophisticated libraries can build on top of.
+The client is designed to be "unopinionated". There are a few universal niceties 
+added to the client (cluster state sniffing, round-robin requests, and so on) 
+but largely it is very barebones. This was intentional; we want a common base 
+that more sophisticated libraries can build on top of.
 


### PR DESCRIPTION
This PR fine-tunes the wording of the Overview section in the PHP book and improves readability.

Related issue: https://github.com/elastic/stack-docs/issues/883