### PR TITLE
[DOCS] Fine-tunes overview and quick start in PHP client book

### DIFF
--- a/docs/overview.asciidoc
+++ b/docs/overview.asciidoc
@@ -1,9 +1,15 @@
 [[overview]]
 == Overview
 
-This is the official PHP client for Elasticsearch.  It is designed to be a very low-level client that does not stray from the REST API.
+This is the official PHP client for {es}. It is designed to be a low-level 
+client that does not stray from the REST API.
 
-All methods closely match the REST API, and furthermore, match the method structure of other language clients (ruby, python, etc).  We hope that this consistency makes it easy to get started with a client, and to seamlessly switch from one language to the next with minimal effort.
+All methods closely match the REST API, and furthermore, match the method 
+structure of other language clients (Ruby, Python, etc). We hope that this 
+consistency makes it easy to get started with a client and to seamlessly switch 
+from one language to the next with minimal effort.
 
-The client is designed to be "unopinionated".  There are a few universal niceties added to the client (cluster state sniffing, round-robin requests, etc) but largely it is very barebones.  This was intentional.  We want a common base that more sophisticated libraries can build on top of.
-
+The client is designed to be "unopinionated". There are a few universal niceties 
+added to the client (cluster state sniffing, round-robin requests, and so on) 
+but largely it is very barebones. This was intentional; we want a common base 
+that more sophisticated libraries can build on top of.

--- a/docs/overview.asciidoc
+++ b/docs/overview.asciidoc
@@ -1,8 +1,8 @@
 [[overview]]
 == Overview
 
-This is the official PHP client for {es}. It is designed to be a low-level 
-client that does not stray from the REST API.
+This is the official PHP client for Elasticsearch. It is designed to be a 
+low-level client that does not stray from the REST API.
 
 All methods closely match the REST API, and furthermore, match the method 
 structure of other language clients (Ruby, Python, etc). We hope that this 

--- a/docs/overview.asciidoc
+++ b/docs/overview.asciidoc
@@ -1,8 +1,8 @@
 [[overview]]
 == Overview
 
-This is the official PHP client for Elasticsearch. It is designed to be a 
-low-level client that does not stray from the REST API.
+This is the official PHP client for {es}. It is designed to be a low-level 
+client that does not stray from the REST API.
 
 All methods closely match the REST API, and furthermore, match the method 
 structure of other language clients (Ruby, Python, etc). We hope that this 

--- a/docs/quickstart.asciidoc
+++ b/docs/quickstart.asciidoc
@@ -1,7 +1,9 @@
 [[quickstart]]
 == Quickstart
 
-This section will give you a quick overview of the client and how the major functions work.
+This section gives you a quick overview of the client and how the major 
+functions work.
+
 
 === Installation
 
@@ -24,7 +26,8 @@ curl -s http://getcomposer.org/installer | php
 php composer.phar install --no-dev
 ----------------------------
 
-* Include the autoloader in your main project (if you haven't already), and instantiate a new client :
+* Include the autoloader in your main project (if you haven't already), and 
+  instantiate a new client :
 +
 [source,php]
 ----------------------------
@@ -38,11 +41,14 @@ $client = ClientBuilder::create()->build();
 
 === Index a document
 
-In elasticsearch-php, almost everything is configured by associative arrays.  The REST endpoint, document and optional parameters - everything is an associative array.
+In elasticsearch-php, almost everything is configured by associative arrays. The 
+REST endpoint, document and optional parameters - everything is an associative 
+array.
 
-To index a document, we need to specify three pieces of information: index, id and a document body. This is done by
-constructing an associative array of key:value pairs.  The request body is itself an associative array with key:value pairs
-corresponding to the data in your document:
+To index a document, we need to specify three pieces of information: index, id 
+and a document body. This is done by constructing an associative array of 
+key:value pairs. The request body is itself an associative array with key:value 
+pairs corresponding to the data in your document:
 
 [source,php]
 ----------------------------
@@ -56,8 +62,9 @@ $response = $client->index($params);
 print_r($response);
 ----------------------------
 
-The response that you get back indicates the document was created in the index that you specified.  The response is an
-associative array containing a decoded version of the JSON that Elasticsearch returns:
+The response that you get back indicates that the document was created in the 
+index that you specified. The response is an associative array containing a 
+decoded version of the JSON that {es} returns:
 
 [source,php]
 ----------------------------
@@ -72,9 +79,10 @@ Array
 
 ----------------------------
 
+
 === Get a document
 
-Let's get the document that we just indexed.  This will simply return the document:
+Let's get the document that we just indexed. This returns the document:
 
 [source,php]
 ----------------------------
@@ -87,8 +95,9 @@ $response = $client->get($params);
 print_r($response);
 ----------------------------
 
-The response contains some metadata (index, version, etc.) as well as a `_source` field, which is the original document
-that you sent to Elasticsearch.
+
+The response contains metadata such as index, version, and so on as well as a 
+`_source` field, which is the original document you sent to {es}.
 
 [source,php]
 ----------------------------
@@ -107,9 +116,11 @@ Array
 )
 ----------------------------
 
+
 === Search for a document
 
-Searching is a hallmark of elasticsearch, so let's perform a search.  We are going to use the Match query as a demonstration:
+Searching is a hallmark of {es}, so let's perform a search.  We are going to use 
+the `match` query as a demonstration:
 
 [source,php]
 ----------------------------
@@ -128,8 +139,9 @@ $response = $client->search($params);
 print_r($response);
 ----------------------------
 
-The response is a little different from the previous responses.  We see some metadata (`took`, `timed_out`, etc) and
-an array named `hits`.  This represents your search results.  Inside of `hits` is another array named `hits`, which contains
+The response here is different from the previous ones. You can see metadata 
+(`took`, `timed_out`, etc.) and an array named `hits`. This represents your 
+search results. Inside of `hits` is another array named `hits`, which contains 
 individual search results:
 
 [source,php]
@@ -167,6 +179,7 @@ Array
 )
 ----------------------------
 
+
 === Delete a document
 
 Alright, let's go ahead and delete the document that we added previously:
@@ -182,8 +195,9 @@ $response = $client->delete($params);
 print_r($response);
 ----------------------------
 
-You'll notice this is identical syntax to the `get` syntax.  The only difference is the operation: `delete` instead of
-`get`.  The response will confirm the document was deleted:
+This syntax is identical to the `get` syntax. The only difference is the 
+operation: `delete` instead of `get`. The response confirms the document is 
+deleted:
 
 [source,php]
 ----------------------------
@@ -200,7 +214,9 @@ Array
 
 === Delete an index
 
-Due to the dynamic nature of elasticsearch, the first document we added automatically built an index with some default settings.  Let's delete that index because we want to specify our own settings later:
+Due to the dynamic nature of {es}, the first document you added automatically 
+built an index with some default settings. Delete that index and specify your 
+own settings later:
 
 [source,php]
 ----------------------------
@@ -224,7 +240,8 @@ Array
 
 === Create an index
 
-Now that we are starting fresh (no data or index), let's add a new index with some custom settings:
+Now that you are starting fresh (no data or index), add a new index with custom 
+settings:
 
 [source,php]
 ----------------------------
@@ -242,7 +259,8 @@ $response = $client->indices()->create($params);
 print_r($response);
 ----------------------------
 
-Elasticsearch will now create that index with your chosen settings, and return an acknowledgement:
+{es} now creates that index with your chosen settings and return an 
+acknowledgement:
 
 [source,php]
 ----------------------------
@@ -252,13 +270,17 @@ Array
 )
 ----------------------------
 
+
 === Wrap up
 
-That was just a crash-course overview of the client and it's syntax.  If you are familiar with elasticsearch, you'll
-notice that the methods are named just like REST endpoints.
+That was just a crash-course overview of the client and it's syntax. If you are 
+familiar with {es}, you'll notice that the methods are named just like REST 
+endpoints.
 
-You'll also notice that the client is configured in a manner that facilitates easy discovery via your IDE.  All core
-actions are available under the `$client` object (indexing, searching, getting, etc).  Index and cluster management
-are located under the `$client->indices()` and `$client->cluster()` objects, respectively.
+You may also notice that the client is configured in a manner that facilitates 
+easy discovery via your IDE. All core actions are available under the `$client` 
+object (indexing, searching, getting, etc). Index and cluster management are 
+located under the `$client->indices()` and `$client->cluster()` objects, 
+respectively.
 
-Check out the rest of the Documentation to see how the entire client works.
+Check out the rest of the documentation to see how the entire client works.

--- a/docs/quickstart.asciidoc
+++ b/docs/quickstart.asciidoc
@@ -64,7 +64,7 @@ print_r($response);
 
 The response that you get back indicates that the document was created in the 
 index that you specified. The response is an associative array containing a 
-decoded version of the JSON that Elasticsearch returns:
+decoded version of the JSON that {es} returns:
 
 [source,php]
 ----------------------------
@@ -97,7 +97,7 @@ print_r($response);
 
 
 The response contains metadata such as index, version, and so on as well as a 
-`_source` field, which is the original document you sent to Elasticsearch.
+`_source` field, which is the original document you sent to {es}.
 
 [source,php]
 ----------------------------
@@ -119,8 +119,8 @@ Array
 
 === Search for a document
 
-Searching is a hallmark of Elasticsearch, so let's perform a search.  We are 
-going to use the `match` query as a demonstration:
+Searching is a hallmark of {es}, so let's perform a search.  We are going to use 
+the `match` query as a demonstration:
 
 [source,php]
 ----------------------------
@@ -214,9 +214,9 @@ Array
 
 === Delete an index
 
-Due to the dynamic nature of Elasticsearch, the first document you added 
-automatically built an index with some default settings. Delete that index and 
-specify your own settings later:
+Due to the dynamic nature of {es}, the first document you added automatically 
+built an index with some default settings. Delete that index and specify your 
+own settings later:
 
 [source,php]
 ----------------------------
@@ -259,7 +259,7 @@ $response = $client->indices()->create($params);
 print_r($response);
 ----------------------------
 
-Elasticsearch now creates that index with your chosen settings and return an 
+{es} now creates that index with your chosen settings and return an 
 acknowledgement:
 
 [source,php]
@@ -274,8 +274,8 @@ Array
 === Wrap up
 
 That was just a crash-course overview of the client and it's syntax. If you are 
-familiar with Elasticsearch, you'll notice that the methods are named just like 
-REST endpoints.
+familiar with {es}, you'll notice that the methods are named just like REST 
+endpoints.
 
 You may also notice that the client is configured in a manner that facilitates 
 easy discovery via your IDE. All core actions are available under the `$client` 

--- a/docs/quickstart.asciidoc
+++ b/docs/quickstart.asciidoc
@@ -64,7 +64,7 @@ print_r($response);
 
 The response that you get back indicates that the document was created in the 
 index that you specified. The response is an associative array containing a 
-decoded version of the JSON that {es} returns:
+decoded version of the JSON that Elasticsearch returns:
 
 [source,php]
 ----------------------------
@@ -97,7 +97,7 @@ print_r($response);
 
 
 The response contains metadata such as index, version, and so on as well as a 
-`_source` field, which is the original document you sent to {es}.
+`_source` field, which is the original document you sent to Elasticsearch.
 
 [source,php]
 ----------------------------
@@ -119,8 +119,8 @@ Array
 
 === Search for a document
 
-Searching is a hallmark of {es}, so let's perform a search.  We are going to use 
-the `match` query as a demonstration:
+Searching is a hallmark of Elasticsearch, so let's perform a search.  We are 
+going to use the `match` query as a demonstration:
 
 [source,php]
 ----------------------------
@@ -214,9 +214,9 @@ Array
 
 === Delete an index
 
-Due to the dynamic nature of {es}, the first document you added automatically 
-built an index with some default settings. Delete that index and specify your 
-own settings later:
+Due to the dynamic nature of Elasticsearch, the first document you added 
+automatically built an index with some default settings. Delete that index and 
+specify your own settings later:
 
 [source,php]
 ----------------------------
@@ -259,7 +259,7 @@ $response = $client->indices()->create($params);
 print_r($response);
 ----------------------------
 
-{es} now creates that index with your chosen settings and return an 
+Elasticsearch now creates that index with your chosen settings and return an 
 acknowledgement:
 
 [source,php]
@@ -274,8 +274,8 @@ Array
 === Wrap up
 
 That was just a crash-course overview of the client and it's syntax. If you are 
-familiar with {es}, you'll notice that the methods are named just like REST 
-endpoints.
+familiar with Elasticsearch, you'll notice that the methods are named just like 
+REST endpoints.
 
 You may also notice that the client is configured in a manner that facilitates 
 easy discovery via your IDE. All core actions are available under the `$client` 


### PR DESCRIPTION
This PR fine-tunes the wording of the following sections and improves readability:

* **Overview**
* **Quickstart**

Related issue: https://github.com/elastic/stack-docs/issues/883

Previews:
* Overview: http://elasticsearch-php_999.docs-preview.app.elstc.co/guide/en/elasticsearch/client/php-api/current/overview.html
* Quickstart: http://elasticsearch-php_999.docs-preview.app.elstc.co/guide/en/elasticsearch/client/php-api/current/quickstart.html