### PR TITLE
Fix StickyRoundRobinSelector

### DIFF
--- a/src/Elasticsearch/ConnectionPool/Selectors/StickyRoundRobinSelector.php
+++ b/src/Elasticsearch/ConnectionPool/Selectors/StickyRoundRobinSelector.php
@@ -36,13 +36,12 @@ class StickyRoundRobinSelector implements SelectorInterface
      * Use current connection unless it is dead, otherwise round-robin
      *
      * @param ConnectionInterface[] $connections Array of connections to choose from
+     *
+     * @return \Elasticsearch\Connections\ConnectionInterface
      */
     public function select(array $connections): ConnectionInterface
     {
-        /**
- * @var ConnectionInterface[] $connections
-*/
-        if ($connections[$this->current]->isAlive()) {
+        if (array_key_exists($this->current, $connections) && $connections[$this->current]->isAlive()) {
             return $connections[$this->current];
         }
 

--- a/tests/Elasticsearch/Tests/ConnectionPool/Selectors/StickyRoundRobinSelectorTest.php
+++ b/tests/Elasticsearch/Tests/ConnectionPool/Selectors/StickyRoundRobinSelectorTest.php
@@ -29,7 +29,7 @@ use Mockery as m;
  */
 class StickyRoundRobinSelectorTest extends \PHPUnit\Framework\TestCase
 {
-    public function tearDown(): void
+    public function tearDown()
     {
         m::close();
     }
@@ -73,5 +73,40 @@ class StickyRoundRobinSelectorTest extends \PHPUnit\Framework\TestCase
 
             $this->assertSame($mockConnections[1], $retConnection);
         }
+    }
+
+    public function testConnectionDroppedBySniffingPool()
+    {
+        $roundRobin = new Elasticsearch\ConnectionPool\Selectors\StickyRoundRobinSelector();
+
+        $mockConnections = [];
+        foreach (range(0, 3) as $index) {
+            $mockConnections[] = m::mock(ConnectionInterface::class)
+                ->shouldReceive('isAlive')->once()->andReturn(false)->getMock();
+        }
+
+        $mockConnections[] = m::mock(ConnectionInterface::class)
+            ->shouldReceive('isAlive')->once()->andReturn(true)->getMock();
+
+        // check we're getting the next one each time
+        foreach (range(0, 3) as $index) {
+            $retConnection = $roundRobin->select($mockConnections);
+            $this->assertSame($mockConnections[$index + 1], $retConnection);
+        }
+
+        // current is 4 now inside the StickyRoundRobinSelector();
+        $retConnection = $roundRobin->select($mockConnections);
+        $this->assertSame($mockConnections[4], $retConnection);
+
+        // now we are going to simulate 1 server dropped out, and thus only 4 connections are giving back, which
+        // resulted in Undefined offset: 4 in Elasticsearch/ConnectionPool/Selectors/StickyRoundRobinSelector.php:45
+        $mockConnections = [];
+        foreach (range(0, 3) as $index) {
+            $mockConnections[] = m::mock(ConnectionInterface::class);
+        }
+
+        // instead of index 4 we should retrieve index 1 (5 % 4 = 1)
+        $retConnection = $roundRobin->select($mockConnections);
+        $this->assertSame($mockConnections[1], $retConnection);
     }
 }

--- a/tests/Elasticsearch/Tests/ConnectionPool/Selectors/StickyRoundRobinSelectorTest.php
+++ b/tests/Elasticsearch/Tests/ConnectionPool/Selectors/StickyRoundRobinSelectorTest.php
@@ -29,7 +29,7 @@ use Mockery as m;
  */
 class StickyRoundRobinSelectorTest extends \PHPUnit\Framework\TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }


### PR DESCRIPTION
When using a `SniffingConnectionPool` is can happen that a connection drops, having the current position inside the `StickyRoundRobinSelector` point to an unexisting connection at that moment, which results in an PHP Notice: undefined offset.

I have added an additional check if the offset exists before checking if the connection is alive, so it continues selecting the next node.

