### PR TITLE
Add support for API Compatibility Header

### DIFF
--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -635,11 +635,20 @@ class ClientBuilder
             if (! isset($this->connectionParams['client']['headers'])) {
                 $this->connectionParams['client']['headers'] = [];
             }
+            $apiVersioning = getenv('ELASTIC_CLIENT_APIVERSIONING');
             if (! isset($this->connectionParams['client']['headers']['Content-Type'])) {
-                $this->connectionParams['client']['headers']['Content-Type'] = ['application/json'];
+                if ($apiVersioning === 'true' || $apiVersioning === '1') {
+                    $this->connectionParams['client']['headers']['Content-Type'] = ['application/vnd.elasticsearch+json;compatible-with=7'];
+                } else {
+                    $this->connectionParams['client']['headers']['Content-Type'] = ['application/json'];
+                }
             }
             if (! isset($this->connectionParams['client']['headers']['Accept'])) {
-                $this->connectionParams['client']['headers']['Accept'] = ['application/json'];
+                if ($apiVersioning === 'true' || $apiVersioning === '1') {
+                    $this->connectionParams['client']['headers']['Accept'] = ['application/vnd.elasticsearch+json;compatible-with=7'];
+                } else {
+                    $this->connectionParams['client']['headers']['Accept'] = ['application/json'];
+                }
             }
 
             $this->connectionFactory = new ConnectionFactory($this->handler, $this->connectionParams, $this->serializer, $this->logger, $this->tracer);


### PR DESCRIPTION
This PR adds the support for API compatibility header. Starting from version 7.13, Elasticsearch supports a compatibility header in `Content-Type` and `Accept`. The `elasticsearch-php` client can be configured to emit the following HTTP headers:
```
Content-Type: application/vnd.elasticsearch+json; compatible-with=7
Accept: application/vnd.elasticsearch+json; compatible-with=7
```
which signals to Elasticsearch that the client is requesting `7.x` version of request and response bodies. This allows forupgrading from 7.x to 8.x version of Elasticsearch without upgrading everything at once. Elasticsearch should be upgraded first after the compatibility header is configured and clients should be upgraded second.

To enable this compatibility header you need to create a `ELASTIC_CLIENT_APIVERSIONING` environment variable and set it to `true` or `1`.

