### PR TITLE
Update search iterators to send "scroll_id" inside the request body

### DIFF
--- a/src/Elasticsearch/Helper/Iterators/SearchHitIterator.php
+++ b/src/Elasticsearch/Helper/Iterators/SearchHitIterator.php
@@ -76,8 +76,8 @@ class SearchHitIterator implements Iterator, \Countable
         }
 
         $this->count = 0;
-        if (isset($current_page['hits']) && isset($current_page['hits']['hits'])) {
-            $this->count = count($current_page['hits']['hits']);
+        if (isset($current_page['hits']) && isset($current_page['hits']['total'])) {
+            $this->count = $current_page['hits']['total']['value'] ?? $current_page['hits']['total'];
         }
 
         $this->readPageData();

--- a/src/Elasticsearch/Helper/Iterators/SearchHitIterator.php
+++ b/src/Elasticsearch/Helper/Iterators/SearchHitIterator.php
@@ -76,8 +76,8 @@ class SearchHitIterator implements Iterator, \Countable
         }
 
         $this->count = 0;
-        if (isset($current_page['hits']) && isset($current_page['hits']['total'])) {
-            $this->count = $current_page['hits']['total'];
+        if (isset($current_page['hits']) && isset($current_page['hits']['hits'])) {
+            $this->count = count($current_page['hits']['hits']);
         }
 
         $this->readPageData();

--- a/src/Elasticsearch/Helper/Iterators/SearchResponseIterator.php
+++ b/src/Elasticsearch/Helper/Iterators/SearchResponseIterator.php
@@ -100,12 +100,14 @@ class SearchResponseIterator implements Iterator
     {
         if (!empty($this->scroll_id)) {
             $this->client->clearScroll(
-                array(
-                    'scroll_id' => $this->scroll_id,
-                    'client' => array(
+                [
+                    'body' => [
+                        'scroll_id' => $this->scroll_id
+                    ],
+                    'client' => [
                         'ignore' => 404
-                    )
-                )
+                    ]
+                ]
             );
             $this->scroll_id = null;
         }
@@ -135,8 +137,10 @@ class SearchResponseIterator implements Iterator
     {
         $this->current_scrolled_response = $this->client->scroll(
             [
-            'scroll_id' => $this->scroll_id,
-            'scroll'    => $this->scroll_ttl
+                'body' => [
+                    'scroll_id' => $this->scroll_id,
+                    'scroll'    => $this->scroll_ttl
+                ]
             ]
         );
         $this->scroll_id = $this->current_scrolled_response['_scroll_id'];

--- a/tests/Elasticsearch/Tests/Helper/Iterators/SearchHitIteratorTest.php
+++ b/tests/Elasticsearch/Tests/Helper/Iterators/SearchHitIteratorTest.php
@@ -64,7 +64,10 @@ class SearchHitIteratorTest extends \PHPUnit\Framework\TestCase
                         [ 'foo' => 'bar1' ],
                         [ 'foo' => 'bar2' ]
                     ],
-                    'total' => 3
+                    'total' => [
+                        'value' => 3,
+                        'relation' => 'eq'
+                    ]
                 ]
                 ],
                 [
@@ -74,7 +77,10 @@ class SearchHitIteratorTest extends \PHPUnit\Framework\TestCase
                         [ 'foo' => 'bar1' ],
                         [ 'foo' => 'bar2' ]
                     ],
-                    'total' => 3
+                    'total' => [
+                        'value' => 3,
+                        'relation' => 'eq'
+                    ]
                 ]
                 ],
                 [
@@ -84,7 +90,10 @@ class SearchHitIteratorTest extends \PHPUnit\Framework\TestCase
                         [ 'foo' => 'bar1' ],
                         [ 'foo' => 'bar2' ]
                     ],
-                    'total' => 3
+                    'total' => [
+                        'value' => 3,
+                        'relation' => 'eq'
+                    ]
                 ]
                 ],
                 [
@@ -94,7 +103,10 @@ class SearchHitIteratorTest extends \PHPUnit\Framework\TestCase
                         [ 'foo' => 'bar1' ],
                         [ 'foo' => 'bar2' ]
                     ],
-                    'total' => 3
+                    'total' => [
+                        'value' => 3,
+                        'relation' => 'eq'
+                    ]
                 ]
                 ],
                 [
@@ -103,7 +115,10 @@ class SearchHitIteratorTest extends \PHPUnit\Framework\TestCase
                         [ 'foo' => 'bar3' ],
                         [ 'foo' => 'bar4' ]
                     ],
-                    'total' => 2
+                    'total' => [
+                        'value' => 2,
+                        'relation' => 'eq'
+                    ]
                 ]
                 ],
                 [
@@ -112,7 +127,10 @@ class SearchHitIteratorTest extends \PHPUnit\Framework\TestCase
                         [ 'foo' => 'bar3' ],
                         [ 'foo' => 'bar4' ]
                     ],
-                    'total' => 2
+                    'total' => [
+                        'value' => 2,
+                        'relation' => 'eq'
+                    ]
                 ]
                 ]
             );

--- a/tests/Elasticsearch/Tests/Helper/Iterators/SearchResponseIteratorTest.php
+++ b/tests/Elasticsearch/Tests/Helper/Iterators/SearchResponseIteratorTest.php
@@ -100,8 +100,10 @@ class SearchResponseIteratorTest extends \PHPUnit\Framework\TestCase
             ->ordered()
             ->with(
                 [
-                    'scroll_id'  => 'scroll_id_01',
-                    'scroll' => '5m'
+                    'body' => [
+                        'scroll_id'  => 'scroll_id_01',
+                        'scroll' => '5m'
+                    ]
                 ]
             )
             ->andReturn(
@@ -122,8 +124,10 @@ class SearchResponseIteratorTest extends \PHPUnit\Framework\TestCase
             ->ordered()
             ->with(
                 [
-                    'scroll_id'  => 'scroll_id_02',
-                    'scroll' => '5m'
+                    'body' => [
+                        'scroll_id' => 'scroll_id_02',
+                        'scroll' => '5m'
+                    ]
                 ]
             )
             ->andReturn(
@@ -144,8 +148,10 @@ class SearchResponseIteratorTest extends \PHPUnit\Framework\TestCase
             ->ordered()
             ->with(
                 [
-                    'scroll_id'  => 'scroll_id_03',
-                    'scroll' => '5m'
+                    'body' => [
+                        'scroll_id' => 'scroll_id_03',
+                        'scroll' => '5m'
+                    ]
                 ]
             )
             ->andReturn(
@@ -161,8 +167,10 @@ class SearchResponseIteratorTest extends \PHPUnit\Framework\TestCase
             ->never()
             ->with(
                 [
-                    'scroll_id'  => 'scroll_id_04',
-                    'scroll' => '5m'
+                    'body' => [
+                        'scroll_id'  => 'scroll_id_04',
+                        'scroll' => '5m'
+                    ]
                 ]
             );
 


### PR DESCRIPTION

Moving scroll_id into requires body #1044 brakes `SearchResponseIterator` by triggering deprecation error.

The goal of this PR is to change the iterator classes as described in the [doc](https://github.com/elastic/elasticsearch-php/blob/master/docs/search-operations.asciidoc#scrolling) to avoid deprecation error