### PR TITLE
[DOCS] Fixing typo in connecting.asciidoc

### DIFF
--- a/docs/connecting.asciidoc
+++ b/docs/connecting.asciidoc
@@ -1,4 +1,4 @@
-[[connceting]]
+[[connecting]]
 == Connecting
 
 This page contains the information you need to connect and use the Client with 


### PR DESCRIPTION
This PR fixes a typo in the asciidoc. 

Currently, the word 'connecting' is misspelled in the URL: 
- https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/connceting.html
