### PR TITLE
[7.x][DOCS] Adds discrete attributes to section titles

### DIFF
--- a/docs/breaking-changes.asciidoc
+++ b/docs/breaking-changes.asciidoc
@@ -1,7 +1,8 @@
 [[breaking_changes]]
 == Breaking changes from 6.x
 
-### E_USER_DEPRECATED notice when using deprecated parameters
+[discrete]
+=== E_USER_DEPRECATED notice when using deprecated parameters
 
 Starting from elasticsearch-php 7.4.0, we generate a PHP 
 https://www.php.net/manual/en/errorfunc.constants.php[E_USER_DEPRECATED] notice 
@@ -23,22 +24,22 @@ set_error_handler(function ($errno, $errstr) {
 @trigger_error('Deprecation message here', E_USER_DEPRECATED);
 ----
 
-
-### Moving from types to typeless APIs in {es} 7.0
+[discrete]
+=== Moving from types to typeless APIs in {es} 7.0
 
 {es} 7.0 deprecated APIs that accept types, introduced new typeless APIs, and 
 removed support for the _default_ mapping. Read 
 https://www.elastic.co/blog/moving-from-types-to-typeless-apis-in-elasticsearch-7-0[this]
 blog post for more information.
 
-
-### Type hint and return type
+[discrete]
+=== Type hint and return type
 
 Added type hints and return type declarations in all the code base where 
 possible. See PR https://github.com/elastic/elasticsearch-php/pull/897[#897].
 
-
-### PHP 7.1+ Requirement
+[discrete]
+=== PHP 7.1+ Requirement
 
 We require using PHP 7.1+ for elasticsearch-php. PHP 7.0 is not supported since
 1st Jan 2019. Refer 

--- a/docs/build/Elasticsearch/Client.asciidoc
+++ b/docs/build/Elasticsearch/Client.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_Client]]
 === Elasticsearch\Client
 

--- a/docs/build/Elasticsearch/ClientBuilder.asciidoc
+++ b/docs/build/Elasticsearch/ClientBuilder.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_ClientBuilder]]
 === Elasticsearch\ClientBuilder
 

--- a/docs/build/Elasticsearch/Namespaces/AsyncSearchNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/AsyncSearchNamespace.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_Namespaces_AsyncSearchNamespace]]
 === Elasticsearch\Namespaces\AsyncSearchNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/AutoscalingNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/AutoscalingNamespace.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_Namespaces_AutoscalingNamespace]]
 === Elasticsearch\Namespaces\AutoscalingNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/CatNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/CatNamespace.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_Namespaces_CatNamespace]]
 === Elasticsearch\Namespaces\CatNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/CcrNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/CcrNamespace.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_Namespaces_CcrNamespace]]
 === Elasticsearch\Namespaces\CcrNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/ClusterNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/ClusterNamespace.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_Namespaces_ClusterNamespace]]
 === Elasticsearch\Namespaces\ClusterNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/DanglingIndicesNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/DanglingIndicesNamespace.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_Namespaces_DanglingIndicesNamespace]]
 === Elasticsearch\Namespaces\DanglingIndicesNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/DataFrameTransformDeprecatedNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/DataFrameTransformDeprecatedNamespace.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_Namespaces_DataFrameTransformDeprecatedNamespace]]
 === Elasticsearch\Namespaces\DataFrameTransformDeprecatedNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/EnrichNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/EnrichNamespace.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_Namespaces_EnrichNamespace]]
 === Elasticsearch\Namespaces\EnrichNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/EqlNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/EqlNamespace.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_Namespaces_EqlNamespace]]
 === Elasticsearch\Namespaces\EqlNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/GraphNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/GraphNamespace.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_Namespaces_GraphNamespace]]
 === Elasticsearch\Namespaces\GraphNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/IlmNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/IlmNamespace.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_Namespaces_IlmNamespace]]
 === Elasticsearch\Namespaces\IlmNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/IndicesNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/IndicesNamespace.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_Namespaces_IndicesNamespace]]
 === Elasticsearch\Namespaces\IndicesNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/IngestNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/IngestNamespace.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_Namespaces_IngestNamespace]]
 === Elasticsearch\Namespaces\IngestNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/LicenseNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/LicenseNamespace.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_Namespaces_LicenseNamespace]]
 === Elasticsearch\Namespaces\LicenseNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/MigrationNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/MigrationNamespace.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_Namespaces_MigrationNamespace]]
 === Elasticsearch\Namespaces\MigrationNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/MlNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/MlNamespace.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_Namespaces_MlNamespace]]
 === Elasticsearch\Namespaces\MlNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/MonitoringNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/MonitoringNamespace.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_Namespaces_MonitoringNamespace]]
 === Elasticsearch\Namespaces\MonitoringNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/NodesNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/NodesNamespace.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_Namespaces_NodesNamespace]]
 === Elasticsearch\Namespaces\NodesNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/RollupNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/RollupNamespace.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_Namespaces_RollupNamespace]]
 === Elasticsearch\Namespaces\RollupNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/SearchableSnapshotsNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/SearchableSnapshotsNamespace.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_Namespaces_SearchableSnapshotsNamespace]]
 === Elasticsearch\Namespaces\SearchableSnapshotsNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/SecurityNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/SecurityNamespace.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_Namespaces_SecurityNamespace]]
 === Elasticsearch\Namespaces\SecurityNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/SlmNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/SlmNamespace.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_Namespaces_SlmNamespace]]
 === Elasticsearch\Namespaces\SlmNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/SnapshotNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/SnapshotNamespace.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_Namespaces_SnapshotNamespace]]
 === Elasticsearch\Namespaces\SnapshotNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/SqlNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/SqlNamespace.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_Namespaces_SqlNamespace]]
 === Elasticsearch\Namespaces\SqlNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/SslNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/SslNamespace.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_Namespaces_SslNamespace]]
 === Elasticsearch\Namespaces\SslNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/TasksNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/TasksNamespace.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_Namespaces_TasksNamespace]]
 === Elasticsearch\Namespaces\TasksNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/TransformNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/TransformNamespace.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_Namespaces_TransformNamespace]]
 === Elasticsearch\Namespaces\TransformNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/WatcherNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/WatcherNamespace.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_Namespaces_WatcherNamespace]]
 === Elasticsearch\Namespaces\WatcherNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/XpackNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/XpackNamespace.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_Namespaces_XpackNamespace]]
 === Elasticsearch\Namespaces\XpackNamespace
 

--- a/docs/community.asciidoc
+++ b/docs/community.asciidoc
@@ -1,6 +1,7 @@
 [[community_dsls]]
 == Community DSLs
 
+[discrete]
 === ElasticsearchDSL
 
 https://github.com/ongr-io/ElasticsearchDSL[Link: ElasticsearchDSL]
@@ -12,6 +13,7 @@ it to an array.
 __________________________
 
 
+[discrete]
 === elasticsearcher
 
 https://github.com/madewithlove/elasticsearcher[Link: elasticsearcher]
@@ -25,6 +27,7 @@ client.
 __________________________
 
 
+[discrete]
 === ElasticSearchQueryDSL
 
 https://github.com/gskema/elasticsearch-query-dsl-php[Link: ElasticSearchQueryDSL]
@@ -39,8 +42,10 @@ __________________________
 
 == Community Integrations
 
+[discrete]
 === Symfony
 
+[discrete]
 ==== ONGR Elasticsearch Bundle
 
 https://github.com/ongr-io/ElasticsearchBundle[Link: ONGR {es} Bundle]
@@ -66,7 +71,7 @@ Technical goodies:
 - Designed in an extensible way for all your custom needs.
 __________________________
 
-
+[discrete]
 ==== FOS Elastica Bundle
 
 https://github.com/FriendsOfSymfony/FOSElasticaBundle[Link: FOS Elastica Bundle]
@@ -82,9 +87,10 @@ include:
 - Listeners for Doctrine events for automatic indexing.
 __________________________
 
-
+[discrete]
 === Drupal
 
+[discrete]
 ==== {es} Connector
 
 https://www.drupal.org/project/elasticsearch_connector[Link: {es} Connector]
@@ -95,8 +101,10 @@ __________________________
 Drupal.
 __________________________
 
+[discrete]
 === Laravel
 
+[discrete]
 ==== shift31/Laravel-Elasticsearch
 
 https://github.com/shift31/laravel-elasticsearch[Link: shift31/Laravel-Elasticsearch]
@@ -106,7 +114,7 @@ __________________________
 This is a Laravel (4+) Service Provider for the official {es} low-level client.
 __________________________
 
-
+[discrete]
 ==== cviebrock/Laravel-Elasticsearch
 
 https://github.com/cviebrock/laravel-elasticsearch[Link: cviebrock/Laravel-Elasticsearch]
@@ -116,7 +124,7 @@ __________________________
 An easy way to use the official {es} client in your Laravel applications.
 __________________________
 
-
+[discrete]
 ==== Plastic
 
 https://github.com/sleimanx2/plastic[Link: Plastic]
@@ -128,8 +136,10 @@ experience more enjoyable while using {es} by providing a fluent syntax for
 mapping, querying, and storing eloquent models.
 __________________________
 
+[discrete]
 === Helper
 
+[discrete]
 ==== Index Helper
 
 https://github.com/Nexucis/es-php-index-helper[Link: nexucis/es-php-index-helper]

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -9,7 +9,7 @@ Custom configuration is accomplished before the client is instantiated, through
 the ClientBuilder helper object. You can find all the configuration options and 
 check sample code that helps you replace the various components.
 
-
+[discrete]
 === Inline Host Configuration
 
 The most common configuration is telling the client about your cluster: the 
@@ -54,7 +54,7 @@ $clientBuilder->setHosts($hosts);           // Set the hosts
 $client = $clientBuilder->build();          // Build the client object
 ----
 
-
+[discrete]
 === Extended Host Configuration
 
 The client also supports an _extended_ host configuration syntax. The inline 
@@ -100,7 +100,7 @@ $client = ClientBuilder::create()           // Instantiate a new ClientBuilder
 Only the `host` parameter is required for each configured host. If not provided, 
 the default port is `9200`. The default scheme is `http`.
 
-
+[discrete]
 === Connect to Elastic Cloud
 
 If you want to connect to Elastic Cloud, you can use your Cloud ID and use basic 
@@ -126,13 +126,13 @@ $client = ClientBuilder::create()
 <1> Your Cloud ID provided by the Elastic Cloud platform
 <2> Your ApiKey pair as described <<authentication,here>>.
 
-
+[discrete]
 === Authorization and Encryption
 
 For details about HTTP Authorization and SSL encryption, see 
 <<authentication,Authorization and SSL>>.
 
-
+[discrete]
 === Set retries
 
 By default, the client will retry `n` times, where `n = number of nodes` in your 
@@ -202,7 +202,7 @@ try {
 }
 ----
 
-
+[discrete]
 [[enabling_logger]]
 === Enabling the Logger
 
@@ -249,7 +249,7 @@ $client = ClientBuilder::create()       // Instantiate a new ClientBuilder
             ->build();                  // Build the client object
 ----
 
-
+[discrete]
 === Configure the HTTP Handler
 
 Elasticsearch-PHP uses an interchangeable HTTP transport layer called 
@@ -289,7 +289,7 @@ with async future mode. You may consider using just the `singleHandler` if you
 know you will never need async capabilities, since it will save a small amount 
 of overhead by reducing indirection.
 
-
+[discrete]
 === Setting the Connection Pool
 
 The client maintains a pool of connections, with each connection representing a 
@@ -308,7 +308,7 @@ $client = ClientBuilder::create()
 For more details, please see the dedicated page on
 <<connection_pool,configuring connection pools>>.
 
-
+[discrete]
 === Setting the Connection Selector
 
 The connection pool manages the connections to your cluster, but the Selector is 
@@ -327,7 +327,7 @@ $client = ClientBuilder::create()
 For more details, please see the dedicated page on 
 <<selectors,configuring selectors>>.
 
-
+[discrete]
 === Setting the Serializer
 
 Requests are given to the client in the form of associative arrays, but {es} 
@@ -350,7 +350,7 @@ $client = ClientBuilder::create()
 For more details, please see the dedicated page on
 <<serializers,configuring serializers>>.
 
-
+[discrete]
 === Setting a custom ConnectionFactory
 
 The ConnectionFactory instantiates new Connection objects when requested by the 
@@ -408,7 +408,7 @@ As you can see, if you decide to inject your own ConnectionFactory, you take
 over the responsibility of wiring it correctly. The ConnectionFactory requires a 
 working HTTP handler, serializer, logger and tracer.
 
-
+[discrete]
 === Set the Endpoint closure
 
 The client uses an Endpoint closure to dispatch API requests to the correct 
@@ -447,7 +447,7 @@ Obviously, by doing this you take responsibility that all existing endpoints
 still function correctly. And you also assume the responsibility of correctly 
 wiring the Transport and Serializer into each endpoint.
 
-
+[discrete]
 === Building the client from a configuration hash
 
 To help ease automated building of the client, all configurations can be 

--- a/docs/connection-pool.asciidoc
+++ b/docs/connection-pool.asciidoc
@@ -26,7 +26,7 @@ be alive, so `NoNodesAvailableException` is returned.
 
 There are several connection pool implementations that you can choose from:
 
-
+[discrete]
 === staticNoPingConnectionPool (default)
 
 This connection pool maintains a static list of hosts which are assumed to be 
@@ -49,7 +49,7 @@ $client = ClientBuilder::create()
 
 Note that the implementation is specified via a namespace path to the class.
 
-
+[discrete]
 === staticConnectionPool
 
 Identical to the `StaticNoPingConnectionPool`, except it pings nodes before they 
@@ -68,7 +68,7 @@ $client = ClientBuilder::create()
 
 Note that the implementation is specified via a namespace path to the class.
 
-
+[discrete]
 === simpleConnectionPool
 
 The `SimpleConnectionPool` returns the next node as specified by the selector; 
@@ -89,7 +89,7 @@ $client = ClientBuilder::create()
 
 Note that the implementation is specified via a namespace path to the class.
 
-
+[discrete]
 === sniffingConnectionPool
 
 Unlike the two previous static connection pools, this one is dynamic. The user 
@@ -108,7 +108,7 @@ $client = ClientBuilder::create()
 
 Note that the implementation is specified via a namespace path to the class.
 
-
+[discrete]
 === Custom Connection Pool
 
 If you wish to implement your own custom Connection Pool, your class must 
@@ -202,7 +202,7 @@ $client = ClientBuilder::create()
             ->build();
 ----
 
-
+[discrete]
 === Which connection pool to choose? PHP and connection pooling
 
 At first glance, the `sniffingConnectionPool` implementation seems superior. For 

--- a/docs/crud.asciidoc
+++ b/docs/crud.asciidoc
@@ -11,7 +11,7 @@ Elasticsearch-PHP you create and pass associative arrays to the client for
 indexing. There are several methods of ingesting data into {es} which we cover 
 here.
 
-
+[discrete]
 === Single document indexing
 
 When indexing a document, you can either provide an ID or let {es} generate one 
@@ -66,7 +66,7 @@ $response = $client->index($params);
 ----
 {zwsp} +
 
-
+[discrete]
 === Bulk Indexing
 
 {es} also supports bulk indexing of documents. The bulk API expects JSON 
@@ -163,6 +163,7 @@ Updating a document allows you to either completely replace the contents of the
 existing document, or perform a partial update to just some fields (either 
 changing an existing field or adding new fields).
 
+[discrete]
 === Partial document update
 
 If you want to partially update a document (for example, change an existing 
@@ -187,7 +188,7 @@ $response = $client->update($params);
 ----
 {zwsp} +
 
-
+[discrete]
 === Scripted document update
 
 Sometimes you need to perform a scripted update, such as incrementing a counter 
@@ -211,7 +212,7 @@ $response = $client->update($params);
 ----
 {zwsp} +
 
-
+[discrete]
 === Upserts
 
 Upserts are "Update or Insert" operations. This means an upsert attempts to run 

--- a/docs/experimental-beta-apis.asciidoc
+++ b/docs/experimental-beta-apis.asciidoc
@@ -18,7 +18,7 @@ The {es} APIs are marked using the following convention:
 All the `experimental` and `beta` APIs are marked with a `@note` tag in the
 phpdoc section of the code.
 
-
+[discrete]
 === Experimental
 
 The experimental APIs included in the current version of `elasticsearch-php` 
@@ -68,7 +68,7 @@ $client = ClientBuilder::create()->build();
 $result = $client->getScriptLanguages();
 ----
 
-
+[discrete]
 === Beta
 
 There are no beta APIs in the current version of `elasticsearch-php`.

--- a/docs/futures.asciidoc
+++ b/docs/futures.asciidoc
@@ -21,6 +21,7 @@ simultaneously, which means the Elasticsearch-PHP client can more effectively
 utilize your full cluster.
 
 
+[discrete]
 === Using Future Mode
 
 Utilizing this feature is straightforward, but it does introduce more 
@@ -131,6 +132,7 @@ for ($i = 0; $i < 1000; $i++) {
 $futures[999]->wait();
 ----
 
+[discrete]
 === Changing batch size
 
 The default batch size is 100, meaning 100 requests queue up before the client 
@@ -188,6 +190,7 @@ $body = $future[499]['body'];
 ----
 
 
+[discrete]
 === Heterogeneous batches are OK
 
 It is possible to queue up heterogeneous batches of requests. For example, you 
@@ -245,6 +248,7 @@ $doc = $futures['getRequest']['_source'];
 ----
 
 
+[discrete]
 === Caveats to Future mode
 
 There are a few caveats to using future mode. The biggest is also the most 

--- a/docs/index-operations.asciidoc
+++ b/docs/index-operations.asciidoc
@@ -5,7 +5,7 @@ Index management operations allow you to manage the indices in your {es}
 cluster, such as creating, deleting and updating indices and their 
 mappings/settings.
 
-
+[discrete]
 === Create an index
 
 The index operations are all contained under a distinct namespace, separated 
@@ -60,7 +60,7 @@ $response = $client->indices()->create($params);
 ----
 {zwsp} +
 
-
+[discrete]
 === Create an index (advanced example)
 
 This is a more complicated example of creating an index, showing how to define 
@@ -138,7 +138,7 @@ char filters and analyzers.
 <3> `mappings` is another element nested inside of `settings`, and contains the 
 mappings for various types.
 
-
+[discrete]
 === Delete an index
 
 Deleting an index is very simple:
@@ -150,7 +150,7 @@ $response = $client->indices()->delete($params);
 ----
 {zwsp} +
 
-
+[discrete]
 === PUT Settings API
 
 The PUT Settings API allows you to modify any index setting that is dynamic:
@@ -171,7 +171,7 @@ $response = $client->indices()->putSettings($params);
 ----
 {zwsp} +
 
-
+[discrete]
 === GET Settings API
 
 The GET Settings API shows you the currently configured settings for one or more 
@@ -191,7 +191,7 @@ $response = $client->indices()->getSettings($params);
 ----
 {zwsp} +
 
-
+[discrete]
 === PUT Mappings API
 
 The PUT Mappings API allows you to modify or add to an existing index's mapping.
@@ -222,7 +222,7 @@ $client->indices()->putMapping($params);
 ----
 {zwsp} +
 
-
+[discrete]
 === GET Mappings API
 
 The GET Mappings API returns the mapping details about your indices. Depending 
@@ -245,7 +245,7 @@ $response = $client->indices()->getMapping($params);
 ----
 {zwsp} +
 
-
+[discrete]
 === Other APIs in the indices namespace
 
 There are a number of other APIs in the indices namespace that allow you to 

--- a/docs/installation.asciidoc
+++ b/docs/installation.asciidoc
@@ -23,6 +23,8 @@ alternate HTTP handler based on PHP streams. Performance _will_ suffer, as the
 libcurl extension is much faster.
 ====
 
+
+[discrete]
 === Version Matrix
 
 You need to match your version of {es} to the appropriate version of this 
@@ -42,6 +44,8 @@ use `dev-master` in your production code.
 | <= 0.90.*            | `0.4`
 |============================
 
+
+[discrete]
 === Composer Installation
 
 * Include elasticsearch-php in your `composer.json` file.  If you are starting a 

--- a/docs/per-request-configuration.asciidoc
+++ b/docs/per-request-configuration.asciidoc
@@ -5,7 +5,7 @@ There are several configurations that can be set on a per-request basis, rather
 than at a connection- or client-level. These are specified as part of the 
 request associative array.
 
-
+[discrete]
 === Request Identification
 
 You can enrich your requests against {es} with an identifier string, that allows 
@@ -34,7 +34,7 @@ $response = $client->get($params);
 <1> This populates the `X-Opaque-Id` header with the value 
 `app17@dc06.eu_user1234`.
 
-
+[discrete]
 === Ignoring exceptions
 
 The library attempts to throw exceptions for common problems. These exceptions 
@@ -93,7 +93,7 @@ could be decoded. In the second example, it was simply a string.
 Since the client has no way of knowing what the exception response will contain, 
 no attempts to decode it are taken.
 
-
+[discrete]
 === Providing custom query parameters
 
 Sometimes you need to provide custom query parameters, such as authentication 
@@ -122,7 +122,7 @@ $params = [
 $exists = $client->exists($params);
 ----
 
-
+[discrete]
 === Increasing the verbosity of responses
 
 By default, the client only returns the response body. If you require more 
@@ -249,6 +249,8 @@ Array
 )
 ----
 
+
+[discrete]
 === Curl Timeouts
 
 It is possible to configure per-request curl timeouts via the `timeout` and 
@@ -287,6 +289,7 @@ $response = $client->get($params);
 ----
 
 
+[discrete]
 === Enabling Future Mode
 
 The client supports asynchronous, batch processing of requests. This is enabled 
@@ -313,6 +316,7 @@ asynchronous execution functions, and how to work with the results, see the
 dedicated page on <<future_mode>>.
 
 
+[discrete]
 === SSL Encryption
 
 Normally, you specify SSL configurations when you create the client (see 

--- a/docs/php_json_objects.asciidoc
+++ b/docs/php_json_objects.asciidoc
@@ -6,6 +6,8 @@ objects, and how to specify them in PHP. In particular, problems are caused by
 empty objects and arrays of objects. This page shows you some common patterns
 used in {es} JSON API and how to convert that to a PHP representation.
 
+
+[discrete]
 === Empty Objects
 
 The {es} API uses empty JSON objects in several locations which can cause 
@@ -61,6 +63,8 @@ correctly output an empty object, instead of an empty array. This verbose
 solution is the only way to acomplish the goal in PHP... there is no "short"
 version of an empty object.
 
+
+[discrete]
 === Arrays of Objects
 
 Another common pattern in {es} DSL is an array of objects. For example, consider 
@@ -123,6 +127,8 @@ $params['body'] = [
 $results = $client->search($params);
 ----
 
+
+[discrete]
 === Arrays of empty objects
 
 Occasionally, you'll encounter DSL that requires both of the previous patterns. 

--- a/docs/search-operations.asciidoc
+++ b/docs/search-operations.asciidoc
@@ -8,7 +8,7 @@ The client gives you full access to every query and parameter exposed by the
 REST API, following the naming scheme as much as possible. Let's look at a few 
 examples so you can become familiar with the syntax.
 
-
+[discrete]
 === Match query
 
 Here is a standard curl for a match query:
@@ -126,7 +126,7 @@ $doc   = $results['hits']['hits'][0]['_source'];
 ----
 {zwsp} +
 
-
+[discrete]
 === Bool Queries
 
 Bool queries can be easily constructed using the client. For example, this 
@@ -180,7 +180,7 @@ into an array of JSON objects internally, so the final resulting output is
 identical to the curl example. For more details about arrays and objects in PHP,
 see <<php_json_objects, Dealing with JSON Arrays and Objects in PHP>>.
 
-
+[discrete]
 === A more complicated example
 
 Let's construct a slightly more complicated example: a boolean query that 
@@ -232,7 +232,7 @@ $results = $client->search($params);
 ----
 {zwsp} +
 
-
+[discrete]
 === Scrolling
 
 The scrolling functionality of {es} is used to paginate over many documents in a 

--- a/docs/selectors.asciidoc
+++ b/docs/selectors.asciidoc
@@ -10,6 +10,7 @@ connections. Like the connection pool, there are several implementations to
 choose from.
 
 
+[discrete]
 === RoundRobinSelector (Default)
 
 This selector returns connections in a round-robin fashion. Node #1 is selected 
@@ -29,7 +30,7 @@ $client = ClientBuilder::create()
 
 Note that the implementation is specified via a namespace path to the class.
 
-
+[discrete]
 === StickyRoundRobinSelector
 
 This selector is "sticky", so that it prefers to reuse the same connection 
@@ -64,7 +65,7 @@ $client = ClientBuilder::create()
 
 Note that the implementation is specified via a namespace path to the class.
 
-
+[discrete]
 === RandomSelector
 
 This selector returns a random node, regardless of state. It is generally just 
@@ -81,7 +82,7 @@ $client = ClientBuilder::create()
 
 Note that the implementation is specified via a namespace path to the class.
 
-
+[discrete]
 === Custom Selector
 
 You can implement your own custom selector. Custom selectors must implement 

--- a/docs/serializers.asciidoc
+++ b/docs/serializers.asciidoc
@@ -11,9 +11,10 @@ JSON.
 
 The default serializer is the `SmartSerializer`.
 
-
+[discrete]
 === SmartSerializer
 
+[discrete]
 ==== Serialize()
 
 The `SmartSerializer` inspects the data to be encoded. If the request body is 
@@ -26,6 +27,7 @@ empty array, the serializer manually converts the JSON from an empty array
 (`[]`) to an empty object (`{}`) so that it is valid JSON for {es} request 
 bodies.
 
+[discrete]
 ==== Deserialize()
 
 When decoding the response body, the `SmartSerializer` introspects the 
@@ -36,7 +38,7 @@ is returned as a string.
 This functionality is required to cooperate with endpoints such as the `Cat` 
 endpoints, which return tabular text instead of JSON.
 
-
+[discrete]
 ==== Selecting the SmartSerializer
 
 The `SmartSerializer` is selected by default, but if you wish to manually 
@@ -53,9 +55,10 @@ $client = ClientBuilder::create()
 Note that the serializer is configured by specifying a namespace path to the 
 serializer.
 
-
+[discrete]
 === ArrayToJSONSerializer
 
+[discrete]
 ==== Serialize()
 
 The `ArrayToJSONSerializer` inspects the data to be encoded. If the request body
@@ -68,13 +71,13 @@ empty array, the serializer manually converts the JSON from an empty array
 (`[]`) to an empty object (`{}`) so that it is valid JSON for {es} request 
 bodies.
 
-
+[discrete]
 ==== Deserialize()
 
 When decoding the response body, everything is decoded to JSON from JSON. If the 
 data is not valid JSON, `null` will be returned.
 
-
+[discrete]
 ==== Selecting the ArrayToJSONSerializer
 
 You can select `ArrayToJSONSerializer` by using the `setSerializer()` method on 
@@ -91,9 +94,10 @@ $client = ClientBuilder::create()
 Note that the serializer is configured by specifying a namespace path to the 
 serializer.
 
-
+[discrete]
 === EverythingToJSONSerializer
 
+[discrete]
 ==== Serialize()
 
 The `EverythingToJSONSerializer` tries to convert everything to JSON.
@@ -105,11 +109,13 @@ JSON for Elasticsearch request bodies.
 If the data was not an array and/or not convertible to JSON, the method returns
 `null`.
 
+[discrete]
 ==== Deserialize()
 
 When decoding the response body, everything is decoded to JSON from JSON. If the 
 data is not valid JSON, `null` is returned.
 
+[discrete]
 ==== Selecting the EverythingToJSONSerializer
 
 You can select  `EverythingToJSONSerializer` by using the `setSerializer()` 
@@ -125,6 +131,8 @@ $client = ClientBuilder::create()
 Note that the serializer is configured by specifying a namespace path to the 
 serializer.
 
+
+[discrete]
 === Implementing your own Serializer
 
 If you want to use your own custom serializer, you need to implement the 


### PR DESCRIPTION
## Overview

This PR adds the `discrete` attribute to every third and fourth level section in the PHP docs. This way these sections won't be chunked into new pages after https://github.com/elastic/docs/pull/2043 merged.