### PR TITLE
[DOCS] Adds API reference section to PHP book

### DIFF
--- a/docs/build/Elasticsearch/Client.asciidoc
+++ b/docs/build/Elasticsearch/Client.asciidoc
@@ -1,5 +1,4 @@
-
-
+[discrete]
 [[Elasticsearch_Client]]
 === Elasticsearch\Client
 

--- a/docs/build/Elasticsearch/ClientBuilder.asciidoc
+++ b/docs/build/Elasticsearch/ClientBuilder.asciidoc
@@ -1,5 +1,4 @@
-
-
+[discrete]
 [[Elasticsearch_ClientBuilder]]
 === Elasticsearch\ClientBuilder
 

--- a/docs/build/Elasticsearch/Namespaces/CatNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/CatNamespace.asciidoc
@@ -1,5 +1,5 @@
 
-
+[discrete]
 [[Elasticsearch_Namespaces_CatNamespace]]
 === Elasticsearch\Namespaces\CatNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/ClusterNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/ClusterNamespace.asciidoc
@@ -1,5 +1,4 @@
-
-
+[discrete]
 [[Elasticsearch_Namespaces_ClusterNamespace]]
 === Elasticsearch\Namespaces\ClusterNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/IndicesNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/IndicesNamespace.asciidoc
@@ -1,5 +1,4 @@
-
-
+[discrete]
 [[Elasticsearch_Namespaces_IndicesNamespace]]
 === Elasticsearch\Namespaces\IndicesNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/IngestNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/IngestNamespace.asciidoc
@@ -1,5 +1,4 @@
-
-
+[discrete]
 [[Elasticsearch_Namespaces_IngestNamespace]]
 === Elasticsearch\Namespaces\IngestNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/NodesNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/NodesNamespace.asciidoc
@@ -1,5 +1,4 @@
-
-
+[discrete]
 [[Elasticsearch_Namespaces_NodesNamespace]]
 === Elasticsearch\Namespaces\NodesNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/SnapshotNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/SnapshotNamespace.asciidoc
@@ -1,5 +1,4 @@
-
-
+[discrete]
 [[Elasticsearch_Namespaces_SnapshotNamespace]]
 === Elasticsearch\Namespaces\SnapshotNamespace
 

--- a/docs/build/Elasticsearch/Namespaces/TasksNamespace.asciidoc
+++ b/docs/build/Elasticsearch/Namespaces/TasksNamespace.asciidoc
@@ -1,5 +1,4 @@
-
-
+[discrete]
 [[Elasticsearch_Namespaces_TasksNamespace]]
 === Elasticsearch\Namespaces\TasksNamespace
 

--- a/docs/build/classes.asciidoc
+++ b/docs/build/classes.asciidoc
@@ -1,6 +1,6 @@
 
 [[ElasticsearchPHP_Endpoints]]
-== Reference - Endpoints
+== API reference
 
 This is a complete list of namespaces and their associated endpoints.
 
@@ -24,3 +24,5 @@ include::Elasticsearch/Namespaces/IngestNamespace.asciidoc[]
 include::Elasticsearch/Namespaces/NodesNamespace.asciidoc[]
 include::Elasticsearch/Namespaces/SnapshotNamespace.asciidoc[]
 include::Elasticsearch/Namespaces/TasksNamespace.asciidoc[]
+
+include::../experimental-beta-apis.asciidoc[]

--- a/docs/experimental-beta-apis.asciidoc
+++ b/docs/experimental-beta-apis.asciidoc
@@ -1,5 +1,5 @@
 [[experimental_and_beta_apis]]
-== Experimental and beta APIs
+=== Experimental and beta APIs
 
 The PHP client offers also `experimental` and `beta` APIs for {es}.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -13,14 +13,12 @@ include::configuration.asciidoc[]
 
 include::operations.asciidoc[]
 
+include::build/classes.asciidoc[]
+
 include::php_json_objects.asciidoc[]
 
 include::breaking-changes.asciidoc[]
 
 include::community.asciidoc[]
-
-include::experimental-beta-apis.asciidoc[]
-
-include::build/classes.asciidoc[]
 
 include::redirects.asciidoc[]


### PR DESCRIPTION
## Overview

This PR renames the `Reference – Endpoints` section to `API reference`. It also puts the `Experimental beta APIs` section under `API reference`.

This PR is part of the Client docs redesign effort. Related issue: https://github.com/elastic/clients-team/issues/257

### Preview

* [API reference](https://elasticsearch-php_1115.docs-preview.app.elstc.co/guide/en/elasticsearch/client/php-api/master/ElasticsearchPHP_Endpoints.html)
* [ToC](https://elasticsearch-php_1115.docs-preview.app.elstc.co/guide/en/elasticsearch/client/php-api/master/index.html)