### PR TITLE
Move scroll_id into body for search operations doc

### DIFF
--- a/docs/search-operations.asciidoc
+++ b/docs/search-operations.asciidoc
@@ -283,9 +283,10 @@ while (isset($response['hits']['hits']) && count($response['hits']['hits']) > 0)
 
     // Execute a Scroll request and repeat
     $response = $client->scroll([
+        'body' => [
             'scroll_id' => $scroll_id,  //...using our previously obtained _scroll_id
             'scroll'    => '30s'        // and the same timeout window
         ]
-    );
+    ]);
 }
 ----


### PR DESCRIPTION
This PR fixes #1044 moving the `scroll_id` and `scroll` parameters in the body of search operations documentation.