### PR TITLE
Removed unused variable

### DIFF
--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -342,7 +342,7 @@ class Connection implements ConnectionInterface
         if (isset($params) === true && !empty($params)) {
             array_walk(
                 $params,
-                function (&$value, &$key) {
+                function (&$value) {
                     if ($value === true) {
                         $value = 'true';
                     } elseif ($value === false) {


### PR DESCRIPTION
Fixies warning in PHP 8.0:
```
Warning
Elasticsearch\Connections\Connection::Elasticsearch\Connections\{closure}(): Argument #2 ($key) must be passed by reference, value given
```