### PR TITLE
Improvements about fixtures and assertion equals

### DIFF
--- a/tests/Elasticsearch/Tests/ClientBuilderTest.php
+++ b/tests/Elasticsearch/Tests/ClientBuilderTest.php
@@ -110,7 +110,7 @@ class ClientBuilderTest extends TestCase
         } catch (ElasticsearchException $e) {
             $request = $client->transport->getLastConnection()->getLastRequestInfo();
             $this->assertTrue(isset($request['request']['headers']['Host'][0]));
-            $this->assertEquals($url, $request['request']['headers']['Host'][0]);
+            $this->assertSame($url, $request['request']['headers']['Host'][0]);
         }
     }
 
@@ -138,7 +138,7 @@ class ClientBuilderTest extends TestCase
         } catch (ElasticsearchException $e) {
             $request = $client->transport->getLastConnection()->getLastRequestInfo();
             $this->assertTrue(isset($request['request']['headers']['Host'][0]));
-            $this->assertEquals($host, $request['request']['headers']['Host'][0]);
+            $this->assertSame($host, $request['request']['headers']['Host'][0]);
         }
     }
 
@@ -167,7 +167,7 @@ class ClientBuilderTest extends TestCase
         } catch (ElasticsearchException $e) {
             $request = $client->transport->getLastConnection()->getLastRequestInfo();
             $this->assertTrue(isset($request['request']['headers']['Host'][0]));
-            $this->assertEquals($host, $request['request']['headers']['Host'][0]);
+            $this->assertSame($host, $request['request']['headers']['Host'][0]);
         }
     }
 }

--- a/tests/Elasticsearch/Tests/ClientIntegrationTest.php
+++ b/tests/Elasticsearch/Tests/ClientIntegrationTest.php
@@ -44,7 +44,7 @@ class ClientIntegrationTest extends \PHPUnit\Framework\TestCase
      */
     private $host;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->host = Utility::getHost();
         if (null == $this->host) {

--- a/tests/Elasticsearch/Tests/ClientTest.php
+++ b/tests/Elasticsearch/Tests/ClientTest.php
@@ -33,7 +33,7 @@ use Mockery as m;
  */
 class ClientTest extends \PHPUnit\Framework\TestCase
 {
-    public function tearDown()
+    protected function tearDown()
     {
         m::close();
     }

--- a/tests/Elasticsearch/Tests/ConnectionPool/Selectors/StickyRoundRobinSelectorTest.php
+++ b/tests/Elasticsearch/Tests/ConnectionPool/Selectors/StickyRoundRobinSelectorTest.php
@@ -29,7 +29,7 @@ use Mockery as m;
  */
 class StickyRoundRobinSelectorTest extends \PHPUnit\Framework\TestCase
 {
-    public function tearDown()
+    protected function tearDown()
     {
         m::close();
     }

--- a/tests/Elasticsearch/Tests/ConnectionPool/SniffingConnectionPoolTest.php
+++ b/tests/Elasticsearch/Tests/ConnectionPool/SniffingConnectionPoolTest.php
@@ -38,7 +38,7 @@ class SniffingConnectionPoolTest extends \PHPUnit\Framework\TestCase
     }
 
 
-    public function tearDown()
+    protected function tearDown()
     {
         m::close();
     }

--- a/tests/Elasticsearch/Tests/ConnectionPool/StaticConnectionPoolIntegrationTest.php
+++ b/tests/Elasticsearch/Tests/ConnectionPool/StaticConnectionPoolIntegrationTest.php
@@ -34,7 +34,7 @@ class StaticConnectionPoolIntegrationTest extends \PHPUnit\Framework\TestCase
      */
     private $host;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->host = Utility::getHost();
         if (null == $this->host) {

--- a/tests/Elasticsearch/Tests/ConnectionPool/StaticConnectionPoolTest.php
+++ b/tests/Elasticsearch/Tests/ConnectionPool/StaticConnectionPoolTest.php
@@ -32,7 +32,7 @@ use Mockery as m;
  */
 class StaticConnectionPoolTest extends \PHPUnit\Framework\TestCase
 {
-    public function tearDown()
+    protected function tearDown()
     {
         m::close();
     }

--- a/tests/Elasticsearch/Tests/Endpoints/AbstractEndpointTest.php
+++ b/tests/Elasticsearch/Tests/Endpoints/AbstractEndpointTest.php
@@ -71,6 +71,6 @@ class AbstractEndpointTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey('headers', $options['client']);
         $this->assertArrayHasKey('x-opaque-id', $options['client']['headers']);
         $this->assertNotEmpty($options['client']['headers']['x-opaque-id']);
-        $this->assertEquals($params['client']['opaqueId'], $options['client']['headers']['x-opaque-id'][0]);
+        $this->assertSame($params['client']['opaqueId'], $options['client']['headers']['x-opaque-id'][0]);
     }
 }

--- a/tests/Elasticsearch/Tests/Helper/Iterators/SearchHitIteratorTest.php
+++ b/tests/Elasticsearch/Tests/Helper/Iterators/SearchHitIteratorTest.php
@@ -33,12 +33,12 @@ class SearchHitIteratorTest extends \PHPUnit\Framework\TestCase
      */
     private $searchResponse;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->searchResponse = Mockery::mock(SearchResponseIterator::class);
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         Mockery::close();
     }
@@ -127,8 +127,8 @@ class SearchHitIteratorTest extends \PHPUnit\Framework\TestCase
         $responses = new SearchHitIterator($this->searchResponse);
         $i = 0;
         foreach ($responses as $key => $value) {
-            $this->assertEquals($i, $key);
-            $this->assertEquals("bar$i", $value['foo']);
+            $this->assertSame($i, $key);
+            $this->assertSame("bar$i", $value['foo']);
             $i++;
         }
     }

--- a/tests/Elasticsearch/Tests/Helper/Iterators/SearchResponseIteratorTest.php
+++ b/tests/Elasticsearch/Tests/Helper/Iterators/SearchResponseIteratorTest.php
@@ -29,7 +29,7 @@ use Mockery as m;
 class SearchResponseIteratorTest extends \PHPUnit\Framework\TestCase
 {
 
-    public function tearDown()
+    protected function tearDown()
     {
         m::close();
     }
@@ -178,6 +178,6 @@ class SearchResponseIteratorTest extends \PHPUnit\Framework\TestCase
             $count += count($response['hits']['hits']);
             $this->assertEquals($response['_scroll_id'], sprintf("scroll_id_%02d", ++$i));
         }
-        $this->assertEquals(3, $count);
+        $this->assertSame(3, $count);
     }
 }

--- a/tests/Elasticsearch/Tests/RegisteredNamespaceTest.php
+++ b/tests/Elasticsearch/Tests/RegisteredNamespaceTest.php
@@ -32,7 +32,7 @@ use Mockery as m;
  */
 class RegisteredNamespaceTest extends \PHPUnit\Framework\TestCase
 {
-    public function tearDown()
+    protected function tearDown()
     {
         m::close();
     }

--- a/tests/Elasticsearch/Tests/Serializers/ArrayToJSONSerializerTest.php
+++ b/tests/Elasticsearch/Tests/Serializers/ArrayToJSONSerializerTest.php
@@ -27,7 +27,7 @@ use Mockery as m;
  */
 class ArrayToJSONSerializerTest extends \PHPUnit\Framework\TestCase
 {
-    public function tearDown()
+    protected function tearDown()
     {
         m::close();
     }

--- a/tests/Elasticsearch/Tests/Serializers/EverythingToJSONSerializerTest.php
+++ b/tests/Elasticsearch/Tests/Serializers/EverythingToJSONSerializerTest.php
@@ -27,7 +27,7 @@ use Mockery as m;
  */
 class EverythingToJSONSerializerTest extends \PHPUnit\Framework\TestCase
 {
-    public function tearDown()
+    protected function tearDown()
     {
         m::close();
     }

--- a/tests/Elasticsearch/Tests/Serializers/SmartSerializerTest.php
+++ b/tests/Elasticsearch/Tests/Serializers/SmartSerializerTest.php
@@ -29,7 +29,7 @@ use PHPUnit\Framework\TestCase;
  */
 class SmartSerializerTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->serializer = new SmartSerializer();
     }

--- a/tests/Elasticsearch/Tests/YamlRunnerTest.php
+++ b/tests/Elasticsearch/Tests/YamlRunnerTest.php
@@ -152,7 +152,7 @@ class YamlRunnerTest extends \PHPUnit\Framework\TestCase
         echo "ES Version: ".static::$esVersion."\n";
     }
 
-    public function setUp()
+    protected function setUp()
     {
         $this->client = Elasticsearch\ClientBuilder::create()
             ->setHosts([self::getHost()]);
@@ -162,7 +162,7 @@ class YamlRunnerTest extends \PHPUnit\Framework\TestCase
         $this->client = $this->client->build();
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         $this->clean();
     }


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to replace `assertEquals` to make assertion equals strict.
- According to the [PHPUnit fixtures reference](https://phpunit.readthedocs.io/en/8.5/fixtures.html#more-setup-than-teardown), it should be the `protected function setUp` and `protected function tearDown` methods.

BTW, I've CLA sigined via this [site](https://www.elastic.co/contributor-agreement), but the CLA checking service still say I don't do CLA sign.

I think this checking service will not recheck the latest CLA sign...