### PR TITLE
Fix for #1064 reset custom headers

### DIFF
--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -200,8 +200,9 @@ class Connection implements ConnectionInterface
             $body = $this->serializer->serialize($body);
         }
 
+        $headers = $this->headers;
         if (isset($options['client']['headers']) && is_array($options['client']['headers'])) {
-            $this->headers = array_merge($this->headers, $options['client']['headers']);
+            $headers = array_merge($this->headers, $options['client']['headers']);
         }
 
         $host = $this->host;
@@ -218,7 +219,7 @@ class Connection implements ConnectionInterface
                 [
                 'Host'  => [$host]
                 ],
-                $this->headers
+                $headers
             )
         ];
 

--- a/tests/Elasticsearch/Tests/Connections/ConnectionTest.php
+++ b/tests/Elasticsearch/Tests/Connections/ConnectionTest.php
@@ -334,4 +334,33 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(ServerErrorResponseException::class, $result);
         $this->assertContains('master_not_discovered_exception', $result->getMessage());
     }
+
+    public function testHeaderClientParamIsResetAfterSent()
+    {
+        $host = [
+            'host' => 'localhost'
+        ];
+
+        $connection = new Connection(
+            ClientBuilder::defaultHandler(),
+            $host,
+            [],
+            new SmartSerializer(),
+            $this->logger,
+            $this->trace
+        );
+        
+        $options = [
+            'client' => [
+                'headers' => [
+                    'Foo' => [ 'Bar' ]
+                ]
+            ]
+        ];
+        
+        $headersBefore = $connection->getHeaders();
+        $result = $connection->performRequest('GET', '/', null, null, $options);
+        $headersAfter = $connection->getHeaders();
+        $this->assertEquals($headersBefore, $headersAfter);
+    }
 }


### PR DESCRIPTION
This PR fixes #1064 resetting the custom headers, passed as parameters, after an endpoint call.