### PR TITLE
Add the x-elastic-client-meta header

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,6 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-version }}
-        tools: prestissimo
       env:
         COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ util/output/
 
 # PHPUnit
 /phpunit.xml
+.phpunit.result.cache
 
 # Code coverage
 build

--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -137,6 +137,11 @@ class ClientBuilder
     /**
      * @var bool
      */
+    private $elasticMetaHeader = true;
+
+    /**
+     * @var bool
+     */
     private $includePortInHostHeader = false;
 
     public static function create(): ClientBuilder
@@ -481,6 +486,16 @@ class ClientBuilder
     }
 
     /**
+     * Set or disable the x-elastic-client-meta header
+     */
+    public function setElasticMetaHeader($value = true): ClientBuilder
+    {
+        $this->elasticMetaHeader = $value;
+
+        return $this;
+    }
+
+    /**
      * Include the port in Host header
      *
      * @see https://github.com/elastic/elasticsearch-php/issues/993
@@ -532,6 +547,7 @@ class ClientBuilder
             $this->serializer = new $this->serializer;
         }
 
+        $this->connectionParams['client']['x-elastic-client-meta']= $this->elasticMetaHeader;
         $this->connectionParams['client']['port_in_header'] = $this->includePortInHostHeader;
 
         if (is_null($this->connectionFactory)) {

--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -585,9 +585,10 @@ class Connection implements ConnectionInterface
     private function getElasticMetaHeader(array $connectionParams): string
     {
         $clientMeta = sprintf(
-            "es=%s,php=%s,a=%d",
+            "es=%s,php=%s,t=%s,a=%d",
             Client::VERSION,
             phpversion(),
+            Client::VERSION,
             isset($connectionParams['client']['future']) && $connectionParams['client']['future'] === 'lazy' ? 1 : 0
         );
         if (function_exists('curl_version')) {

--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -584,10 +584,11 @@ class Connection implements ConnectionInterface
      */
     private function getElasticMetaHeader(array $connectionParams): string
     {
+        $phpSemVersion = sprintf("%d.%d.%d", PHP_MAJOR_VERSION, PHP_MINOR_VERSION, PHP_RELEASE_VERSION);
         $clientMeta = sprintf(
             "es=%s,php=%s,t=%s,a=%d",
             Client::VERSION,
-            phpversion(),
+            $phpSemVersion,
             Client::VERSION,
             isset($connectionParams['client']['future']) && $connectionParams['client']['future'] === 'lazy' ? 1 : 0
         );

--- a/tests/Elasticsearch/Tests/ClientBuilderTest.php
+++ b/tests/Elasticsearch/Tests/ClientBuilderTest.php
@@ -227,9 +227,6 @@ class ClientBuilderTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException Elasticsearch\Common\Exceptions\RuntimeException
-     */
     public function testFromConfigQuiteFalseWithUnknownKey()
     {
         $this->expectException(RuntimeException::class);

--- a/tests/Elasticsearch/Tests/ClientBuilderTest.php
+++ b/tests/Elasticsearch/Tests/ClientBuilderTest.php
@@ -241,4 +241,62 @@ class ClientBuilderTest extends TestCase
             false
         );
     }
+
+    public function testElasticClientMetaHeaderIsSentByDefault()
+    {
+        $client = ClientBuilder::create()
+            ->build();
+        $this->assertInstanceOf(Client::class, $client);
+
+        try {
+            $result = $client->info();
+        } catch (ElasticsearchException $e) {
+            $request = $client->transport->getLastConnection()->getLastRequestInfo();
+            $this->assertTrue(isset($request['request']['headers']['x-elastic-client-meta']));
+            $this->assertEquals(
+                1,
+                preg_match(
+                    '/^[a-z]{1,}=[a-z0-9\.\-]{1,}(?:,[a-z]{1,}=[a-z0-9\.\-]+)*$/', 
+                    $request['request']['headers']['x-elastic-client-meta'][0]
+                )
+            );
+        }    
+    }
+
+    public function testElasticClientMetaHeaderIsSentWhenEnabled()
+    {
+        $client = ClientBuilder::create()
+            ->setElasticMetaHeader(true)
+            ->build();
+        $this->assertInstanceOf(Client::class, $client);
+
+        try {
+            $result = $client->info();
+        } catch (ElasticsearchException $e) {
+            $request = $client->transport->getLastConnection()->getLastRequestInfo();
+            $this->assertTrue(isset($request['request']['headers']['x-elastic-client-meta']));
+            $this->assertEquals(
+                1,
+                preg_match(
+                    '/^[a-z]{1,}=[a-z0-9\.\-]{1,}(?:,[a-z]{1,}=[a-z0-9\.\-]+)*$/', 
+                    $request['request']['headers']['x-elastic-client-meta'][0]
+                )
+            );
+        }    
+    }
+
+    public function testElasticClientMetaHeaderIsNotSentWhenDisabled()
+    {
+        $client = ClientBuilder::create()
+            ->setElasticMetaHeader(false)
+            ->build();
+        $this->assertInstanceOf(Client::class, $client);
+
+        try {
+            $result = $client->info();
+        } catch (ElasticsearchException $e) {
+            $request = $client->transport->getLastConnection()->getLastRequestInfo();
+            $this->assertFalse(isset($request['request']['headers']['x-elastic-client-meta']));
+        }    
+    }
 }

--- a/tests/Elasticsearch/Tests/Connections/ConnectionTest.php
+++ b/tests/Elasticsearch/Tests/Connections/ConnectionTest.php
@@ -363,4 +363,67 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
         $headersAfter = $connection->getHeaders();
         $this->assertEquals($headersBefore, $headersAfter);
     }
+
+    /**
+     * Test if the x-elastic-client-meta header is sent if $params['client']['x-elastic-client-meta'] is true  
+     */
+    public function testElasticMetaClientHeaderIsSentWhenParameterIsTrue()
+    {
+        $params = [
+            'client' => [
+                'x-elastic-client-meta'=> true
+            ]
+        ];
+        $host = [
+            'host' => 'localhost'
+        ];
+
+        $connection = new Connection(
+            ClientBuilder::defaultHandler(),
+            $host,
+            $params,
+            $this->serializer,
+            $this->logger,
+            $this->trace
+        );
+        $result  = $connection->performRequest('GET', '/');
+        $request = $connection->getLastRequestInfo()['request'];
+
+        $this->assertArrayHasKey('x-elastic-client-meta', $request['headers']);
+        $this->assertEquals(
+            1,
+            preg_match(
+                '/^[a-z]{1,}=[a-z0-9\.\-]{1,}(?:,[a-z]{1,}=[a-z0-9\.\-]+)*$/', 
+                $request['headers']['x-elastic-client-meta'][0]
+            )
+        );
+    }
+
+    /**
+     * Test if the x-elastic-client-meta header is sent if $params['client']['x-elastic-client-meta'] is true  
+     */
+    public function testElasticMetaClientHeaderIsNotSentWhenParameterIsFalse()
+    {
+        $params = [
+            'client' => [
+                'x-elastic-client-meta'=> false
+            ]
+        ];
+        $host = [
+            'host' => 'localhost'
+        ];
+
+        $connection = new Connection(
+            ClientBuilder::defaultHandler(),
+            $host,
+            $params,
+            $this->serializer,
+            $this->logger,
+            $this->trace
+        );
+        $result  = $connection->performRequest('GET', '/');
+        $request = $connection->getLastRequestInfo()['request'];
+
+        $this->assertArrayNotHasKey('x-elastic-client-meta', $request['headers']);
+    }
 }


### PR DESCRIPTION
This PR adds a `x-elastic-client-meta` header in the HTTP request to send version information about the PHP language, the client library, the cURL version, the usage of async, etc.
An example of `x-elastic-client-meta` is as follows:
```
x-elastic-client-meta: es=7.10.0,php=7.4.11,a=0,c=7.68.0
```
where `es` is Elasticsearch version, `php`is PHP version, `a=0` means the HTTP call was sync (1=async), `c` is the cURL version.

This header can be disabled using the function `ClientBuilder::setElasticMetaHeader(false)`, as follows:
```php
$client = ClientBuilder::create()
    ->setElasticMetaHeader(false)  // default is true
    ->build();
```