### PR TITLE
Refactor for abstract return type

### DIFF
--- a/src/Elasticsearch/Endpoints/AbstractEndpoint.php
+++ b/src/Elasticsearch/Endpoints/AbstractEndpoint.php
@@ -45,20 +45,20 @@ abstract class AbstractEndpoint
     /** @var  SerializerInterface */
     protected $serializer;
 
-    /**
-     * @return string[]
-     */
-    abstract public function getParamWhitelist();
+   /**
+    * @return string[]
+    */
+    abstract public function getParamWhitelist(): array;
 
-    /**
-     * @return string
-     */
-    abstract public function getURI();
+   /**
+    * @return string
+    */
+    abstract public function getURI(): string;
 
-    /**
-     * @return string
-     */
-    abstract public function getMethod();
+   /**
+    * @return string
+    */
+    abstract public function getMethod(): string;
 
 
     /**

--- a/src/Elasticsearch/Endpoints/Bulk.php
+++ b/src/Elasticsearch/Endpoints/Bulk.php
@@ -53,18 +53,18 @@ class Bulk extends AbstractEndpoint implements BulkEndpointInterface
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         return $this->getOptionalURI('_bulk');
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'consistency',
@@ -83,10 +83,10 @@ class Bulk extends AbstractEndpoint implements BulkEndpointInterface
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Cat/Aliases.php
+++ b/src/Elasticsearch/Endpoints/Cat/Aliases.php
@@ -40,10 +40,10 @@ class Aliases extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $name = $this->name;
         $uri   = "/_cat/aliases";
@@ -55,10 +55,10 @@ class Aliases extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'local',
@@ -72,10 +72,10 @@ class Aliases extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/Allocation.php
+++ b/src/Elasticsearch/Endpoints/Cat/Allocation.php
@@ -40,10 +40,10 @@ class Allocation extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $node_id = $this->node_id;
         $uri   = "/_cat/allocation";
@@ -55,10 +55,10 @@ class Allocation extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'bytes',
@@ -72,10 +72,10 @@ class Allocation extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/Count.php
+++ b/src/Elasticsearch/Endpoints/Cat/Count.php
@@ -17,10 +17,10 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  */
 class Count extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $uri   = "/_cat/count";
@@ -32,10 +32,10 @@ class Count extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'local',
@@ -48,10 +48,10 @@ class Count extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/Fielddata.php
+++ b/src/Elasticsearch/Endpoints/Cat/Fielddata.php
@@ -35,10 +35,10 @@ class Fielddata extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $fields = $this->fields;
         $uri   = "/_cat/fielddata";
@@ -50,10 +50,10 @@ class Fielddata extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'local',
@@ -66,10 +66,10 @@ class Fielddata extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/Health.php
+++ b/src/Elasticsearch/Endpoints/Cat/Health.php
@@ -17,20 +17,20 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  */
 class Health extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $uri   = "/_cat/health";
 
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'local',
@@ -44,10 +44,10 @@ class Health extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/Help.php
+++ b/src/Elasticsearch/Endpoints/Cat/Help.php
@@ -17,20 +17,20 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  */
 class Help extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $uri   = "/_cat";
 
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'help',
@@ -39,10 +39,10 @@ class Help extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/Indices.php
+++ b/src/Elasticsearch/Endpoints/Cat/Indices.php
@@ -18,10 +18,10 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
 
 class Indices extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $uri   = "/_cat/indices";
@@ -33,10 +33,10 @@ class Indices extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'bytes',
@@ -52,10 +52,10 @@ class Indices extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/Master.php
+++ b/src/Elasticsearch/Endpoints/Cat/Master.php
@@ -17,20 +17,20 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  */
 class Master extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $uri   = "/_cat/master";
 
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'local',
@@ -43,10 +43,10 @@ class Master extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/NodeAttrs.php
+++ b/src/Elasticsearch/Endpoints/Cat/NodeAttrs.php
@@ -17,20 +17,20 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  */
 class NodeAttrs extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $uri   = "/_cat/nodeattrs";
 
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'local',
@@ -43,10 +43,10 @@ class NodeAttrs extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/Nodes.php
+++ b/src/Elasticsearch/Endpoints/Cat/Nodes.php
@@ -17,20 +17,20 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  */
 class Nodes extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $uri   = "/_cat/nodes";
 
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'local',
@@ -44,10 +44,10 @@ class Nodes extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/PendingTasks.php
+++ b/src/Elasticsearch/Endpoints/Cat/PendingTasks.php
@@ -17,20 +17,20 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  */
 class PendingTasks extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $uri   = "/_cat/pending_tasks";
 
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'local',
@@ -43,10 +43,10 @@ class PendingTasks extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/Plugins.php
+++ b/src/Elasticsearch/Endpoints/Cat/Plugins.php
@@ -17,20 +17,20 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  */
 class Plugins extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $uri   = "/_cat/plugins";
 
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'local',
@@ -43,10 +43,10 @@ class Plugins extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/Recovery.php
+++ b/src/Elasticsearch/Endpoints/Cat/Recovery.php
@@ -17,10 +17,10 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  */
 class Recovery extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $uri   = "/_cat/recovery";
@@ -32,10 +32,10 @@ class Recovery extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'bytes',
@@ -49,10 +49,10 @@ class Recovery extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/Repositories.php
+++ b/src/Elasticsearch/Endpoints/Cat/Repositories.php
@@ -17,20 +17,20 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  */
 class Repositories extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $uri   = "/_cat/repositories";
 
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'local',
@@ -43,10 +43,10 @@ class Repositories extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/Segments.php
+++ b/src/Elasticsearch/Endpoints/Cat/Segments.php
@@ -24,10 +24,10 @@ use Elasticsearch\Common\Exceptions;
 
 class Segments extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $uri   = "/_cat/segments";
@@ -39,11 +39,10 @@ class Segments extends AbstractEndpoint
         return $uri;
     }
 
-
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'h',
@@ -54,11 +53,10 @@ class Segments extends AbstractEndpoint
         );
     }
 
-
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/Shards.php
+++ b/src/Elasticsearch/Endpoints/Cat/Shards.php
@@ -17,10 +17,10 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  */
 class Shards extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $uri   = "/_cat/shards";
@@ -32,10 +32,10 @@ class Shards extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'bytes',
@@ -49,10 +49,10 @@ class Shards extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/Snapshots.php
+++ b/src/Elasticsearch/Endpoints/Cat/Snapshots.php
@@ -36,10 +36,10 @@ class Snapshots extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $repository = $this->repository;
         if (isset($this->repository) === true) {
@@ -49,10 +49,10 @@ class Snapshots extends AbstractEndpoint
         return "/_cat/snapshots/";
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'local',
@@ -65,10 +65,10 @@ class Snapshots extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/Tasks.php
+++ b/src/Elasticsearch/Endpoints/Cat/Tasks.php
@@ -17,18 +17,18 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  */
 class Tasks extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         return "/_cat/tasks";
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'format',
@@ -44,10 +44,10 @@ class Tasks extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/Templates.php
+++ b/src/Elasticsearch/Endpoints/Cat/Templates.php
@@ -29,10 +29,10 @@ class Templates extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         if (isset($this->name)) {
             return "/_cat/templates/{$this->name}";
@@ -41,10 +41,10 @@ class Templates extends AbstractEndpoint
         }
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'format',
@@ -62,10 +62,10 @@ class Templates extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cat/ThreadPool.php
+++ b/src/Elasticsearch/Endpoints/Cat/ThreadPool.php
@@ -18,20 +18,20 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
 
 class ThreadPool extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $uri   = "/_cat/thread_pool";
 
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'local',
@@ -47,10 +47,10 @@ class ThreadPool extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/ClearScroll.php
+++ b/src/Elasticsearch/Endpoints/ClearScroll.php
@@ -40,11 +40,11 @@ class ClearScroll extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         return "/_search/scroll/";
     }
@@ -80,19 +80,19 @@ class ClearScroll extends AbstractEndpoint
         return ['scroll_id' => [$this->scrollId]];
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'DELETE';
     }

--- a/src/Elasticsearch/Endpoints/Cluster/AllocationExplain.php
+++ b/src/Elasticsearch/Endpoints/Cluster/AllocationExplain.php
@@ -35,18 +35,18 @@ class AllocationExplain extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         return "/_cluster/allocation/explain";
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'include_yes_decisions',
@@ -54,10 +54,10 @@ class AllocationExplain extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return isset($this->body) ? 'POST' : 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cluster/Health.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Health.php
@@ -17,10 +17,10 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  */
 class Health extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $uri   = "/_cluster/health";
@@ -32,10 +32,10 @@ class Health extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'level',
@@ -52,10 +52,10 @@ class Health extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cluster/Nodes/HotThreads.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Nodes/HotThreads.php
@@ -15,10 +15,10 @@ namespace Elasticsearch\Endpoints\Cluster\Nodes;
  */
 class HotThreads extends AbstractNodesEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $node_id = $this->nodeID;
         $uri   = "/_cluster/nodes/hotthreads";
@@ -30,10 +30,10 @@ class HotThreads extends AbstractNodesEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'interval',
@@ -43,10 +43,10 @@ class HotThreads extends AbstractNodesEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cluster/Nodes/Info.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Nodes/Info.php
@@ -42,10 +42,10 @@ class Info extends AbstractNodesEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $node_id = $this->nodeID;
         $metric = $this->metric;
@@ -62,10 +62,10 @@ class Info extends AbstractNodesEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'flat_settings',
@@ -73,10 +73,10 @@ class Info extends AbstractNodesEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cluster/Nodes/ReloadSecureSettings.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Nodes/ReloadSecureSettings.php
@@ -15,10 +15,10 @@ namespace Elasticsearch\Endpoints\Cluster\Nodes;
  */
 class ReloadSecureSettings extends AbstractNodesEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $nodeId = $this->nodeID;
         $uri   = "/_nodes/reload_secure_settings";
@@ -30,18 +30,18 @@ class ReloadSecureSettings extends AbstractNodesEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return [];
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Cluster/Nodes/Stats.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Nodes/Stats.php
@@ -70,10 +70,10 @@ class Stats extends AbstractNodesEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $metric = $this->metric;
         $index_metric = $this->indexMetric;
@@ -95,10 +95,10 @@ class Stats extends AbstractNodesEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'completion_fields',
@@ -112,10 +112,10 @@ class Stats extends AbstractNodesEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cluster/PendingTasks.php
+++ b/src/Elasticsearch/Endpoints/Cluster/PendingTasks.php
@@ -17,20 +17,20 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  */
 class PendingTasks extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $uri   = "/_cluster/pending_tasks";
 
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'local',
@@ -38,10 +38,10 @@ class PendingTasks extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cluster/RemoteInfo.php
+++ b/src/Elasticsearch/Endpoints/Cluster/RemoteInfo.php
@@ -17,26 +17,26 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  */
 class RemoteInfo extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         return "/_remote/info";
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return [];
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cluster/Reroute.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Reroute.php
@@ -35,20 +35,20 @@ class Reroute extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $uri   = "/_cluster/reroute";
 
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'dry_run',
@@ -60,10 +60,10 @@ class Reroute extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Cluster/Settings/Get.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Settings/Get.php
@@ -18,20 +18,20 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
 
 class Get extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $uri   = "/_cluster/settings";
 
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'flat_settings',
@@ -41,10 +41,10 @@ class Get extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cluster/Settings/Put.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Settings/Put.php
@@ -35,30 +35,30 @@ class Put extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $uri   = "/_cluster/settings";
 
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'flat_settings',
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'PUT';
     }

--- a/src/Elasticsearch/Endpoints/Cluster/State.php
+++ b/src/Elasticsearch/Endpoints/Cluster/State.php
@@ -44,10 +44,10 @@ class State extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $metric = $this->metric;
@@ -62,10 +62,10 @@ class State extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'local',
@@ -78,10 +78,10 @@ class State extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Cluster/Stats.php
+++ b/src/Elasticsearch/Endpoints/Cluster/Stats.php
@@ -42,10 +42,10 @@ class Stats extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $node_id = $this->nodeID;
         $uri   = "/_cluster/stats";
@@ -57,10 +57,10 @@ class Stats extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'flat_settings',
@@ -68,10 +68,10 @@ class Stats extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Count.php
+++ b/src/Elasticsearch/Endpoints/Count.php
@@ -34,10 +34,10 @@ class Count extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $type = $this->type;
@@ -54,10 +54,10 @@ class Count extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'ignore_unavailable',
@@ -79,10 +79,10 @@ class Count extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return isset($this->body) ? 'POST' : 'GET';
     }

--- a/src/Elasticsearch/Endpoints/CountPercolate.php
+++ b/src/Elasticsearch/Endpoints/CountPercolate.php
@@ -34,11 +34,11 @@ class CountPercolate extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->index) !== true) {
             throw new Exceptions\RuntimeException(
@@ -64,10 +64,10 @@ class CountPercolate extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'routing',
@@ -82,10 +82,10 @@ class CountPercolate extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Create.php
+++ b/src/Elasticsearch/Endpoints/Create.php
@@ -34,11 +34,11 @@ class Create extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->index) !== true) {
             throw new Exceptions\RuntimeException(
@@ -64,10 +64,10 @@ class Create extends AbstractEndpoint
         return "/$index/$type/$id/_create";
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'consistency',
@@ -86,10 +86,10 @@ class Create extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'PUT';
     }

--- a/src/Elasticsearch/Endpoints/Delete.php
+++ b/src/Elasticsearch/Endpoints/Delete.php
@@ -17,11 +17,11 @@ use Elasticsearch\Common\Exceptions;
  */
 class Delete extends AbstractEndpoint
 {
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->id) !== true) {
             throw new Exceptions\RuntimeException(
@@ -50,10 +50,10 @@ class Delete extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'consistency',
@@ -70,10 +70,10 @@ class Delete extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'DELETE';
     }

--- a/src/Elasticsearch/Endpoints/DeleteByQuery.php
+++ b/src/Elasticsearch/Endpoints/DeleteByQuery.php
@@ -34,11 +34,11 @@ class DeleteByQuery extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (!$this->index) {
             throw new Exceptions\RuntimeException(
@@ -54,10 +54,10 @@ class DeleteByQuery extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             '_source',
@@ -98,10 +98,10 @@ class DeleteByQuery extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Exists.php
+++ b/src/Elasticsearch/Endpoints/Exists.php
@@ -17,11 +17,11 @@ use Elasticsearch\Common\Exceptions;
  */
 class Exists extends AbstractEndpoint
 {
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->id) !== true) {
             throw new Exceptions\RuntimeException(
@@ -50,10 +50,10 @@ class Exists extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'parent',
@@ -66,10 +66,10 @@ class Exists extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'HEAD';
     }

--- a/src/Elasticsearch/Endpoints/Explain.php
+++ b/src/Elasticsearch/Endpoints/Explain.php
@@ -34,11 +34,11 @@ class Explain extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->id) !== true) {
             throw new Exceptions\RuntimeException(
@@ -67,10 +67,10 @@ class Explain extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'analyze_wildcard',
@@ -94,10 +94,10 @@ class Explain extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return isset($this->body) ? 'POST' : 'GET';
     }

--- a/src/Elasticsearch/Endpoints/FieldCaps.php
+++ b/src/Elasticsearch/Endpoints/FieldCaps.php
@@ -34,10 +34,10 @@ class FieldCaps extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
 
@@ -48,10 +48,10 @@ class FieldCaps extends AbstractEndpoint
         }
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'fields',
@@ -61,10 +61,10 @@ class FieldCaps extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return isset($this->body) ? 'POST' : 'GET';
     }

--- a/src/Elasticsearch/Endpoints/FieldStats.php
+++ b/src/Elasticsearch/Endpoints/FieldStats.php
@@ -35,10 +35,10 @@ class FieldStats extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $uri   = "/_field_stats";
@@ -50,10 +50,10 @@ class FieldStats extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'fields',
@@ -65,10 +65,10 @@ class FieldStats extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Get.php
+++ b/src/Elasticsearch/Endpoints/Get.php
@@ -43,11 +43,11 @@ class Get extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->id) !== true) {
             throw new Exceptions\RuntimeException(
@@ -80,10 +80,10 @@ class Get extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'fields',
@@ -104,10 +104,10 @@ class Get extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         if ($this->checkOnlyExistance === true) {
             return 'HEAD';

--- a/src/Elasticsearch/Endpoints/Index.php
+++ b/src/Elasticsearch/Endpoints/Index.php
@@ -47,11 +47,11 @@ class Index extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->index) !== true) {
             throw new Exceptions\RuntimeException(
@@ -76,10 +76,10 @@ class Index extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'consistency',
@@ -101,10 +101,10 @@ class Index extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         if (isset($this->id) === true) {
             return 'PUT';

--- a/src/Elasticsearch/Endpoints/Indices/Alias/Delete.php
+++ b/src/Elasticsearch/Endpoints/Indices/Alias/Delete.php
@@ -41,11 +41,11 @@ class Delete extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->index) !== true) {
             throw new Exceptions\RuntimeException(
@@ -68,10 +68,10 @@ class Delete extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'timeout',
@@ -79,10 +79,10 @@ class Delete extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'DELETE';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Alias/Exists.php
+++ b/src/Elasticsearch/Endpoints/Indices/Alias/Exists.php
@@ -40,10 +40,10 @@ class Exists extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $name = $this->name;
@@ -60,10 +60,10 @@ class Exists extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'ignore_unavailable',
@@ -73,10 +73,10 @@ class Exists extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'HEAD';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Alias/Get.php
+++ b/src/Elasticsearch/Endpoints/Indices/Alias/Get.php
@@ -40,10 +40,10 @@ class Get extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $name = $this->name;
@@ -60,10 +60,10 @@ class Get extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'ignore_unavailable',
@@ -73,10 +73,10 @@ class Get extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Alias/Put.php
+++ b/src/Elasticsearch/Endpoints/Indices/Alias/Put.php
@@ -58,11 +58,11 @@ class Put extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->name) !== true) {
             throw new Exceptions\RuntimeException(
@@ -82,10 +82,10 @@ class Put extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'timeout',
@@ -93,10 +93,10 @@ class Put extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'PUT';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Aliases/Update.php
+++ b/src/Elasticsearch/Endpoints/Indices/Aliases/Update.php
@@ -35,20 +35,20 @@ class Update extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $uri   = "/_aliases";
 
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'timeout',
@@ -69,10 +69,10 @@ class Update extends AbstractEndpoint
         return $this->body;
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Analyze.php
+++ b/src/Elasticsearch/Endpoints/Indices/Analyze.php
@@ -35,10 +35,10 @@ class Analyze extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $uri   = "/_analyze";
@@ -50,10 +50,10 @@ class Analyze extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'analyzer',
@@ -71,10 +71,10 @@ class Analyze extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return isset($this->body) ? 'POST' : 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Cache/Clear.php
+++ b/src/Elasticsearch/Endpoints/Indices/Cache/Clear.php
@@ -17,10 +17,10 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  */
 class Clear extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $uri   = "/_cache/clear";
@@ -32,10 +32,10 @@ class Clear extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'field_data',
@@ -56,10 +56,10 @@ class Clear extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Indices/ClearCache.php
+++ b/src/Elasticsearch/Endpoints/Indices/ClearCache.php
@@ -17,10 +17,10 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  */
 class ClearCache extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $uri   = "/_cache/clear";
@@ -32,10 +32,10 @@ class ClearCache extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'field_data',
@@ -54,10 +54,10 @@ class ClearCache extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return isset($this->body) ? 'POST' : 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Close.php
+++ b/src/Elasticsearch/Endpoints/Indices/Close.php
@@ -18,11 +18,11 @@ use Elasticsearch\Common\Exceptions;
  */
 class Close extends AbstractEndpoint
 {
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->index) !== true) {
             throw new Exceptions\RuntimeException(
@@ -39,10 +39,10 @@ class Close extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'timeout',
@@ -53,10 +53,10 @@ class Close extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Create.php
+++ b/src/Elasticsearch/Endpoints/Indices/Create.php
@@ -35,11 +35,11 @@ class Create extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->index) !== true) {
             throw new Exceptions\RuntimeException(
@@ -56,10 +56,10 @@ class Create extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'timeout',
@@ -70,10 +70,10 @@ class Create extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'PUT';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Delete.php
+++ b/src/Elasticsearch/Endpoints/Indices/Delete.php
@@ -17,10 +17,10 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  */
 class Delete extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $uri   = "/$index";
@@ -32,10 +32,10 @@ class Delete extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'timeout',
@@ -45,10 +45,10 @@ class Delete extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'DELETE';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Exists.php
+++ b/src/Elasticsearch/Endpoints/Indices/Exists.php
@@ -18,11 +18,11 @@ use Elasticsearch\Common\Exceptions;
  */
 class Exists extends AbstractEndpoint
 {
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->index) !== true) {
             throw new Exceptions\RuntimeException(
@@ -39,10 +39,10 @@ class Exists extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'ignore_unavailable',
@@ -52,10 +52,10 @@ class Exists extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'HEAD';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Exists/Types.php
+++ b/src/Elasticsearch/Endpoints/Indices/Exists/Types.php
@@ -18,11 +18,11 @@ use Elasticsearch\Common\Exceptions;
  */
 class Types extends AbstractEndpoint
 {
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->index) !== true) {
             throw new Exceptions\RuntimeException(
@@ -43,10 +43,10 @@ class Types extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'ignore_unavailable',
@@ -55,10 +55,10 @@ class Types extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'HEAD';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Field/Get.php
+++ b/src/Elasticsearch/Endpoints/Indices/Field/Get.php
@@ -41,11 +41,11 @@ class Get extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->field) !== true) {
             throw new Exceptions\RuntimeException(
@@ -70,10 +70,10 @@ class Get extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'include_defaults',
@@ -84,10 +84,10 @@ class Get extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Flush.php
+++ b/src/Elasticsearch/Endpoints/Indices/Flush.php
@@ -24,10 +24,10 @@ class Flush extends AbstractEndpoint
         $this->synced = $synced;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $uri   = "/_flush";
@@ -43,10 +43,10 @@ class Flush extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'force',
@@ -58,10 +58,10 @@ class Flush extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return isset($this->body) ? 'POST' : 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/ForceMerge.php
+++ b/src/Elasticsearch/Endpoints/Indices/ForceMerge.php
@@ -17,10 +17,10 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  */
 class ForceMerge extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $uri   = "/_forcemerge";
@@ -32,10 +32,10 @@ class ForceMerge extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'flush',
@@ -49,10 +49,10 @@ class ForceMerge extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Get.php
+++ b/src/Elasticsearch/Endpoints/Indices/Get.php
@@ -20,11 +20,11 @@ class Get extends AbstractEndpoint
 {
     private $feature;
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->index) !== true) {
             throw new Exceptions\RuntimeException(
@@ -57,10 +57,10 @@ class Get extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'local',
@@ -72,10 +72,10 @@ class Get extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Mapping/Delete.php
+++ b/src/Elasticsearch/Endpoints/Indices/Mapping/Delete.php
@@ -18,11 +18,11 @@ use Elasticsearch\Common\Exceptions;
  */
 class Delete extends AbstractEndpoint
 {
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->index) !== true) {
             throw new Exceptions\RuntimeException(
@@ -45,20 +45,20 @@ class Delete extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'master_timeout',
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'DELETE';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Mapping/Get.php
+++ b/src/Elasticsearch/Endpoints/Indices/Mapping/Get.php
@@ -17,10 +17,10 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  */
 class Get extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $type = $this->type;
@@ -37,10 +37,10 @@ class Get extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'ignore_unavailable',
@@ -52,10 +52,10 @@ class Get extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Mapping/GetField.php
+++ b/src/Elasticsearch/Endpoints/Indices/Mapping/GetField.php
@@ -41,11 +41,11 @@ class GetField extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->fields) !== true) {
             throw new Exceptions\RuntimeException(
@@ -57,10 +57,10 @@ class GetField extends AbstractEndpoint
         return $uri.'/'.$this->fields;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'include_defaults',
@@ -72,10 +72,10 @@ class GetField extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Mapping/Put.php
+++ b/src/Elasticsearch/Endpoints/Indices/Mapping/Put.php
@@ -35,11 +35,11 @@ class Put extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         $index = $this->index ?? null;
         $type = $this->type ?? null;
@@ -61,10 +61,10 @@ class Put extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'ignore_conflicts',
@@ -91,10 +91,10 @@ class Put extends AbstractEndpoint
         return $this->body;
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'PUT';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Open.php
+++ b/src/Elasticsearch/Endpoints/Indices/Open.php
@@ -18,11 +18,11 @@ use Elasticsearch\Common\Exceptions;
  */
 class Open extends AbstractEndpoint
 {
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->index) !== true) {
             throw new Exceptions\RuntimeException(
@@ -39,10 +39,10 @@ class Open extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'timeout',
@@ -54,10 +54,10 @@ class Open extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Recovery.php
+++ b/src/Elasticsearch/Endpoints/Indices/Recovery.php
@@ -17,10 +17,10 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  */
 class Recovery extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $uri   = "/_recovery";
@@ -32,10 +32,10 @@ class Recovery extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'detailed',
@@ -44,10 +44,10 @@ class Recovery extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Refresh.php
+++ b/src/Elasticsearch/Endpoints/Indices/Refresh.php
@@ -17,10 +17,10 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  */
 class Refresh extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $uri   = "/_refresh";
@@ -32,10 +32,10 @@ class Refresh extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'ignore_unavailable',
@@ -46,10 +46,10 @@ class Refresh extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Rollover.php
+++ b/src/Elasticsearch/Endpoints/Indices/Rollover.php
@@ -68,11 +68,11 @@ class Rollover extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->alias) !== true) {
             throw new Exceptions\RuntimeException(
@@ -89,10 +89,10 @@ class Rollover extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'timeout',
@@ -102,10 +102,10 @@ class Rollover extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Seal.php
+++ b/src/Elasticsearch/Endpoints/Indices/Seal.php
@@ -18,11 +18,11 @@ use Elasticsearch\Common\Exceptions;
  */
 class Seal extends AbstractEndpoint
 {
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $uri   = "/_seal";
@@ -34,18 +34,18 @@ class Seal extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array();
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Segments.php
+++ b/src/Elasticsearch/Endpoints/Indices/Segments.php
@@ -17,10 +17,10 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  */
 class Segments extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $uri   = "/_segments";
@@ -32,10 +32,10 @@ class Segments extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'ignore_unavailable',
@@ -46,10 +46,10 @@ class Segments extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Settings/Get.php
+++ b/src/Elasticsearch/Endpoints/Indices/Settings/Get.php
@@ -40,10 +40,10 @@ class Get extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $name = $this->name;
@@ -60,10 +60,10 @@ class Get extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'ignore_unavailable',
@@ -75,10 +75,10 @@ class Get extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Settings/Put.php
+++ b/src/Elasticsearch/Endpoints/Indices/Settings/Put.php
@@ -35,10 +35,10 @@ class Put extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $uri   = "/_settings";
@@ -50,10 +50,10 @@ class Put extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'master_timeout',
@@ -78,10 +78,10 @@ class Put extends AbstractEndpoint
         return $this->body;
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'PUT';
     }

--- a/src/Elasticsearch/Endpoints/Indices/ShardStores.php
+++ b/src/Elasticsearch/Endpoints/Indices/ShardStores.php
@@ -19,11 +19,11 @@ use Elasticsearch\Common\Exceptions;
 
 class ShardStores extends AbstractEndpoint
 {
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $uri   = "/_shard_stores";
@@ -35,11 +35,10 @@ class ShardStores extends AbstractEndpoint
         return $uri;
     }
 
-
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'status',
@@ -50,11 +49,10 @@ class ShardStores extends AbstractEndpoint
         );
     }
 
-
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Shrink.php
+++ b/src/Elasticsearch/Endpoints/Indices/Shrink.php
@@ -59,12 +59,11 @@ class Shrink extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\BadMethodCallException
-     *
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\BadMethodCallException
+    */
+    public function getURI(): string
     {
         if (isset($this->index) !== true) {
             throw new Exceptions\RuntimeException(
@@ -86,10 +85,10 @@ class Shrink extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'timeout',
@@ -97,10 +96,10 @@ class Shrink extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         //TODO Fix Me!
         return 'PUT';

--- a/src/Elasticsearch/Endpoints/Indices/Split.php
+++ b/src/Elasticsearch/Endpoints/Indices/Split.php
@@ -52,11 +52,11 @@ class Split extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->index) !== true) {
             throw new Exceptions\RuntimeException(
@@ -75,10 +75,10 @@ class Split extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'copy_settings',
@@ -88,10 +88,10 @@ class Split extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'PUT';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Stats.php
+++ b/src/Elasticsearch/Endpoints/Indices/Stats.php
@@ -44,10 +44,10 @@ class Stats extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $metric = $this->metric;
@@ -64,10 +64,10 @@ class Stats extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'completion_fields',
@@ -82,10 +82,10 @@ class Stats extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Status.php
+++ b/src/Elasticsearch/Endpoints/Indices/Status.php
@@ -17,10 +17,10 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  */
 class Status extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $uri   = "/_status";
@@ -32,10 +32,10 @@ class Status extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'ignore_unavailable',
@@ -48,10 +48,10 @@ class Status extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Template/Delete.php
+++ b/src/Elasticsearch/Endpoints/Indices/Template/Delete.php
@@ -42,11 +42,11 @@ class Delete extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->name) !== true) {
             throw new Exceptions\RuntimeException(
@@ -63,10 +63,10 @@ class Delete extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'timeout',
@@ -74,10 +74,10 @@ class Delete extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'DELETE';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Template/Exists.php
+++ b/src/Elasticsearch/Endpoints/Indices/Template/Exists.php
@@ -41,11 +41,11 @@ class Exists extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->name) !== true) {
             throw new Exceptions\RuntimeException(
@@ -62,10 +62,10 @@ class Exists extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'local',
@@ -73,10 +73,10 @@ class Exists extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'HEAD';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Template/Get.php
+++ b/src/Elasticsearch/Endpoints/Indices/Template/Get.php
@@ -41,11 +41,11 @@ class Get extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         $name = $this->name;
         $uri   = "/_template";
@@ -57,10 +57,10 @@ class Get extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'flat_settings',
@@ -70,10 +70,10 @@ class Get extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Template/Put.php
+++ b/src/Elasticsearch/Endpoints/Indices/Template/Put.php
@@ -58,11 +58,11 @@ class Put extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->name) !== true) {
             throw new Exceptions\RuntimeException(
@@ -79,10 +79,10 @@ class Put extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'order',
@@ -107,10 +107,10 @@ class Put extends AbstractEndpoint
         return $this->body;
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'PUT';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Type/Exists.php
+++ b/src/Elasticsearch/Endpoints/Indices/Type/Exists.php
@@ -18,11 +18,11 @@ use Elasticsearch\Common\Exceptions;
  */
 class Exists extends AbstractEndpoint
 {
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->index) !== true) {
             throw new Exceptions\RuntimeException(
@@ -39,10 +39,10 @@ class Exists extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'ignore_unavailable',
@@ -52,10 +52,10 @@ class Exists extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'HEAD';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Upgrade/Get.php
+++ b/src/Elasticsearch/Endpoints/Indices/Upgrade/Get.php
@@ -25,10 +25,10 @@ use Elasticsearch\Common\Exceptions;
 class Get extends AbstractEndpoint
 {
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $uri   = "/_upgrade";
@@ -41,11 +41,10 @@ class Get extends AbstractEndpoint
         return $uri;
     }
 
-
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'wait_for_completion',
@@ -56,11 +55,10 @@ class Get extends AbstractEndpoint
         );
     }
 
-
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Upgrade/Post.php
+++ b/src/Elasticsearch/Endpoints/Indices/Upgrade/Post.php
@@ -25,10 +25,10 @@ use Elasticsearch\Common\Exceptions;
 class Post extends AbstractEndpoint
 {
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $uri   = "/_upgrade";
@@ -41,11 +41,10 @@ class Post extends AbstractEndpoint
         return $uri;
     }
 
-
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'wait_for_completion',
@@ -56,11 +55,10 @@ class Post extends AbstractEndpoint
         );
     }
 
-
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Indices/Validate/Query.php
+++ b/src/Elasticsearch/Endpoints/Indices/Validate/Query.php
@@ -35,18 +35,18 @@ class Query extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         return $this->getOptionalURI('_validate/query');
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'explain',
@@ -63,10 +63,10 @@ class Query extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Indices/ValidateQuery.php
+++ b/src/Elasticsearch/Endpoints/Indices/ValidateQuery.php
@@ -35,10 +35,10 @@ class ValidateQuery extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $type = $this->type;
@@ -53,10 +53,10 @@ class ValidateQuery extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'explain',
@@ -69,10 +69,10 @@ class ValidateQuery extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return isset($this->body) ? 'POST' : 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Info.php
+++ b/src/Elasticsearch/Endpoints/Info.php
@@ -15,29 +15,29 @@ namespace Elasticsearch\Endpoints;
  */
 class Info extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $uri   = "/";
 
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Ingest/Pipeline/Delete.php
+++ b/src/Elasticsearch/Endpoints/Ingest/Pipeline/Delete.php
@@ -18,11 +18,11 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  */
 class Delete extends AbstractEndpoint
 {
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->id) !== true) {
             throw new Exceptions\RuntimeException(
@@ -35,10 +35,10 @@ class Delete extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'master_timeout',
@@ -46,10 +46,10 @@ class Delete extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'DELETE';
     }

--- a/src/Elasticsearch/Endpoints/Ingest/Pipeline/Get.php
+++ b/src/Elasticsearch/Endpoints/Ingest/Pipeline/Get.php
@@ -18,11 +18,11 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  */
 class Get extends AbstractEndpoint
 {
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->id) !== true) {
             return '/_ingest/pipeline/*';
@@ -33,20 +33,20 @@ class Get extends AbstractEndpoint
         return "/_ingest/pipeline/$id";
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'master_timeout'
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Ingest/Pipeline/ProcessorGrok.php
+++ b/src/Elasticsearch/Endpoints/Ingest/Pipeline/ProcessorGrok.php
@@ -18,27 +18,27 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  */
 class ProcessorGrok extends AbstractEndpoint
 {
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         return "/_ingest/processor/grok";
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return [];
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Ingest/Pipeline/Put.php
+++ b/src/Elasticsearch/Endpoints/Ingest/Pipeline/Put.php
@@ -35,11 +35,11 @@ class Put extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->id) !== true) {
             throw new Exceptions\RuntimeException(
@@ -52,10 +52,10 @@ class Put extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'master_timeout',
@@ -63,10 +63,10 @@ class Put extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'PUT';
     }

--- a/src/Elasticsearch/Endpoints/Ingest/Simulate.php
+++ b/src/Elasticsearch/Endpoints/Ingest/Simulate.php
@@ -35,11 +35,11 @@ class Simulate extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->id) === true) {
             return "/_ingest/pipeline/{$this->id}/_simulate";
@@ -47,20 +47,20 @@ class Simulate extends AbstractEndpoint
         return "/_ingest/pipeline/_simulate";
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'verbose',
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return isset($this->body) ? 'POST' : 'GET';
     }

--- a/src/Elasticsearch/Endpoints/MPercolate.php
+++ b/src/Elasticsearch/Endpoints/MPercolate.php
@@ -50,18 +50,18 @@ class MPercolate extends AbstractEndpoint implements BulkEndpointInterface
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         return $this->getOptionalURI('_mpercolate');
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'ignore_unavailable',
@@ -70,10 +70,10 @@ class MPercolate extends AbstractEndpoint implements BulkEndpointInterface
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/MTermVectors.php
+++ b/src/Elasticsearch/Endpoints/MTermVectors.php
@@ -34,18 +34,18 @@ class MTermVectors extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         return $this->getOptionalURI('_mtermvectors');
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'ids',
@@ -62,10 +62,10 @@ class MTermVectors extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return isset($this->body) ? 'POST' : 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Mget.php
+++ b/src/Elasticsearch/Endpoints/Mget.php
@@ -34,10 +34,10 @@ class Mget extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $type = $this->type;
@@ -54,10 +54,10 @@ class Mget extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'fields',
@@ -87,10 +87,10 @@ class Mget extends AbstractEndpoint
         return $this->body;
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Msearch.php
+++ b/src/Elasticsearch/Endpoints/Msearch.php
@@ -52,10 +52,10 @@ class Msearch extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $type = $this->type;
@@ -72,10 +72,10 @@ class Msearch extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'search_type',
@@ -99,10 +99,10 @@ class Msearch extends AbstractEndpoint
         return $this->body;
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return isset($this->body) ? 'POST' : 'GET';
     }

--- a/src/Elasticsearch/Endpoints/MsearchTemplate.php
+++ b/src/Elasticsearch/Endpoints/MsearchTemplate.php
@@ -52,10 +52,10 @@ class MsearchTemplate extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $type = $this->type;
@@ -72,10 +72,10 @@ class MsearchTemplate extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'search_type',
@@ -97,10 +97,10 @@ class MsearchTemplate extends AbstractEndpoint
         return $this->body;
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return isset($this->body) ? 'POST' : 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Percolate.php
+++ b/src/Elasticsearch/Endpoints/Percolate.php
@@ -34,11 +34,11 @@ class Percolate extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->index) !== true) {
             throw new Exceptions\RuntimeException(
@@ -62,10 +62,10 @@ class Percolate extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'routing',
@@ -90,10 +90,10 @@ class Percolate extends AbstractEndpoint
         return $this->body;
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Ping.php
+++ b/src/Elasticsearch/Endpoints/Ping.php
@@ -15,29 +15,29 @@ namespace Elasticsearch\Endpoints;
  */
 class Ping extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $uri   = "/";
 
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'HEAD';
     }

--- a/src/Elasticsearch/Endpoints/RankEval.php
+++ b/src/Elasticsearch/Endpoints/RankEval.php
@@ -14,10 +14,10 @@ namespace Elasticsearch\Endpoints;
  */
 class RankEval extends AbstractEndpoint
 {
-    /**
-     * @return array
-     */
-    public function getParamWhitelist()
+   /**
+    * @return array
+    */
+    public function getParamWhitelist(): array
     {
         return [
             'ignore_unavailable',
@@ -26,10 +26,10 @@ class RankEval extends AbstractEndpoint
         ];
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index ?? null;
         if (isset($index)) {
@@ -38,10 +38,10 @@ class RankEval extends AbstractEndpoint
         return '/_rank_eval';
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Reindex.php
+++ b/src/Elasticsearch/Endpoints/Reindex.php
@@ -16,10 +16,10 @@ namespace Elasticsearch\Endpoints;
 class Reindex extends AbstractEndpoint
 {
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'slices',
@@ -31,18 +31,18 @@ class Reindex extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         return '/_reindex';
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Remote/Info.php
+++ b/src/Elasticsearch/Endpoints/Remote/Info.php
@@ -17,26 +17,26 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
  */
 class Info extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         return "/_remote/info";
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array();
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/RenderSearchTemplate.php
+++ b/src/Elasticsearch/Endpoints/RenderSearchTemplate.php
@@ -35,11 +35,11 @@ class RenderSearchTemplate extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         $id = $this->id;
 
@@ -52,10 +52,10 @@ class RenderSearchTemplate extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array();
     }
@@ -69,10 +69,10 @@ class RenderSearchTemplate extends AbstractEndpoint
         return $this->body;
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return isset($this->body) ? 'POST' : 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Script/Delete.php
+++ b/src/Elasticsearch/Endpoints/Script/Delete.php
@@ -18,11 +18,11 @@ use Elasticsearch\Common\Exceptions;
  */
 class Delete extends AbstractEndpoint
 {
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->id) !== true) {
             throw new Exceptions\RuntimeException(
@@ -35,10 +35,10 @@ class Delete extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'version',
@@ -46,10 +46,10 @@ class Delete extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'DELETE';
     }

--- a/src/Elasticsearch/Endpoints/Script/Get.php
+++ b/src/Elasticsearch/Endpoints/Script/Get.php
@@ -18,11 +18,11 @@ use Elasticsearch\Common\Exceptions;
  */
 class Get extends AbstractEndpoint
 {
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->id) !== true) {
             throw new Exceptions\RuntimeException(
@@ -35,10 +35,10 @@ class Get extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'version_type',
@@ -46,10 +46,10 @@ class Get extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Script/Put.php
+++ b/src/Elasticsearch/Endpoints/Script/Put.php
@@ -34,11 +34,11 @@ class Put extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->id) !== true) {
             throw new Exceptions\RuntimeException(
@@ -51,10 +51,10 @@ class Put extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'version_type',
@@ -63,10 +63,10 @@ class Put extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'PUT';
     }

--- a/src/Elasticsearch/Endpoints/ScriptsPainlessExecute.php
+++ b/src/Elasticsearch/Endpoints/ScriptsPainlessExecute.php
@@ -17,26 +17,26 @@ use Elasticsearch\Common\Exceptions\RuntimeException;
  */
 class ScriptsPainlessExecute extends AbstractEndpoint
 {
-    /**
-     * @return array
-     */
-    public function getParamWhitelist()
+   /**
+    * @return array
+    */
+    public function getParamWhitelist(): array
     {
         return [];
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         return "/_scripts/painless/_execute";
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return isset($this->body) ? 'POST' : 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Scroll.php
+++ b/src/Elasticsearch/Endpoints/Scroll.php
@@ -75,19 +75,19 @@ class Scroll extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $uri   = "/_search/scroll";
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'scroll',
@@ -95,10 +95,10 @@ class Scroll extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return isset($this->body) ? 'POST' : 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Search.php
+++ b/src/Elasticsearch/Endpoints/Search.php
@@ -35,10 +35,10 @@ class Search extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $type = $this->type;
@@ -55,10 +55,10 @@ class Search extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'analyzer',
@@ -110,10 +110,10 @@ class Search extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return isset($this->body) ? 'POST' : 'GET';
     }

--- a/src/Elasticsearch/Endpoints/SearchShards.php
+++ b/src/Elasticsearch/Endpoints/SearchShards.php
@@ -15,10 +15,10 @@ namespace Elasticsearch\Endpoints;
  */
 class SearchShards extends AbstractEndpoint
 {
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $type = $this->type;
@@ -35,10 +35,10 @@ class SearchShards extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'preference',
@@ -50,10 +50,10 @@ class SearchShards extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/SearchTemplate.php
+++ b/src/Elasticsearch/Endpoints/SearchTemplate.php
@@ -35,10 +35,10 @@ class SearchTemplate extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $index = $this->index;
         $type = $this->type;
@@ -55,10 +55,10 @@ class SearchTemplate extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'ignore_unavailable',
@@ -71,10 +71,10 @@ class SearchTemplate extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return isset($this->body) ? 'POST' : 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Snapshot/Create.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Create.php
@@ -81,11 +81,11 @@ class Create extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->repository) !== true) {
             throw new Exceptions\RuntimeException(
@@ -108,10 +108,10 @@ class Create extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'master_timeout',
@@ -119,10 +119,10 @@ class Create extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'PUT';
     }

--- a/src/Elasticsearch/Endpoints/Snapshot/Delete.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Delete.php
@@ -64,11 +64,11 @@ class Delete extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->repository) !== true) {
             throw new Exceptions\RuntimeException(
@@ -91,20 +91,20 @@ class Delete extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'master_timeout',
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'DELETE';
     }

--- a/src/Elasticsearch/Endpoints/Snapshot/Get.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Get.php
@@ -64,11 +64,11 @@ class Get extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->repository) !== true) {
             throw new Exceptions\RuntimeException(
@@ -91,10 +91,10 @@ class Get extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'master_timeout',
@@ -103,10 +103,10 @@ class Get extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Snapshot/Repository/Create.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Repository/Create.php
@@ -58,11 +58,11 @@ class Create extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->repository) !== true) {
             throw new Exceptions\RuntimeException(
@@ -79,10 +79,10 @@ class Create extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'master_timeout',
@@ -104,10 +104,10 @@ class Create extends AbstractEndpoint
         return $this->body;
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'PUT';
     }

--- a/src/Elasticsearch/Endpoints/Snapshot/Repository/Delete.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Repository/Delete.php
@@ -41,11 +41,11 @@ class Delete extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->repository) !== true) {
             throw new Exceptions\RuntimeException(
@@ -62,10 +62,10 @@ class Delete extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'master_timeout',
@@ -73,10 +73,10 @@ class Delete extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'DELETE';
     }

--- a/src/Elasticsearch/Endpoints/Snapshot/Repository/Get.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Repository/Get.php
@@ -40,10 +40,10 @@ class Get extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    */
+    public function getURI(): string
     {
         $repository = $this->repository;
         $uri   = "/_snapshot";
@@ -55,10 +55,10 @@ class Get extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'master_timeout',
@@ -66,10 +66,10 @@ class Get extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Snapshot/Repository/Verify.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Repository/Verify.php
@@ -41,11 +41,11 @@ class Verify extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         $repository = $this->repository;
         if (isset($this->repository) !== true) {
@@ -59,10 +59,10 @@ class Verify extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'master_timeout',
@@ -70,10 +70,10 @@ class Verify extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Snapshot/Restore.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Restore.php
@@ -80,11 +80,11 @@ class Restore extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->repository) !== true) {
             throw new Exceptions\RuntimeException(
@@ -107,10 +107,10 @@ class Restore extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'master_timeout',
@@ -118,10 +118,10 @@ class Restore extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Snapshot/Status.php
+++ b/src/Elasticsearch/Endpoints/Snapshot/Status.php
@@ -64,11 +64,11 @@ class Status extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->snapshot) === true && isset($this->repository) !== true) {
             throw new Exceptions\RuntimeException(
@@ -89,10 +89,10 @@ class Status extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'master_timeout',
@@ -100,10 +100,10 @@ class Status extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Source/Get.php
+++ b/src/Elasticsearch/Endpoints/Source/Get.php
@@ -18,11 +18,11 @@ use Elasticsearch\Common\Exceptions;
  */
 class Get extends AbstractEndpoint
 {
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->id) !== true) {
             throw new Exceptions\RuntimeException(
@@ -51,10 +51,10 @@ class Get extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'parent',
@@ -72,10 +72,10 @@ class Get extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Tasks/Cancel.php
+++ b/src/Elasticsearch/Endpoints/Tasks/Cancel.php
@@ -37,11 +37,11 @@ class Cancel extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->id) === true) {
             return "/_tasks/{$this->taskId}/_cancel";
@@ -50,10 +50,10 @@ class Cancel extends AbstractEndpoint
         return "/_tasks/_cancel";
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'node_id',
@@ -63,10 +63,10 @@ class Cancel extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/Tasks/Get.php
+++ b/src/Elasticsearch/Endpoints/Tasks/Get.php
@@ -37,11 +37,11 @@ class Get extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->taskId) === true) {
             return "/_tasks/{$this->taskId}";
@@ -50,20 +50,20 @@ class Get extends AbstractEndpoint
         return "/_tasks";
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'wait_for_completion'
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Tasks/TasksList.php
+++ b/src/Elasticsearch/Endpoints/Tasks/TasksList.php
@@ -19,19 +19,19 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
 class TasksList extends AbstractEndpoint
 {
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         return "/_tasks";
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'node_id',
@@ -45,10 +45,10 @@ class TasksList extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Template/Delete.php
+++ b/src/Elasticsearch/Endpoints/Template/Delete.php
@@ -18,11 +18,11 @@ use Elasticsearch\Common\Exceptions;
  */
 class Delete extends AbstractEndpoint
 {
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->id) !== true) {
             throw new Exceptions\RuntimeException(
@@ -35,18 +35,18 @@ class Delete extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array();
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'DELETE';
     }

--- a/src/Elasticsearch/Endpoints/Template/Get.php
+++ b/src/Elasticsearch/Endpoints/Template/Get.php
@@ -18,11 +18,11 @@ use Elasticsearch\Common\Exceptions;
  */
 class Get extends AbstractEndpoint
 {
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->id) !== true) {
             throw new Exceptions\RuntimeException(
@@ -35,18 +35,18 @@ class Get extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array();
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'GET';
     }

--- a/src/Elasticsearch/Endpoints/TermVectors.php
+++ b/src/Elasticsearch/Endpoints/TermVectors.php
@@ -34,11 +34,11 @@ class TermVectors extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->index) !== true) {
             throw new Exceptions\RuntimeException(
@@ -68,10 +68,10 @@ class TermVectors extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'term_statistics',
@@ -87,10 +87,10 @@ class TermVectors extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return isset($this->body) ? 'POST' : 'GET';
     }

--- a/src/Elasticsearch/Endpoints/Update.php
+++ b/src/Elasticsearch/Endpoints/Update.php
@@ -34,11 +34,11 @@ class Update extends AbstractEndpoint
         return $this;
     }
 
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\RuntimeException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\RuntimeException
+    */
+    public function getURI(): string
     {
         if (isset($this->id) !== true) {
             throw new Exceptions\RuntimeException(
@@ -67,10 +67,10 @@ class Update extends AbstractEndpoint
         return $uri;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return array(
             'consistency',
@@ -94,10 +94,10 @@ class Update extends AbstractEndpoint
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'POST';
     }

--- a/src/Elasticsearch/Endpoints/UpdateByQuery.php
+++ b/src/Elasticsearch/Endpoints/UpdateByQuery.php
@@ -39,12 +39,11 @@ class UpdateByQuery extends AbstractEndpoint
         return $this;
     }
 
-
-    /**
-     * @throws \Elasticsearch\Common\Exceptions\BadMethodCallException
-     * @return string
-     */
-    public function getURI()
+   /**
+    * @return string
+    * @throws Exceptions\BadMethodCallException
+    */
+    public function getURI(): string
     {
         if (!$this->index) {
             throw new Exceptions\RuntimeException(
@@ -60,11 +59,10 @@ class UpdateByQuery extends AbstractEndpoint
         return $uri;
     }
 
-
-    /**
-     * @return string[]
-     */
-    public function getParamWhitelist()
+   /**
+    * @return string[]
+    */
+    public function getParamWhitelist(): array
     {
         return [
             'analyzer',
@@ -116,11 +114,10 @@ class UpdateByQuery extends AbstractEndpoint
         ];
     }
 
-
-    /**
-     * @return string
-     */
-    public function getMethod()
+   /**
+    * @return string
+    */
+    public function getMethod(): string
     {
         return 'POST';
     }


### PR DESCRIPTION
PHP 7.4 complains now about return types on abstract functions. This is an issue for my using CirrusSearch mediawiki module. I see this is fixed in later branches but not for the 6.7.x stream
