### PR TITLE
Allow psr/log 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "php": "^7.3 || ^8.0",
     "ext-json": ">=1.3.7",
     "ezimuel/ringphp": "^1.1.2",
-    "psr/log": "~1.0"
+    "psr/log": "^1|^2"
   },
   "require-dev": {
     "symplify/git-wrapper": ">=9.0 <9.3.27",


### PR DESCRIPTION
This PR enables this library to be used with the updated `psr/log` interfaces. The current code is already compatible with version 2 of the interfaces.

There's also a version 3, but unfortunately it requires a return type to be added to `Elasticsearch\Common\EmptyLogger`. Adding that type could break userland code that extends `EmptyLogger`.