### PR TITLE
Create ES 5.5.1 / PHP 8 backwards compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": "^5.6|^7.0",
+    "php": ">=5.6",
     "psr/log": "~1.0",
     "guzzlehttp/ringphp" : "~1.0"
   },

--- a/src/Elasticsearch/Client.php
+++ b/src/Elasticsearch/Client.php
@@ -32,7 +32,7 @@ use Elasticsearch\Namespaces\TasksNamespace;
  */
 class Client
 {
-    const VERSION = '5.5.0';
+    const VERSION = '5.5.1';
 
     /**
      * @var Transport

--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -326,7 +326,7 @@ class Connection implements ConnectionInterface
     private function getURI($uri, $params)
     {
         if (isset($params) === true && !empty($params)) {
-            array_walk($params, function (&$value, &$key) {
+            array_walk($params, function (&$value) {
                 if ($value === true) {
                     $value = 'true';
                 } else if ($value === false) {

--- a/src/Elasticsearch/Connections/ConnectionInterface.php
+++ b/src/Elasticsearch/Connections/ConnectionInterface.php
@@ -95,5 +95,5 @@ interface ConnectionInterface
      * @param \Elasticsearch\Transport $transport
      * @return mixed
      */
-    public function performRequest($method, $uri, $params = null, $body = null, $options = [], Transport $transport);
+    public function performRequest($method, $uri, $params = null, $body = null, $options = [], Transport $transport = null);
 }

--- a/src/Elasticsearch/Transport.php
+++ b/src/Elasticsearch/Transport.php
@@ -48,7 +48,7 @@ class Transport
      * @param ConnectionPool\AbstractConnectionPool $connectionPool
      * @param \Psr\Log\LoggerInterface $log    Monolog logger object
      */
-    public function __construct($retries, $sniffOnStart = false, AbstractConnectionPool $connectionPool, LoggerInterface $log)
+    public function __construct($retries, $sniffOnStart = false, AbstractConnectionPool $connectionPool = null, LoggerInterface $log = null)
     {
         $this->log            = $log;
         $this->connectionPool = $connectionPool;


### PR DESCRIPTION
This backports the changes suggested in https://github.com/elastic/elasticsearch-php/pull/1063#issuecomment-727770331 into the `5.x` branch (we're currently on `v5.4.0` and the latest is `v5.5.0`. Guess the PHP ES team is against backporting anything non-critical to ES5 or ES6.