### PR TITLE
Make ClientBuilder override possible

### DIFF
--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -180,7 +180,7 @@ class ClientBuilder
      */
     public static function fromConfig(array $config, bool $quiet = false): Client
     {
-        $builder = new self;
+        $builder = new static;
         foreach ($config as $key => $value) {
             $method = "set$key";
             if (method_exists($builder, $method)) {


### PR DESCRIPTION
As instantiate method is protected, using static instead of self allow you to create your own ClientBuilder and override it