### PR TITLE
Remove unnecessary InvalidArgumentExceptions

### DIFF
--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -305,10 +305,6 @@ class ClientBuilder
 
     public function setLogger(LoggerInterface $logger): ClientBuilder
     {
-        if (!$logger instanceof LoggerInterface) {
-            throw new InvalidArgumentException('$logger must implement \Psr\Log\LoggerInterface!');
-        }
-
         $this->logger = $logger;
 
         return $this;
@@ -316,10 +312,6 @@ class ClientBuilder
 
     public function setTracer(LoggerInterface $tracer): ClientBuilder
     {
-        if (!$tracer instanceof LoggerInterface) {
-            throw new InvalidArgumentException('$tracer must implement \Psr\Log\LoggerInterface!');
-        }
-
         $this->tracer = $tracer;
 
         return $this;


### PR DESCRIPTION
There are some locations where an object is type hinted and inside the method a check is performed to verify the type again. This is not necessary as PHP will take care of this. A consequence of this is that these methods no longer throw an instance of `\Elasticsearch\Common\Exceptions\InvalidArgumentException` but of `\InvalidArgumentException`. As theres no PHPDoc indicating that the aforementioned exception is thrown by these methods I don't see any issues with this.

I've been working with this library for a little while now and I notice discrepancies in type hints and docblocks. All of the public methods in `\Elasticsearch\Client` can throw exceptions, but this is not reflected in the docblocks. I did not want to make a large pull request with a lot of changes as it is an unsolicited pull request. Would you be interested in some pull requests to try and straighten that?