### PR TITLE
Better exception message for Could not parse URI

### DIFF
--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -670,7 +670,7 @@ class ClientBuilder
         $parts = parse_url($host);
 
         if ($parts === false) {
-            throw new InvalidArgumentException("Could not parse URI");
+            throw new InvalidArgumentException(sprintf('Could not parse URI: "%s"', $host));
         }
 
         if (isset($parts['port']) !== true) {


### PR DESCRIPTION
Not sure what the current lowest supported version is. Please change the target branch or ping me.

Most users run into this exception when they configure the URI false but mostly we are not sure if the ENV environment don't work or if they just really configured a not parse able url. So it would be great to output the given value in the exception message also to improve developer experience.
