### PR TITLE
Remove superfluous @throws annotations

### DIFF
--- a/src/Elasticsearch/Namespaces/BooleanRequestWrapper.php
+++ b/src/Elasticsearch/Namespaces/BooleanRequestWrapper.php
@@ -23,9 +23,6 @@ trait BooleanRequestWrapper
      *
      * @param  AbstractEndpoint $endpoint The Endpoint to perform this request against
      *
-     * @throws Missing404Exception
-     * @throws RoutingMissingException
-     *
      * @return array|bool|callable
      */
     public static function performRequest(AbstractEndpoint $endpoint)


### PR DESCRIPTION
As the method catches these exceptions and returns false in this case, those annotations are wrong because those exceptions are never thrown from this method.

Since I'm not sure what your merge strategy is between version branches, I just picked the oldest version I could find the code in.