### PR TITLE
Support `psr/log:^3`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "php": "^7.3 || ^8.0",
     "ext-json": ">=1.3.7",
     "ezimuel/ringphp": "^1.1.2",
-    "psr/log": "^1|^2"
+    "psr/log": "^1|^2|^3"
   },
   "require-dev": {
     "ext-yaml": "*",


### PR DESCRIPTION
See https://github.com/php-fig/log/compare/2.0.0...3.0.0

`psr/log:3.0.0` adds return types to all signatures: we don't implement `psr/log`, but only consume it, so we should be fine here.