### PR TITLE
Fix for #1171 utf-16 issue in SmartSerializer

### DIFF
--- a/src/Elasticsearch/Serializers/SmartSerializer.php
+++ b/src/Elasticsearch/Serializers/SmartSerializer.php
@@ -88,7 +88,13 @@ class SmartSerializer implements SerializerInterface
             } catch (JsonException $e) {
                 switch ($e->getCode()) {
                     case JSON_ERROR_UTF16:
-                        return $this->decode(str_replace('\\', '\\\\', $data));
+                        try {
+                            $data = str_replace('\\', '\\\\', $data);
+                            $result = json_decode($data, true, 512, JSON_THROW_ON_ERROR);
+                            return $result;
+                        } catch (JsonException $e) {
+                            throw new JsonErrorException($e->getCode(), $data, $result ?? []);
+                        }
                 }
                 throw new JsonErrorException($e->getCode(), $data, $result ?? []);
             }

--- a/tests/Elasticsearch/Tests/Serializers/SmartSerializerTest.php
+++ b/tests/Elasticsearch/Tests/Serializers/SmartSerializerTest.php
@@ -45,4 +45,18 @@ class SmartSerializerTest extends TestCase
 
         $result = $this->serializer->deserialize('{ "foo" : bar" }', []);
     }
+
+    /**
+     * Single unpaired UTF-16 surrogate in unicode escape
+     * 
+     * @requires PHP 7.3
+     * @see https://github.com/elastic/elasticsearch-php/issues/1171
+     */
+    public function testSingleUnpairedUTF16SurrogateInUnicodeEscape()
+    {
+        $json = '{ "data": "ud83d\ude4f" }';
+
+        $result = $this->serializer->deserialize($json, []);
+        $this->assertEquals($result['data'], 'ud83d\ude4f');
+    }
 }


### PR DESCRIPTION
This PR contains the fix for #1171 related to single unpaired UTF-16 surrogate in unicode escape. In case of `JSON_ERROR_UTF16` the `SmartSerilizer::decode()` function escape the backslash `\` using the double backslash `\\`.