### PR TITLE
Replace trait with abstract class to avoid Deprecated Functionality issue in PHP 8.1

### DIFF
--- a/src/Elasticsearch/Endpoints/Ml/PostData.php
+++ b/src/Elasticsearch/Endpoints/Ml/PostData.php
@@ -89,5 +89,4 @@ class PostData extends AbstractEndpoint
 
         return $this;
     }
-
 }

--- a/src/Elasticsearch/Namespaces/BooleanRequestWrapper.php
+++ b/src/Elasticsearch/Namespaces/BooleanRequestWrapper.php
@@ -24,7 +24,7 @@ use Elasticsearch\Endpoints\AbstractEndpoint;
 use Elasticsearch\Transport;
 use GuzzleHttp\Ring\Future\FutureArrayInterface;
 
-trait BooleanRequestWrapper
+abstract class BooleanRequestWrapper
 {
     /**
      * Perform Request


### PR DESCRIPTION
In PHP 8.1, Calling a static method directly on a trait is deprecated.
(see https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.core.static-trait)

Because of this, we receive such a deprecation notice when running our code with PHP8.1:
`Deprecated Functionality: Calling static trait method Elasticsearch\Namespaces\BooleanRequestWrapper::performRequest is deprecated, it should only be called on a class using the trait`

The simplest solution is to replace trait with abstract class.
We also can make  performRequest function non-static, but there will be naming conflicts (classes that use it already have the function with the same name). Thus there will more BIC changes.

