### PR TITLE
[DOCS] Adds Operations section to PHP book

### DIFF
--- a/docs/crud.asciidoc
+++ b/docs/crud.asciidoc
@@ -1,5 +1,5 @@
 [[indexing_documents]]
-== Indexing documents
+=== Indexing documents
 
 IMPORTANT: Please note that mapping types will disappear from {es}, read more 
 {ref-7x}/removal-of-types.html[here]. If you migrated types from {es} 6 to 7, 
@@ -12,7 +12,7 @@ indexing. There are several methods of ingesting data into {es} which we cover
 here.
 
 [discrete]
-=== Single document indexing
+==== Single document indexing
 
 When indexing a document, you can either provide an ID or let {es} generate one 
 for you.
@@ -67,7 +67,7 @@ $response = $client->index($params);
 {zwsp} +
 
 [discrete]
-=== Bulk Indexing
+==== Bulk Indexing
 
 {es} also supports bulk indexing of documents. The bulk API expects JSON 
 action/metadata pairs, separated by newlines. When constructing your documents 
@@ -137,7 +137,7 @@ if (!empty($params['body'])) {
 ----
 
 [[getting_documents]]
-== Getting documents
+=== Getting documents
 
 {es} provides realtime GETs of documents. This means that as soon as the 
 document is indexed and your client receives an acknowledgement, you can 
@@ -157,14 +157,14 @@ $response = $client->get($params);
 {zwsp} +
 
 [[updating_documents]]
-== Updating documents
+=== Updating documents
 
 Updating a document allows you to either completely replace the contents of the 
 existing document, or perform a partial update to just some fields (either 
 changing an existing field or adding new fields).
 
 [discrete]
-=== Partial document update
+==== Partial document update
 
 If you want to partially update a document (for example, change an existing 
 field or add a new one) you can do so by specifying the `doc` in the `body` 
@@ -189,7 +189,7 @@ $response = $client->update($params);
 {zwsp} +
 
 [discrete]
-=== Scripted document update
+==== Scripted document update
 
 Sometimes you need to perform a scripted update, such as incrementing a counter 
 or appending a new value to an array. To perform a scripted update, you need to 
@@ -213,7 +213,7 @@ $response = $client->update($params);
 {zwsp} +
 
 [discrete]
-=== Upserts
+==== Upserts
 
 Upserts are "Update or Insert" operations. This means an upsert attempts to run 
 your update script, but if the document does not exist (or the field you are 
@@ -243,7 +243,7 @@ $response = $client->update($params);
 
 
 [[deleting_documents]]
-== Deleting documents
+=== Deleting documents
 
 Finally, you can delete documents by specifying their full `/index/_doc_/id` 
 path:

--- a/docs/index-operations.asciidoc
+++ b/docs/index-operations.asciidoc
@@ -1,12 +1,12 @@
 [[index_management]]
-== Index management operations
+=== Index management operations
 
 Index management operations allow you to manage the indices in your {es} 
 cluster, such as creating, deleting and updating indices and their 
 mappings/settings.
 
 [discrete]
-=== Create an index
+==== Create an index
 
 The index operations are all contained under a distinct namespace, separated 
 from other methods that are on the root client object. As an example, let's 
@@ -61,7 +61,7 @@ $response = $client->indices()->create($params);
 {zwsp} +
 
 [discrete]
-=== Create an index (advanced example)
+==== Create an index (advanced example)
 
 This is a more complicated example of creating an index, showing how to define 
 analyzers, tokenizers, filters and index settings. Although essentially the same 
@@ -139,7 +139,7 @@ char filters and analyzers.
 mappings for various types.
 
 [discrete]
-=== Delete an index
+==== Delete an index
 
 Deleting an index is very simple:
 
@@ -172,7 +172,7 @@ $response = $client->indices()->putSettings($params);
 {zwsp} +
 
 [discrete]
-=== GET Settings API
+==== GET Settings API
 
 The GET Settings API shows you the currently configured settings for one or more 
 indices:
@@ -192,7 +192,7 @@ $response = $client->indices()->getSettings($params);
 {zwsp} +
 
 [discrete]
-=== PUT Mappings API
+==== PUT Mappings API
 
 The PUT Mappings API allows you to modify or add to an existing index's mapping.
 
@@ -223,7 +223,7 @@ $client->indices()->putMapping($params);
 {zwsp} +
 
 [discrete]
-=== GET Mappings API
+==== GET Mappings API
 
 The GET Mappings API returns the mapping details about your indices. Depending 
 on the mappings that you wish to retrieve, you can specify one of more indices:
@@ -246,7 +246,7 @@ $response = $client->indices()->getMapping($params);
 {zwsp} +
 
 [discrete]
-=== Other APIs in the indices namespace
+==== Other APIs in the indices namespace
 
 There are a number of other APIs in the indices namespace that allow you to 
 manage your {es} indices (add/remove templates, flush segments, close indices, 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -11,13 +11,9 @@ include::connecting.asciidoc[]
 
 include::configuration.asciidoc[]
 
+include::operations.asciidoc[]
+
 include::php_json_objects.asciidoc[]
-
-include::index-operations.asciidoc[]
-
-include::crud.asciidoc[]
-
-include::search-operations.asciidoc[]
 
 include::breaking-changes.asciidoc[]
 

--- a/docs/operations.asciidoc
+++ b/docs/operations.asciidoc
@@ -13,6 +13,6 @@ by using the Client.
 
 include::index-operations.asciidoc[]
 
-include:search-operations.asciidoc[]
+include::search-operations.asciidoc[]
 
 include::crud.asciidoc[]

--- a/docs/operations.asciidoc
+++ b/docs/operations.asciidoc
@@ -1,0 +1,18 @@
+[[operations]]
+== Operations 
+
+This page contains the information you need to perform various {es} operations 
+by using the Client.
+
+* <<index_management>>
+* <<search_operations>>
+* <<indexing_documents>>
+* <<getting_documents>>
+* <<updating_documents>>
+* <<deleting_documents>>
+
+include::index-operations.asciidoc[]
+
+include:search-operations.asciidoc[]
+
+include::crud.asciidoc[]

--- a/docs/search-operations.asciidoc
+++ b/docs/search-operations.asciidoc
@@ -1,5 +1,5 @@
 [[search_operations]]
-== Search operations
+=== Search operations
 
 Well...it isn't called {es} for nothing! Let's talk about search operations in 
 the client.
@@ -9,7 +9,7 @@ REST API, following the naming scheme as much as possible. Let's look at a few
 examples so you can become familiar with the syntax.
 
 [discrete]
-=== Match query
+==== Match query
 
 Here is a standard curl for a match query:
 
@@ -127,7 +127,7 @@ $doc   = $results['hits']['hits'][0]['_source'];
 {zwsp} +
 
 [discrete]
-=== Bool Queries
+==== Bool Queries
 
 Bool queries can be easily constructed using the client. For example, this 
 query:
@@ -181,7 +181,7 @@ identical to the curl example. For more details about arrays and objects in PHP,
 see <<php_json_objects, Dealing with JSON Arrays and Objects in PHP>>.
 
 [discrete]
-=== A more complicated example
+==== A more complicated example
 
 Let's construct a slightly more complicated example: a boolean query that 
 contains both a filter and a query. This is a very common activity in {es} 
@@ -232,8 +232,9 @@ $results = $client->search($params);
 ----
 {zwsp} +
 
+
 [discrete]
-=== Scrolling
+==== Scrolling
 
 The scrolling functionality of {es} is used to paginate over many documents in a 
 bulk manner, such as exporting all the documents belonging to a single user. It 


### PR DESCRIPTION
## Overview

This PR adds a new section to the PHP book called `Operations`. It contains the following:
* Index management operations,
* Search operations,
* CRUD operations.

This PR is part of the Client docs redesign effort. Related issue: https://github.com/elastic/clients-team/issues/257

### Preview

[Operations](https://elasticsearch-php_1110.docs-preview.app.elstc.co/guide/en/elasticsearch/client/php-api/master/operations.html)