### PR TITLE
Fix #1176 adding includePortInHostHeader in fromConfig

### DIFF
--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -197,7 +197,8 @@ class ClientBuilder
     {
         $builder = new static;
         foreach ($config as $key => $value) {
-            $method = "set$key";
+            $allowedMethods = ['includePortInHostHeader']; // other available methods
+            $method = in_array($key, $allowedMethods) ? $key : "set$key";
             $reflection = new ReflectionClass($builder);
             if ($reflection->hasMethod($method)) {
                 $func = $reflection->getMethod($method);

--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -42,6 +42,8 @@ use ReflectionClass;
 
 class ClientBuilder
 {
+    const ALLOWED_METHODS_FROM_CONFIG = ['includePortInHostHeader'];
+
     /**
      * @var Transport
      */
@@ -197,8 +199,7 @@ class ClientBuilder
     {
         $builder = new static;
         foreach ($config as $key => $value) {
-            $allowedMethods = ['includePortInHostHeader']; // other available methods
-            $method = in_array($key, $allowedMethods) ? $key : "set$key";
+            $method = in_array($key, self::ALLOWED_METHODS_FROM_CONFIG) ? $key : "set$key";
             $reflection = new ReflectionClass($builder);
             if ($reflection->hasMethod($method)) {
                 $func = $reflection->getMethod($method);


### PR DESCRIPTION
This PR fixes #1176 adding includePortInHostHeader support in ClientBuilder::fromConfig.