### PR TITLE
Allow php 8.0+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": "^5.6|^7.0",
+    "php": "^5.6|^7.0|^8.0",
     "psr/log": "~1.0",
     "guzzlehttp/ringphp" : "~1.0"
   },


### PR DESCRIPTION
I would like to use the 5.x version with PHP 8. It already ran and installed fine with `"php": "^7.4 || ^8.0"`. However upon removing `^7.4 || ` I can not install this package version anymore. 

This intends fixing it