### PR TITLE
Fix array_walk() call on PHP 8

### DIFF
--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -327,7 +327,7 @@ class Connection implements ConnectionInterface
     private function getURI($uri, $params)
     {
         if (isset($params) === true && !empty($params)) {
-            array_walk($params, function (&$value, &$key) {
+            array_walk($params, function (&$value) {
                 if ($value === true) {
                     $value = 'true';
                 } elseif ($value === false) {


### PR DESCRIPTION
Running version 6.7 of this library on PHP 8 will result in a warning being triggered:

```
Argument #2 ($key) must be passed by reference, value given
```

The fix is fairly trivial because the affected variable is not used and can be removed.

This issue has already been reported as #1085 fixed on higher branches. However the project I'm working with at the moment is currently unable to upgrade to Elasticsearch 7. And as far as I can tell, this issue seems to be our only blocker for upgrading to PHP 8.

If the 6.7.x branch is closed for bugfixes, please close this PR.