### PR TITLE
Replaced array_walk with array_map in Connection::getURI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,6 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-version }}
-        tools: prestissimo
       env:
         COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ util/output/
 
 # PHPUnit
 /phpunit.xml
+.phpunit.result.cache
 
 # Code coverage
 build

--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -137,6 +137,11 @@ class ClientBuilder
     /**
      * @var bool
      */
+    private $elasticMetaHeader = true;
+
+    /**
+     * @var bool
+     */
     private $includePortInHostHeader = false;
 
     public static function create(): ClientBuilder
@@ -481,6 +486,16 @@ class ClientBuilder
     }
 
     /**
+     * Set or disable the x-elastic-client-meta header
+     */
+    public function setElasticMetaHeader($value = true): ClientBuilder
+    {
+        $this->elasticMetaHeader = $value;
+
+        return $this;
+    }
+
+    /**
      * Include the port in Host header
      *
      * @see https://github.com/elastic/elasticsearch-php/issues/993
@@ -532,6 +547,7 @@ class ClientBuilder
             $this->serializer = new $this->serializer;
         }
 
+        $this->connectionParams['client']['x-elastic-client-meta']= $this->elasticMetaHeader;
         $this->connectionParams['client']['port_in_header'] = $this->includePortInHostHeader;
 
         if (is_null($this->connectionFactory)) {

--- a/tests/Elasticsearch/Tests/ClientBuilderTest.php
+++ b/tests/Elasticsearch/Tests/ClientBuilderTest.php
@@ -227,9 +227,6 @@ class ClientBuilderTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException Elasticsearch\Common\Exceptions\RuntimeException
-     */
     public function testFromConfigQuiteFalseWithUnknownKey()
     {
         $this->expectException(RuntimeException::class);
@@ -240,5 +237,63 @@ class ClientBuilderTest extends TestCase
             ],
             false
         );
+    }
+
+    public function testElasticClientMetaHeaderIsSentByDefault()
+    {
+        $client = ClientBuilder::create()
+            ->build();
+        $this->assertInstanceOf(Client::class, $client);
+
+        try {
+            $result = $client->info();
+        } catch (ElasticsearchException $e) {
+            $request = $client->transport->getLastConnection()->getLastRequestInfo();
+            $this->assertTrue(isset($request['request']['headers']['x-elastic-client-meta']));
+            $this->assertEquals(
+                1,
+                preg_match(
+                    '/^[a-z]{1,}=[a-z0-9\.\-]{1,}(?:,[a-z]{1,}=[a-z0-9\.\-]+)*$/', 
+                    $request['request']['headers']['x-elastic-client-meta'][0]
+                )
+            );
+        }    
+    }
+
+    public function testElasticClientMetaHeaderIsSentWhenEnabled()
+    {
+        $client = ClientBuilder::create()
+            ->setElasticMetaHeader(true)
+            ->build();
+        $this->assertInstanceOf(Client::class, $client);
+
+        try {
+            $result = $client->info();
+        } catch (ElasticsearchException $e) {
+            $request = $client->transport->getLastConnection()->getLastRequestInfo();
+            $this->assertTrue(isset($request['request']['headers']['x-elastic-client-meta']));
+            $this->assertEquals(
+                1,
+                preg_match(
+                    '/^[a-z]{1,}=[a-z0-9\.\-]{1,}(?:,[a-z]{1,}=[a-z0-9\.\-]+)*$/', 
+                    $request['request']['headers']['x-elastic-client-meta'][0]
+                )
+            );
+        }    
+    }
+
+    public function testElasticClientMetaHeaderIsNotSentWhenDisabled()
+    {
+        $client = ClientBuilder::create()
+            ->setElasticMetaHeader(false)
+            ->build();
+        $this->assertInstanceOf(Client::class, $client);
+
+        try {
+            $result = $client->info();
+        } catch (ElasticsearchException $e) {
+            $request = $client->transport->getLastConnection()->getLastRequestInfo();
+            $this->assertFalse(isset($request['request']['headers']['x-elastic-client-meta']));
+        }    
     }
 }

--- a/tests/Elasticsearch/Tests/Connections/ConnectionTest.php
+++ b/tests/Elasticsearch/Tests/Connections/ConnectionTest.php
@@ -363,4 +363,67 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
         $headersAfter = $connection->getHeaders();
         $this->assertEquals($headersBefore, $headersAfter);
     }
+
+    /**
+     * Test if the x-elastic-client-meta header is sent if $params['client']['x-elastic-client-meta'] is true  
+     */
+    public function testElasticMetaClientHeaderIsSentWhenParameterIsTrue()
+    {
+        $params = [
+            'client' => [
+                'x-elastic-client-meta'=> true
+            ]
+        ];
+        $host = [
+            'host' => 'localhost'
+        ];
+
+        $connection = new Connection(
+            ClientBuilder::defaultHandler(),
+            $host,
+            $params,
+            $this->serializer,
+            $this->logger,
+            $this->trace
+        );
+        $result  = $connection->performRequest('GET', '/');
+        $request = $connection->getLastRequestInfo()['request'];
+
+        $this->assertArrayHasKey('x-elastic-client-meta', $request['headers']);
+        $this->assertEquals(
+            1,
+            preg_match(
+                '/^[a-z]{1,}=[a-z0-9\.\-]{1,}(?:,[a-z]{1,}=[a-z0-9\.\-]+)*$/', 
+                $request['headers']['x-elastic-client-meta'][0]
+            )
+        );
+    }
+
+    /**
+     * Test if the x-elastic-client-meta header is sent if $params['client']['x-elastic-client-meta'] is true  
+     */
+    public function testElasticMetaClientHeaderIsNotSentWhenParameterIsFalse()
+    {
+        $params = [
+            'client' => [
+                'x-elastic-client-meta'=> false
+            ]
+        ];
+        $host = [
+            'host' => 'localhost'
+        ];
+
+        $connection = new Connection(
+            ClientBuilder::defaultHandler(),
+            $host,
+            $params,
+            $this->serializer,
+            $this->logger,
+            $this->trace
+        );
+        $result  = $connection->performRequest('GET', '/');
+        $request = $connection->getLastRequestInfo()['request'];
+
+        $this->assertArrayNotHasKey('x-elastic-client-meta', $request['headers']);
+    }
 }


### PR DESCRIPTION
In Connection::getURI, array_walk was used together with passing the values as references, to change the original array.
Passing values as references is error-prone and discouraged for quite some time.
Also, when using in conjunction with PHP 8.0, it will fail.

array_map can do the same thing as the original array_walk implementation, but without the downsides of having side effects and having to pass values as references.
