### PR TITLE
Update Connection.php

### DIFF
--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -174,7 +174,7 @@ class Connection implements ConnectionInterface
      * @param \Elasticsearch\Transport $transport
      * @return mixed
      */
-    public function performRequest($method, $uri, $params = null, $body = null, $options = [], Transport $transport = null)
+    public function performRequest(string $method, string $uri, ?array $params = [], $body = null, array $options = [], Transport $transport = null)
     {
         if ($body !== null) {
             $body = $this->serializer->serialize($body);


### PR DESCRIPTION
Fix function signature of performRequest to match declaration in ConnectionInterface

Issue:
```
Fatal error: 
Declaration of Elasticsearch\Connections\Connection::performRequest($method, $uri, $params = NULL, $body = NULL, $options = Array, ?Elasticsearch\Transport $transport = NULL) 
must be compatible with 
Elasticsearch\Connections\ConnectionInterface::performRequest(string $method, string $uri, ?array $params = Array, $body = NULL, array $options = Array, ?Elasticsearch\Transport $transport = NULL) 
in /mnt/volume-lon1-01/var/www/xxxx/vendor/elasticsearch/elasticsearch/src/Elasticsearch/Connections/Connection.php on line 49
```

https://github.com/elastic/elasticsearch-php/issues/989 - but for 6.8.x function missing all type hinting
<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you signed [Contributor License Agreement](https://www.elastic.co/contributor-agreement)?
PR's (no matter how small) cannot be merged until the CLA has been signed.  It only needs to be signed once,
however.

- Have you read the [Contributing Guidelines](https://github.com/elastic/elasticsearch-php/blob/master/.github/CONTRIBUTING.md)?

If you answered yes to both, thanks for the PR and we'll get to it ASAP! :)

-->
