### PR TITLE
Fixing the PHP Unit tests.

### DIFF
--- a/tests/Elasticsearch/Tests/ClientTest.php
+++ b/tests/Elasticsearch/Tests/ClientTest.php
@@ -132,7 +132,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
     {
         $client = ClientBuilder::create()->build();
 
-        $this->expectException(Elasticsearch\Common\Exceptions\Missing404Exception::class);
+        $this->expectException(Elasticsearch\Common\Exceptions\BadRequest400Exception::class);
 
         $client->delete(
             [
@@ -177,7 +177,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
     {
         $client = ClientBuilder::create()->build();
 
-        $this->expectException(Elasticsearch\Common\Exceptions\Missing404Exception::class);
+        $this->expectException(Elasticsearch\Common\Exceptions\BadRequest400Exception::class);
 
         $client->delete(
             [
@@ -192,7 +192,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
     {
         $client = ClientBuilder::create()->build();
 
-        $this->expectException(Elasticsearch\Common\Exceptions\Missing404Exception::class);
+        $this->expectException(Elasticsearch\Common\Exceptions\BadRequest400Exception::class);
 
         $client->delete(
             [


### PR DESCRIPTION
Fixing the unit tests.

I choose to fix the unit test in a way that it maybe allows a BC break, because the client now throws a different exception. But I think that this is okay because the response from the ES sever has a different error code.