### PR TITLE
[DOCS] Adds section about PSR 7

### DIFF
--- a/docs/overview.asciidoc
+++ b/docs/overview.asciidoc
@@ -13,3 +13,12 @@ The client is designed to be "unopinionated". There are a few universal niceties
 added to the client (cluster state sniffing, round-robin requests, and so on) 
 but largely it is very barebones. This was intentional; we want a common base 
 that more sophisticated libraries can build on top of.
+
+[discrete]
+[[psr-7-standard]]
+=== PSR 7 standard
+
+The {es} PHP client uses the https://www.php-fig.org/psr/[PSR] 7 standard. This 
+standard is a community effort that contains a set of interfaces defined by the 
+PHP Framework Interop Group. For more information, refer to the 
+https://www.php-fig.org/psr/psr-7/[PSR 7 standard documentation].


### PR DESCRIPTION
## Overview

This PR adds a section to the `Overview` page about the PSR 7 standard used in the PHP Client.

### Preview

[Overview](https://elasticsearch-php_1137.docs-preview.app.elstc.co/guide/en/elasticsearch/client/php-api/master/overview.html)

### Note

Applies to `master` only.