### PR TITLE
[7.x] Adds shared/attributes.asciidoc to index

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -40,3 +40,5 @@ include::community.asciidoc[]
 include::experimental-beta-apis.asciidoc[]
 
 include::build/classes.asciidoc[]
+
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]


### PR DESCRIPTION
This PR applies the changes of the following commit to the 7.x branch: 
Adds shared/attributes.asciidoc to index #1000