### PR TITLE
Remove setId() into Endpoints, fixes #1017

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
 
 env:
   global:
-    - STACK_VERSION="7.7.0-SNAPSHOT"
+    - STACK_VERSION="7.7-SNAPSHOT"
 
 before_install:
   - ./travis/run_es_docker.sh

--- a/src/Elasticsearch/Endpoints/AbstractEndpoint.php
+++ b/src/Elasticsearch/Endpoints/AbstractEndpoint.php
@@ -160,7 +160,7 @@ abstract class AbstractEndpoint
      *
      * @return $this
      */
-    public function setID($docID)
+    public function setId($docID)
     {
         if ($docID === null) {
             return $this;
@@ -169,7 +169,7 @@ abstract class AbstractEndpoint
         if (is_int($docID)) {
             $docID = (string) $docID;
         }
-
+        
         $this->id = urlencode($docID);
 
         return $this;

--- a/src/Elasticsearch/Endpoints/AsyncSearch/Delete.php
+++ b/src/Elasticsearch/Endpoints/AsyncSearch/Delete.php
@@ -39,14 +39,4 @@ class Delete extends AbstractEndpoint
     {
         return 'DELETE';
     }
-
-    public function setId($id): Delete
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/AsyncSearch/Get.php
+++ b/src/Elasticsearch/Endpoints/AsyncSearch/Get.php
@@ -43,14 +43,4 @@ class Get extends AbstractEndpoint
     {
         return 'GET';
     }
-
-    public function setId($id): Get
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/Cat/MlDataFrameAnalytics.php
+++ b/src/Elasticsearch/Endpoints/Cat/MlDataFrameAnalytics.php
@@ -47,14 +47,4 @@ class MlDataFrameAnalytics extends AbstractEndpoint
     {
         return 'GET';
     }
-
-    public function setId($id): MlDataFrameAnalytics
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/Create.php
+++ b/src/Elasticsearch/Endpoints/Create.php
@@ -72,14 +72,4 @@ class Create extends AbstractEndpoint
 
         return $this;
     }
-
-    public function setId($id): Create
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/Delete.php
+++ b/src/Elasticsearch/Endpoints/Delete.php
@@ -63,14 +63,4 @@ class Delete extends AbstractEndpoint
     {
         return 'DELETE';
     }
-
-    public function setId($id): Delete
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/DeleteScript.php
+++ b/src/Elasticsearch/Endpoints/DeleteScript.php
@@ -42,14 +42,4 @@ class DeleteScript extends AbstractEndpoint
     {
         return 'DELETE';
     }
-
-    public function setId($id): DeleteScript
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/Exists.php
+++ b/src/Elasticsearch/Endpoints/Exists.php
@@ -65,14 +65,4 @@ class Exists extends AbstractEndpoint
     {
         return 'HEAD';
     }
-
-    public function setId($id): Exists
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/ExistsSource.php
+++ b/src/Elasticsearch/Endpoints/ExistsSource.php
@@ -64,14 +64,4 @@ class ExistsSource extends AbstractEndpoint
     {
         return 'HEAD';
     }
-
-    public function setId($id): ExistsSource
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/Explain.php
+++ b/src/Elasticsearch/Endpoints/Explain.php
@@ -77,14 +77,4 @@ class Explain extends AbstractEndpoint
 
         return $this;
     }
-
-    public function setId($id): Explain
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/Get.php
+++ b/src/Elasticsearch/Endpoints/Get.php
@@ -65,14 +65,4 @@ class Get extends AbstractEndpoint
     {
         return 'GET';
     }
-
-    public function setId($id): Get
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/GetScript.php
+++ b/src/Elasticsearch/Endpoints/GetScript.php
@@ -41,14 +41,4 @@ class GetScript extends AbstractEndpoint
     {
         return 'GET';
     }
-
-    public function setId($id): GetScript
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/GetSource.php
+++ b/src/Elasticsearch/Endpoints/GetSource.php
@@ -64,14 +64,4 @@ class GetSource extends AbstractEndpoint
     {
         return 'GET';
     }
-
-    public function setId($id): GetSource
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/Index.php
+++ b/src/Elasticsearch/Endpoints/Index.php
@@ -76,14 +76,4 @@ class Index extends AbstractEndpoint
 
         return $this;
     }
-
-    public function setId($id): Index
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/Ingest/DeletePipeline.php
+++ b/src/Elasticsearch/Endpoints/Ingest/DeletePipeline.php
@@ -42,14 +42,4 @@ class DeletePipeline extends AbstractEndpoint
     {
         return 'DELETE';
     }
-
-    public function setId($id): DeletePipeline
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/Ingest/GetPipeline.php
+++ b/src/Elasticsearch/Endpoints/Ingest/GetPipeline.php
@@ -40,14 +40,4 @@ class GetPipeline extends AbstractEndpoint
     {
         return 'GET';
     }
-
-    public function setId($id): GetPipeline
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/Ingest/PutPipeline.php
+++ b/src/Elasticsearch/Endpoints/Ingest/PutPipeline.php
@@ -52,14 +52,4 @@ class PutPipeline extends AbstractEndpoint
 
         return $this;
     }
-
-    public function setId($id): PutPipeline
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/Ingest/Simulate.php
+++ b/src/Elasticsearch/Endpoints/Ingest/Simulate.php
@@ -50,14 +50,4 @@ class Simulate extends AbstractEndpoint
 
         return $this;
     }
-
-    public function setId($id): Simulate
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/Ml/DeleteDataFrameAnalytics.php
+++ b/src/Elasticsearch/Endpoints/Ml/DeleteDataFrameAnalytics.php
@@ -41,14 +41,4 @@ class DeleteDataFrameAnalytics extends AbstractEndpoint
     {
         return 'DELETE';
     }
-
-    public function setId($id): DeleteDataFrameAnalytics
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/Ml/ExplainDataFrameAnalytics.php
+++ b/src/Elasticsearch/Endpoints/Ml/ExplainDataFrameAnalytics.php
@@ -48,14 +48,4 @@ class ExplainDataFrameAnalytics extends AbstractEndpoint
 
         return $this;
     }
-
-    public function setId($id): ExplainDataFrameAnalytics
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/Ml/GetDataFrameAnalytics.php
+++ b/src/Elasticsearch/Endpoints/Ml/GetDataFrameAnalytics.php
@@ -42,14 +42,4 @@ class GetDataFrameAnalytics extends AbstractEndpoint
     {
         return 'GET';
     }
-
-    public function setId($id): GetDataFrameAnalytics
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/Ml/GetDataFrameAnalyticsStats.php
+++ b/src/Elasticsearch/Endpoints/Ml/GetDataFrameAnalyticsStats.php
@@ -42,14 +42,4 @@ class GetDataFrameAnalyticsStats extends AbstractEndpoint
     {
         return 'GET';
     }
-
-    public function setId($id): GetDataFrameAnalyticsStats
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/Ml/PutDataFrameAnalytics.php
+++ b/src/Elasticsearch/Endpoints/Ml/PutDataFrameAnalytics.php
@@ -49,14 +49,4 @@ class PutDataFrameAnalytics extends AbstractEndpoint
 
         return $this;
     }
-
-    public function setId($id): PutDataFrameAnalytics
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/Ml/StartDataFrameAnalytics.php
+++ b/src/Elasticsearch/Endpoints/Ml/StartDataFrameAnalytics.php
@@ -51,14 +51,4 @@ class StartDataFrameAnalytics extends AbstractEndpoint
 
         return $this;
     }
-
-    public function setId($id): StartDataFrameAnalytics
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/Ml/StopDataFrameAnalytics.php
+++ b/src/Elasticsearch/Endpoints/Ml/StopDataFrameAnalytics.php
@@ -53,14 +53,4 @@ class StopDataFrameAnalytics extends AbstractEndpoint
 
         return $this;
     }
-
-    public function setId($id): StopDataFrameAnalytics
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/Nodes/ReloadSecureSettings.php
+++ b/src/Elasticsearch/Endpoints/Nodes/ReloadSecureSettings.php
@@ -42,6 +42,16 @@ class ReloadSecureSettings extends AbstractEndpoint
         return 'POST';
     }
 
+    public function setBody($body): ReloadSecureSettings
+    {
+        if (isset($body) !== true) {
+            return $this;
+        }
+        $this->body = $body;
+
+        return $this;
+    }
+
     public function setNodeId($node_id): ReloadSecureSettings
     {
         if (isset($node_id) !== true) {

--- a/src/Elasticsearch/Endpoints/PutScript.php
+++ b/src/Elasticsearch/Endpoints/PutScript.php
@@ -61,16 +61,6 @@ class PutScript extends AbstractEndpoint
         return $this;
     }
 
-    public function setId($id): PutScript
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
-
     public function setContext($context): PutScript
     {
         if (isset($context) !== true) {

--- a/src/Elasticsearch/Endpoints/RenderSearchTemplate.php
+++ b/src/Elasticsearch/Endpoints/RenderSearchTemplate.php
@@ -48,14 +48,4 @@ class RenderSearchTemplate extends AbstractEndpoint
 
         return $this;
     }
-
-    public function setId($id): RenderSearchTemplate
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/Rollup/DeleteJob.php
+++ b/src/Elasticsearch/Endpoints/Rollup/DeleteJob.php
@@ -39,14 +39,4 @@ class DeleteJob extends AbstractEndpoint
     {
         return 'DELETE';
     }
-
-    public function setId($id): DeleteJob
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/Rollup/GetJobs.php
+++ b/src/Elasticsearch/Endpoints/Rollup/GetJobs.php
@@ -38,14 +38,4 @@ class GetJobs extends AbstractEndpoint
     {
         return 'GET';
     }
-
-    public function setId($id): GetJobs
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/Rollup/GetRollupCaps.php
+++ b/src/Elasticsearch/Endpoints/Rollup/GetRollupCaps.php
@@ -38,14 +38,4 @@ class GetRollupCaps extends AbstractEndpoint
     {
         return 'GET';
     }
-
-    public function setId($id): GetRollupCaps
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/Rollup/PutJob.php
+++ b/src/Elasticsearch/Endpoints/Rollup/PutJob.php
@@ -49,14 +49,4 @@ class PutJob extends AbstractEndpoint
 
         return $this;
     }
-
-    public function setId($id): PutJob
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/Rollup/StartJob.php
+++ b/src/Elasticsearch/Endpoints/Rollup/StartJob.php
@@ -39,14 +39,4 @@ class StartJob extends AbstractEndpoint
     {
         return 'POST';
     }
-
-    public function setId($id): StartJob
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/Rollup/StopJob.php
+++ b/src/Elasticsearch/Endpoints/Rollup/StopJob.php
@@ -42,14 +42,4 @@ class StopJob extends AbstractEndpoint
     {
         return 'POST';
     }
-
-    public function setId($id): StopJob
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/TermVectors.php
+++ b/src/Elasticsearch/Endpoints/TermVectors.php
@@ -77,14 +77,4 @@ class TermVectors extends AbstractEndpoint
 
         return $this;
     }
-
-    public function setId($id): TermVectors
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/Update.php
+++ b/src/Elasticsearch/Endpoints/Update.php
@@ -76,14 +76,4 @@ class Update extends AbstractEndpoint
 
         return $this;
     }
-
-    public function setId($id): Update
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/Watcher/DeleteWatch.php
+++ b/src/Elasticsearch/Endpoints/Watcher/DeleteWatch.php
@@ -39,14 +39,4 @@ class DeleteWatch extends AbstractEndpoint
     {
         return 'DELETE';
     }
-
-    public function setId($id): DeleteWatch
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/Watcher/ExecuteWatch.php
+++ b/src/Elasticsearch/Endpoints/Watcher/ExecuteWatch.php
@@ -50,14 +50,4 @@ class ExecuteWatch extends AbstractEndpoint
 
         return $this;
     }
-
-    public function setId($id): ExecuteWatch
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/Watcher/GetWatch.php
+++ b/src/Elasticsearch/Endpoints/Watcher/GetWatch.php
@@ -41,14 +41,4 @@ class GetWatch extends AbstractEndpoint
     {
         return 'GET';
     }
-
-    public function setId($id): GetWatch
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Endpoints/Watcher/PutWatch.php
+++ b/src/Elasticsearch/Endpoints/Watcher/PutWatch.php
@@ -54,14 +54,4 @@ class PutWatch extends AbstractEndpoint
 
         return $this;
     }
-
-    public function setId($id): PutWatch
-    {
-        if (isset($id) !== true) {
-            return $this;
-        }
-        $this->id = $id;
-
-        return $this;
-    }
 }

--- a/src/Elasticsearch/Namespaces/ClusterNamespace.php
+++ b/src/Elasticsearch/Namespaces/ClusterNamespace.php
@@ -46,6 +46,9 @@ class ClusterNamespace extends AbstractNamespace
      * @param array $params Associative array of parameters
      * @return array
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-templates.html
+     *
+     * @note This API is EXPERIMENTAL and may be changed or removed completely in a future release
+     *
      */
     public function deleteComponentTemplate(array $params = [])
     {
@@ -66,6 +69,9 @@ class ClusterNamespace extends AbstractNamespace
      * @param array $params Associative array of parameters
      * @return array
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-templates.html
+     *
+     * @note This API is EXPERIMENTAL and may be changed or removed completely in a future release
+     *
      */
     public function getComponentTemplate(array $params = [])
     {
@@ -153,6 +159,9 @@ class ClusterNamespace extends AbstractNamespace
      * @param array $params Associative array of parameters
      * @return array
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-templates.html
+     *
+     * @note This API is EXPERIMENTAL and may be changed or removed completely in a future release
+     *
      */
     public function putComponentTemplate(array $params = [])
     {

--- a/src/Elasticsearch/Namespaces/NodesNamespace.php
+++ b/src/Elasticsearch/Namespaces/NodesNamespace.php
@@ -68,6 +68,7 @@ class NodesNamespace extends AbstractNamespace
     /**
      * $params['node_id'] = (list) A comma-separated list of node IDs to span the reload/reinit call. Should stay empty because reloading usually involves all cluster nodes.
      * $params['timeout'] = (time) Explicit operation timeout
+     * $params['body']    = (array) An object containing the password for the elasticsearch keystore
      *
      * @param array $params Associative array of parameters
      * @return array
@@ -76,11 +77,13 @@ class NodesNamespace extends AbstractNamespace
     public function reloadSecureSettings(array $params = [])
     {
         $node_id = $this->extractArgument($params, 'node_id');
+        $body = $this->extractArgument($params, 'body');
 
         $endpointBuilder = $this->endpoints;
         $endpoint = $endpointBuilder('Nodes\ReloadSecureSettings');
         $endpoint->setParams($params);
         $endpoint->setNodeId($node_id);
+        $endpoint->setBody($body);
 
         return $this->performRequest($endpoint);
     }

--- a/tests/Elasticsearch/Tests/YamlRunnerTest.php
+++ b/tests/Elasticsearch/Tests/YamlRunnerTest.php
@@ -588,10 +588,6 @@ class YamlRunnerTest extends \PHPUnit\Framework\TestCase
                     }
                 }
                 break;
-            case 'Basic':
-                // Fix issue converting "中文" in unicode
-                $match = is_string($match) ? utf8_decode($match) : $match;
-                break;
         }
 
         $expected = $this->replaceWithContext(current($operation), $context);

--- a/tests/Elasticsearch/Tests/YamlRunnerTest.php
+++ b/tests/Elasticsearch/Tests/YamlRunnerTest.php
@@ -840,7 +840,6 @@ class YamlRunnerTest extends \PHPUnit\Framework\TestCase
         foreach ($finder as $file) {
             $files = array_merge($files, $this->splitDocument($file, $path, $filter));
         }
-
         return $files;
     }
 

--- a/util/Endpoint.php
+++ b/util/Endpoint.php
@@ -168,7 +168,7 @@ class Endpoint
             }
         }
         foreach ($this->parts as $part => $value) {
-            if (in_array($part, ['type', 'index'])) {
+            if (in_array($part, ['type', 'index', 'id'])) {
                 continue;
             }
             if (isset($value['type']) && $value['type'] === 'list') {


### PR DESCRIPTION
This PR provides a fix for #1017 removing the setId() from the endpoints into the code generator (https://github.com/elastic/elasticsearch-php/blob/7.7/util/GenerateEndpoints.php).
This PR includes also all the endpoints generated with the fix.