### PR TITLE
Adds shared/attributes.asciidoc to index

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -40,3 +40,5 @@ include::community.asciidoc[]
 include::experimental-beta-apis.asciidoc[]
 
 include::build/classes.asciidoc[]
+
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]


### PR DESCRIPTION
This PR adds a reference to `shared/attributes.asciidoc` to the index file to make it possible to use attributes in the PHP book.

Related PR in docs infra repo: https://github.com/elastic/docs/pull/1744