### PR TITLE
Fix typo on per-request-configuration.asciidoc

### DIFF
--- a/docs/per-request-configuration.asciidoc
+++ b/docs/per-request-configuration.asciidoc
@@ -253,7 +253,7 @@ Array
 
 It is possible to configure per-request curl timeouts via the `timeout` and 
 `connect_timeout` parameters. These control the client-side, curl timeouts. The 
-`connect_timeout` paramter controls how long curl should wait for the "connect" 
+`connect_timeout` parameter controls how long curl should wait for the "connect" 
 phase to finish, while the `timeout` parameter controls how long curl should 
 wait for the entire request to finish.
 


### PR DESCRIPTION
<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you signed [Contributor License Agreement](https://www.elastic.co/contributor-agreement)?
PR's (no matter how small) cannot be merged until the CLA has been signed.  It only needs to be signed once,
however.

- Have you read the [Contributing Guidelines](https://github.com/elastic/elasticsearch-php/blob/master/.github/CONTRIBUTING.md)?

If you answered yes to both, thanks for the PR and we'll get to it ASAP! :)

-->

Hello, i just noticed a tiny typo in this page : https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/per_request_configuration.html

Thanks <3 ! 

