### PR TITLE
Replace guzzlehttp/ringphp with ezimuel/ringphp

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   "require": {
     "php": "^7.0",
     "ext-json": ">=1.3.7",
-    "guzzlehttp/ringphp": "~1.0",
+    "ezimuel/ringphp": "~1.0",
     "psr/log": "~1.0"
   },
   "require-dev": {


### PR DESCRIPTION
`guzzlehttp/ringphp` is abandoned, so it's better to use the fork that was introduced in the 7.x branch