### PR TITLE
[docs] Recommend simpleConnectionPool for Cloud

### DIFF
--- a/docs/connection-pool.asciidoc
+++ b/docs/connection-pool.asciidoc
@@ -78,8 +78,10 @@ The `SimpleConnectionPool` returns the next node as specified by the selector;
 it does not track node conditions. It returns nodes either they are dead or 
 alive. It is a simple pool of static hosts.
 
-The `SimpleConnectionPool` is not recommended for routine use but it may be a 
-useful debugging tool.
+The `SimpleConnectionPool` is recommended where the Elasticsearch deployment
+is located behnd a (reverse-) proxy or load balancer, where the individual
+Elasticsearch nodes are not visible to the client. This should be used when
+running Elasticsearch deployments on Cloud.
 
 To use the `SimpleConnectionPool`:
 


### PR DESCRIPTION
As per https://github.com/elastic/elasticsearch-php/issues/918#issuecomment-511337920 and https://elastic.slack.com/archives/CH37CF39S/p1643707941052409 we recommend using the `simpleConnectionPool` when there is a proxy or load balancer in place. This applies to Elasticsearch Service and ECE (Cloud). Hence the comments need to be updated.

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you signed [Contributor License Agreement](https://www.elastic.co/contributor-agreement)?
PR's (no matter how small) cannot be merged until the CLA has been signed.  It only needs to be signed once,
however.

- Have you read the [Contributing Guidelines](https://github.com/elastic/elasticsearch-php/blob/master/.github/CONTRIBUTING.md)?

If you answered yes to both, thanks for the PR and we'll get to it ASAP! :)

-->
