### PR TITLE
[DOCS] Fine-tunes per-request conf and futures pages in PHP client book

### DIFF
--- a/docs/futures.asciidoc
+++ b/docs/futures.asciidoc
@@ -1,24 +1,31 @@
 [[future_mode]]
 == Future Mode
 
-The client offers a mode called "future" or "async" mode.  This allows batch processing of requests (sent in parallel
-to the cluster), which can have a dramatic impact on performance and throughput.
+The client offers a mode called "future" or "async" mode. This allows batch 
+processing of requests (sent in parallel to the cluster), which can have a 
+dramatic impact on performance and throughput.
 
-PHP is fundamentally single-threaded, however libcurl provides functionality called the "multi interface".  This allows
-languages like PHP to gain concurrency by providing a batch of requests to process.  The batch is executed in a parallel
-by the underlying multithreaded libcurl library, and the batch of responses is then returned to PHP.
+PHP is fundamentally single-threaded, however, libcurl provides a functionality 
+called the "multi interface". This functionality allows languages like PHP to 
+gain concurrency by providing a batch of requests to process. The batch is 
+executed in parallel by the underlying multithreaded libcurl library, and the 
+batch of responses is then returned to PHP.
 
-In a single-threaded environment, the time to execute `n` requests is the sum of those `n` request's latencies.  With
-the multi interface, the time to execute `n` requests is the latency of the slowest request (assuming enough handles
-are available to execute all requests in parallel).
+In a single-threaded environment, the time to execute `n` requests is the sum of 
+those `n` request's latencies. With the multi interface, the time to execute `n` 
+requests is the latency of the slowest request (assuming enough handles are 
+available to execute all requests in parallel).
 
-Furthermore, the multi-interface allows requests to different hosts simultaneously, which means the Elasticsearch-PHP
-client can more effectively utilize your full cluster.
+Furthermore, the multi-interface allows requests to different hosts 
+simultaneously, which means the Elasticsearch-PHP client can more effectively 
+utilize your full cluster.
+
 
 === Using Future Mode
 
-Utilizing this feature is relatively straightforward, but it does introduce more responsibility into your code.  To enable
-future mode, set the `future` flag in the client options to `'lazy'`:
+Utilizing this feature is straightforward, but it does introduce more 
+responsibility into your code. To enable future mode, set the `future` flag in 
+the client options to `'lazy'`:
 
 [source,php]
 ----
@@ -35,17 +42,22 @@ $params = [
 $future = $client->get($params);
 ----
 
-This will return a _future_, rather than the actual response.  A future represents a _future computation_ and acts like
-a placeholder.  You can pass a future around your code like a regular object.  When you need the result values, you
-can _resolve_ the future.  If the future has already resolved (due to some other activity), the values will be immediately
-available.  If the future has not resolved yet, the resolution will block until those values have become available (e.g.
+This returns a _future_, rather than the actual response. A future represents a 
+_future computation_ and acts like a placeholder. You can pass a future around 
+your code like a regular object. When you need the result values, you can 
+_resolve_ the future. If the future has already resolved (due to some other 
+activity), the values are immediately available. If the future has not resolved 
+yet, the resolution blocks until those values become available (for example, 
 after the API call completes).
 
-In practice, this means you can queue up a batch of requests by using `future: lazy` and they will pend until you resolve
-the futures, at which time all requests will be sent in parallel to the cluster and return asynchronously to curl.
+In practice, this means you can queue up a batch of requests by using 
+`future: lazy` and they pend until you resolve the futures, at which time all 
+requests will be sent in parallel to the cluster and return asynchronously to 
+curl.
 
-This sounds tricky, but it is actually very simple thanks to RingPHP's `FutureArray` interface, which makes the future
-act like a simple associative array.  For example:
+This sounds tricky, but it is actually simple thanks to RingPHP's `FutureArray` 
+interface, which makes the future act like a simple associative array. For 
+example:
 
 [source,php]
 ----
@@ -61,11 +73,12 @@ $params = [
 
 $future = $client->get($params);
 
-$doc = $future['_source'];    // This call will block and force the future to resolve
+$doc = $future['_source'];    // This call blocks and forces the future to resolve
 ----
 
-Interacting with the future as an associative array, just like a normal response, will cause the future to resolve
-that particular value (which in turn resolves all pending requests and values).  This allows patterns such as:
+Interacting with the future as an associative array, just like a normal 
+response, causes the future to resolve that particular value (which in turn 
+resolves all pending requests and values). This allows patterns such as:
 
 [source,php]
 ----
@@ -91,11 +104,11 @@ foreach ($futures as $future) {
 }
 ----
 
-The queued requests will execute in parallel and populate their futures after execution.  Batch size defaults to
-100 requests-per-batch.
+The queued requests will execute in parallel and populate their futures after 
+execution. Batch size defaults to 100 requests/batch.
 
-If you wish to force future resolution, but don't actually need the values immediately, you can call `wait()` on the future
-to force resolution too:
+If you wish to force future resolution, but don't need the values immediately, 
+you can call `wait()` on the future to force resolution, too:
 
 [source,php]
 ----
@@ -120,9 +133,10 @@ $futures[999]->wait();
 
 === Changing batch size
 
-The default batch size is 100, meaning 100 requests will queue up before the client forces futures to begin resolving
-(e.g. initiate a `curl_multi` call).  The batch size can be changed depending on your preferences.  The batch size
-is controllable via the `max_handles` setting when configuring the handler:
+The default batch size is 100, meaning 100 requests queue up before the client 
+forces futures to begin resolving (for example, initiate a `curl_multi` call). 
+The batch size can be changed depending on your preferences. The batch size can 
+be set via the `max_handles` setting when configuring the handler:
 
 [source,php]
 ----
@@ -137,10 +151,11 @@ $client = ClientBuilder::create()
             ->build();
 ----
 
-This will change the behavior to wait on 500 queued requests before sending the batch.  Note, however, that forcing a
-future to resolve will cause the underlying curl batch to execute, regardless of if the batch is "full" or not.  In this
-example, only 499 requests are added to the queue...but the final future resolution will force the batch to flush
-anyway:
+This changes the behavior to wait on 500 queued requests before sending the 
+batch. Note, however, that forcing a future to resolve causes the underlying 
+curl batch to execute, regardless of if the batch is "full" or not. In this 
+example, only 499 requests are added to the queue, but the final future 
+resolution forces the batch to flush anyway:
 
 [source,php]
 ----
@@ -172,10 +187,11 @@ for ($i = 0; $i < 499; $i++) {
 $body = $future[499]['body'];
 ----
 
+
 === Heterogeneous batches are OK
 
-It is possible to queue up heterogeneous batches of requests.  For example, you can queue up several GETs, indexing requests
-and a search:
+It is possible to queue up heterogeneous batches of requests. For example, you 
+can queue up several GETs, indexing requests, and a search:
 
 [source,php]
 ----
@@ -228,24 +244,30 @@ $searchResults = $futures['searchRequest']['hits'];
 $doc = $futures['getRequest']['_source'];
 ----
 
+
 === Caveats to Future mode
 
-There are a few caveats to using future mode.  The biggest is also the most obvious: you need to deal with resolving the
-future yourself.  This is usually trivial, but can sometimes introduce unexpected complications.
+There are a few caveats to using future mode. The biggest is also the most 
+obvious: you need to deal with resolving the future yourself. This is usually 
+trivial, but can sometimes introduce unexpected complications.
 
-For example, if you resolve manually using `wait()`, you may need to call `wait()` several times if there were retries.
-This is because each retry will introduce another layer of wrapped futures, and each needs to be resolved to get the
-final result.
+For example, if you resolve manually using `wait()`, you may need to call 
+`wait()` several times if there were retries. This is because each retry 
+introduces another layer of wrapped futures, and each needs to be resolved to 
+get the final result.
 
-This is not needed if you access values via the ArrayInterface however (e.g. `$response['hits']['hits']`), since
-FutureArrayInterface will automatically and fully resolve the future to provide values.
+However, this is not needed if you access values via the ArrayInterface (for 
+example, `$response['hits']['hits']`) since FutureArrayInterface automatically 
+and fully resolves the future to provide values.
 
-Another caveat is that certain APIs will lose their "helper" functionality.  For example, "exists" APIs (e.g.
-`$client->exists()`, `$client->indices()->exists`, `$client->indices->templateExists()`, etc) typically return a true
-or false under normal operation.
+Another caveat is that certain APIs will lose their "helper" functionality. For 
+example, "exists" APIs (`$client->exists()`, `$client->indices()->exists`, 
+`$client->indices->templateExists()`, and so on) typically return a true or 
+false under normal operation.
 
-When operated in future mode, unwrapping of the future is left to your application,
-which means the client can no longer inspect the response and return a simple true/false.  Instead, you'll see the raw
-response from Elasticsearch and will have to take action appropriately.
+When operated in future mode, the unwrapping of the future is left to your 
+application, which means the client can no longer inspect the response and 
+return a simple true/false. Instead, you'll see the raw response from {es} and 
+will have to take action appropriately.
 
 This also applies to `ping()`.

--- a/docs/per-request-configuration.asciidoc
+++ b/docs/per-request-configuration.asciidoc
@@ -1,16 +1,20 @@
 [[per_request_configuration]]
 == Per-request configuration
 
-There are several configurations that can be set on a per-request basis, rather than at a connection- or client-level.
-These are specified as part of the request associative array.
+There are several configurations that can be set on a per-request basis, rather 
+than at a connection- or client-level. These are specified as part of the 
+request associative array.
 
 
 === Request Identification
 
-You can enrich your requests against Elasticsearch with an identifier string, that allows you to discover this identifier
-in https://www.elastic.co/guide/en/elasticsearch/reference/7.4/logging.html#deprecation-logging[deprecation logs], to support you with
+You can enrich your requests against {es} with an identifier string, that allows 
+you to discover this identifier in 
+https://www.elastic.co/guide/en/elasticsearch/reference/7.4/logging.html#deprecation-logging[deprecation logs], 
+to support you with 
 https://www.elastic.co/guide/en/elasticsearch/reference/7.4/index-modules-slowlog.html#_identifying_search_slow_log_origin[identifying search slow log origin]
-or to help with https://www.elastic.co/guide/en/elasticsearch/reference/current/tasks.html#_identifying_running_tasks[identifying running tasks].
+or to help with 
+https://www.elastic.co/guide/en/elasticsearch/reference/current/tasks.html#_identifying_running_tasks[identifying running tasks].
 
 
 [source,php]
@@ -27,20 +31,25 @@ $params = [
 $response = $client->get($params);
 
 ----
-<1> This will populate the `X-Opaque-Id` header with the value `app17@dc06.eu_user1234`
+<1> This populates the `X-Opaque-Id` header with the value 
+`app17@dc06.eu_user1234`.
 
 
 === Ignoring exceptions
-The library attempts to throw exceptions for common problems.  These exceptions match the HTTP response code provided
-by Elasticsearch.  For example, attempting to GET a nonexistent document will throw a `MissingDocument404Exception`.
 
-Exceptions are a useful and consistent way to deal with problems like missing documents, syntax errors, version
-conflicts, etc.  But sometimes you want to deal with the response body rather than catch exceptions (often useful
-in test suites).
+The library attempts to throw exceptions for common problems. These exceptions 
+match the HTTP response code provided by {es}. For example, attempting to GET a 
+nonexistent document will throw a `MissingDocument404Exception`.
 
-If you need that behavior, you can configure an `ignore` parameter.  This should be configured in the `client` parameter
-of the request array.  For example, this example will ignore the `MissingDocument404Exception`
-exception and instead return the JSON provided by Elasticsearch.
+Exceptions are a useful and consistent way to deal with problems like missing 
+documents, syntax errors, version conflicts, and so on. But sometimes you want 
+to deal with the response body rather than catch exceptions (often useful in 
+test suites).
+
+If you need that behavior, you can configure an `ignore` parameter. You can 
+configure it in the `client` parameter of the request array. For instance, the 
+example below ignores the `MissingDocument404Exception` exception and returns 
+the JSON provided by {es} instead.
 
 
 [source,php]
@@ -56,9 +65,10 @@ echo $client->get($params);
 
 > {"_index":"test_missing","_type":"_doc","_id":"1","found":false}
 ----
-<1> This will ignore just the 404 missing exception
+<1> This ignores the 404 missing exception.
 
-You can specify multiple HTTP status codes to ignore, by providing an array of values:
+You can specify multiple HTTP status codes to ignore by providing an array of 
+values:
 
 [source,php]
 ----
@@ -73,23 +83,26 @@ echo $client->get($params);
 > No handler found for uri [/test_missing/test/] and method [GET]
 
 ----
-<1> `ignore` also accepts an array of exceptions to ignore. In this example,
-the `BadRequest400Exception` is being ignored
+<1> `ignore` also accepts an array of exceptions to ignore. In this example, the 
+`BadRequest400Exception` is being ignored.
 
+It should be noted that the response is a string which may or may not be encoded 
+as JSON. In the first example, the response body is a complete JSON object which 
+could be decoded. In the second example, it was simply a string.
 
-It should be noted that the response is simply a string, which may or may not be encoded as JSON.  In the first example,
-the response body was a complete JSON object which could be decoded.  In the second example, it was simply a string.
+Since the client has no way of knowing what the exception response will contain, 
+no attempts to decode it are taken.
 
-Since the client has no way of knowing what the exception response will contain, no attempts to decode it are taken.
 
 === Providing custom query parameters
 
-Sometimes you need to provide custom query params, such as authentication tokens for a third-party plugin or proxy.
-All query parameters are white-listed in Elasticsearch-php, which is to protect you from specifying a param which is
-not accepted by Elasticsearch.
+Sometimes you need to provide custom query parameters, such as authentication 
+tokens for a third-party plugin or proxy. All query parameters are allow listed 
+in Elasticsearch-php, which is to protect you from specifying a parameter which 
+is not accepted by {es}.
 
-If you need custom parameters, you need to bypass this whitelisting mechanism.  To do so, add them to the `custom`
-parameter as an array of values:
+If you need custom parameters, you need to bypass this allow listing mechanism. 
+To do so, add them to the `custom` parameter as an array of values:
 
 [source,php]
 ----
@@ -98,10 +111,10 @@ $client = ClientBuilder::create()->build();
 $params = [
     'index'  => 'test',
     'id'     => 1,
-    'parent' => 'abc',              // white-listed Elasticsearch parameter
+    'parent' => 'abc',              // allowlisted Elasticsearch parameter
     'client' => [
         'custom' => [
-            'customToken' => 'abc', // user-defined, not white listed, not checked
+            'customToken' => 'abc', // user-defined, not allow listed, not checked
             'otherToken'  => 123
         ]
     ]
@@ -110,11 +123,12 @@ $exists = $client->exists($params);
 ----
 
 
-=== Increasing the Verbosity of responses
+=== Increasing the verbosity of responses
 
-By default, the client will only return the response body.  If you require more information (e.g. stats about the transfer,
-headers, status codes, etc), you can tell the client to return a more verbose response.  This is enabled via the
-`verbose` parameter in the client options.
+By default, the client only returns the response body. If you require more 
+information (for example, stats about the transfer, headers, status codes, and 
+so on), you can tell the client to return a more verbose response. This is 
+enabled via the `verbose` parameter in the client options.
 
 Without verbosity, all you see is the response body:
 
@@ -237,20 +251,25 @@ Array
 
 === Curl Timeouts
 
-It is possible to configure per-request curl timeouts via the `timeout` and `connect_timeout` parameters.  These
-control the client-side, curl timeouts.  The `connect_timeout` paramter controls how long curl should wait for the
-"connect" phase to finish, while the `timeout` parameter controls how long curl should wait for the entire request
-to finish.
+It is possible to configure per-request curl timeouts via the `timeout` and 
+`connect_timeout` parameters. These control the client-side, curl timeouts. The 
+`connect_timeout` paramter controls how long curl should wait for the "connect" 
+phase to finish, while the `timeout` parameter controls how long curl should 
+wait for the entire request to finish.
 
-If either timeout expires, curl will close the connection and return an error.  Both parameters should be specified
-in seconds.
+If either timeout expires, curl closes the connection and returns an error. Both 
+parameters should be specified in seconds.
 
-Note: client-side timeouts *do not* mean that Elasticsearch aborts the request.  Elasticsearch will continue executing
-the request until it completes.  In the case of a slow query or bulk request, the operation will continue executing
-"in the background", unknown to your client.  If your client kills connections rapidly with a timeout, only to immediately
-execute another request, it is possible to swamp the server with many connections because there is no "back-pressure" on the
-client.  In these situations, you will see the appropriate threadpool queue growing in size, and may start receiving
-`EsRejectedExecutionException` exceptions from Elasticsearch when the queue finally reaches capacity.
+Note: client-side timeouts *do not* mean that {es} aborts the request. {es} will 
+continue executing the request until it completes. In the case of a slow query 
+or bulk request, the operation continues executing "in the background", unknown 
+to your client. If your client kills connections rapidly with a timeout, only to 
+immediately execute another request, it is possible to swamp the server with 
+many connections because there is no "back-pressure" on the client. In these 
+situations, you will see the appropriate threadpool queue growing in size, and 
+may start receiving `EsRejectedExecutionException` exceptions from {es} when the 
+queue finally reaches capacity.
+
 
 [source,php]
 ----
@@ -267,10 +286,12 @@ $params = [
 $response = $client->get($params);
 ----
 
+
 === Enabling Future Mode
 
-The client supports asynchronous, batch processing of requests.  This is enabled (if your HTTP handler supports it) on
-a per-request basis via the `future` parameter in the client options:
+The client supports asynchronous, batch processing of requests. This is enabled 
+(if your HTTP handler supports it) on a per-request basis via the `future` 
+parameter in the client options:
 
 [source,php]
 ----
@@ -287,17 +308,19 @@ $future = $client->get($params);
 $results = $future->wait();       // resolve the future
 ----
 
-Future mode supports two options: `true` or `'lazy'`.  For more details about how asynchronous execution functions, and
-how to work with the results, see the dedicated page on <<future_mode>>.
+Future mode supports two options: `true` or `'lazy'`. For more details about how 
+asynchronous execution functions, and how to work with the results, see the 
+dedicated page on <<future_mode>>.
+
 
 === SSL Encryption
 
-Normally, you will specify SSL configurations when you create the client (see
-<<security>> for more details), since encryption typically
-applies to all requests. However, it is possible to configure on a per-request basis too if you need that functionality.
-For example, if you  need to use a self-signed cert on a specific request, you can specify it via the `verify` parameter
-in the client options:
-
+Normally, you specify SSL configurations when you create the client (see 
+<<security>> for more details), since encryption typically applies to all 
+requests. However, it is possible to configure on a per-request basis, too, if 
+you need that functionality. For example, if you need to use a self-signed cert 
+on a specific request, you can specify it via the `verify` parameter in the 
+client options:
 
 [source,php]
 ----


### PR DESCRIPTION
This PR fine-tunes the wording of the following sections and improves readability:

* **Per-request configuration**
* **Future Mode**

Related issue: https://github.com/elastic/stack-docs/issues/883

Previews:
* Per-request configuration: http://elasticsearch-php_1005.docs-preview.app.elstc.co/guide/en/elasticsearch/client/php-api/7.x/per_request_configuration.html
* Future Mode: http://elasticsearch-php_1005.docs-preview.app.elstc.co/guide/en/elasticsearch/client/php-api/7.x/future_mode.html