### PR TITLE
Output json_last_error_msg instead of json_last_error

### DIFF
--- a/src/Elasticsearch/Serializers/SmartSerializer.php
+++ b/src/Elasticsearch/Serializers/SmartSerializer.php
@@ -33,7 +33,7 @@ class SmartSerializer implements SerializerInterface
         } else {
             $data = json_encode($data, JSON_PRESERVE_ZERO_FRACTION + JSON_INVALID_UTF8_SUBSTITUTE);
             if ($data === false) {
-                throw new Exceptions\RuntimeException("Failed to JSON encode: ".json_last_error());
+                throw new Exceptions\RuntimeException("Failed to JSON encode: ".json_last_error_msg());
             }
             if ($data === '[]') {
                 return '{}';


### PR DESCRIPTION
The `JsonErrorException` already converts the error code from `json_last_error` into a human readable error message. The `RuntimeException` however does not do this. To have more consistency between the two and for improved human readability I have changed `json_last_error` to `json_last_error_msg`. Error messages now no longer look like this:

```
[Elasticsearch\Common\Exceptions\RuntimeException]  
Failed to JSON encode: 5
```

And instead they look more like this:

```
[Elasticsearch\Common\Exceptions\RuntimeException]                               
Failed to JSON encode: Malformed UTF-8 characters, possibly incorrectly encoded
```