### PR TITLE
Fix #1058 using object instead of array in onFailure event

### DIFF
--- a/src/Elasticsearch/Transport.php
+++ b/src/Elasticsearch/Transport.php
@@ -93,7 +93,7 @@ class Transport
      *
      * @throws Common\Exceptions\NoNodesAvailableException|\Exception
      */
-    public function performRequest(string $method, string $uri, array $params = null, $body = null, array $options = []): FutureArrayInterface
+    public function performRequest(string $method, string $uri, array $params = [], $body = null, array $options = []): FutureArrayInterface
     {
         try {
             $connection  = $this->getConnection();
@@ -114,7 +114,7 @@ class Transport
             $options,
             $this
         );
-
+        
         $future->promise()->then(
             //onSuccess
             function ($response) {
@@ -123,8 +123,9 @@ class Transport
             },
             //onFailure
             function ($response) {
+                $code = $response->getCode();
                 // Ignore 400 level errors, as that means the server responded just fine
-                if (!(isset($response['code']) && $response['code'] >=400 && $response['code'] < 500)) {
+                if ($code < 400 || $code >= 500) {
                     // Otherwise schedule a check
                     $this->connectionPool->scheduleCheck();
                 }

--- a/tests/Elasticsearch/Tests/TransportTest.php
+++ b/tests/Elasticsearch/Tests/TransportTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Elasticsearch PHP client
+ *
+ * @link      https://github.com/elastic/elasticsearch-php/
+ * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
+ * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
+ *
+ * Licensed to Elasticsearch B.V under one or more agreements.
+ * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
+ * the GNU Lesser General Public License, Version 2.1, at your option.
+ * See the LICENSE file in the project root for more information.
+ */
+
+
+declare(strict_types = 1);
+
+namespace Elasticsearch\Tests;
+
+use Elasticsearch\Common\Exceptions\ServerErrorResponseException;
+use Elasticsearch\ConnectionPool\AbstractConnectionPool;
+use Elasticsearch\Connections\Connection;
+use Elasticsearch\Serializers\SerializerInterface;
+use Elasticsearch\Transport;
+use GuzzleHttp\Ring\Future\FutureArray;
+use GuzzleHttp\Ring\Future\FutureArrayInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use React\Promise\Deferred;
+use React\Promise\Promise;
+
+class TransportTest extends TestCase
+{
+    public function setUp(): void
+    {
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->trace = $this->createMock(LoggerInterface::class);
+        $this->serializer = $this->createMock(SerializerInterface::class);
+        $this->connectionPool = $this->createMock(AbstractConnectionPool::class);
+        $this->connection = $this->createMock(Connection::class);
+    }
+
+    public function testPerformRequestWithServerErrorResponseException404Result()
+    {
+        $deferred = new Deferred();
+        $deferred->reject(new ServerErrorResponseException('foo', 404));
+        $future = new FutureArray($deferred->promise());
+
+        $this->connection->method('performRequest')
+            ->willReturn($future);
+        
+        $this->connectionPool->method('nextConnection')
+            ->willReturn($this->connection);
+
+        $this->connectionPool->expects($this->never())
+            ->method('scheduleCheck');
+
+        $transport = new Transport(1, $this->connectionPool, $this->logger);
+
+        $result = $transport->performRequest('GET', '/');
+        $this->assertInstanceOf(FutureArrayInterface::class, $result);
+    }
+
+    public function testPerformRequestWithServerErrorResponseException500Result()
+    {
+        $deferred = new Deferred();
+        $deferred->reject(new ServerErrorResponseException('foo', 500));
+        $future = new FutureArray($deferred->promise());
+
+        $this->connection->method('performRequest')
+            ->willReturn($future);
+        
+        $this->connectionPool->method('nextConnection')
+            ->willReturn($this->connection);
+
+        $this->connectionPool->expects($this->once())
+            ->method('scheduleCheck');
+
+        $transport = new Transport(1, $this->connectionPool, $this->logger);
+
+        $result = $transport->performRequest('GET', '/');
+        $this->assertInstanceOf(FutureArrayInterface::class, $result);
+    }
+}


### PR DESCRIPTION
This PR fixes #1058 using response object instead of array in `onFailure` promise of `Elasticsearch\Transport`. 
I also added a unit test to cover the issue.