### PR TITLE
Fix #1176 rename includePortInHostHeader to setIncludePortInHostHeader

### DIFF
--- a/docs/http-meta-data.asciidoc
+++ b/docs/http-meta-data.asciidoc
@@ -39,7 +39,7 @@ as follows:
 [source,php]
 ----
 $client = Elasticsearch\ClientBuilder::create()
-    ->includePortInHostHeader(true)
+    ->setIncludePortInHostHeader(true)
     ->build();
 ----
 

--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -572,7 +572,7 @@ class ClientBuilder
      *
      * @see https://github.com/elastic/elasticsearch-php/issues/993
      */
-    public function includePortInHostHeader(bool $enable): ClientBuilder
+    public function setIncludePortInHostHeader(bool $enable): ClientBuilder
     {
         $this->includePortInHostHeader = $enable;
 


### PR DESCRIPTION
This PR modifies #997 by renaming the added method and therefore fixes #1176 as the aforementioned method is now accessible via `ClientBuilder` `fromConfig` as well.
