### PR TITLE
[8.1][DOCS] Fixes Connecting section ID

### DIFF
--- a/docs/connecting.asciidoc
+++ b/docs/connecting.asciidoc
@@ -1,4 +1,4 @@
-[[connceting]]
+[[connecting]]
 == Connecting
 
 This page contains the information you need to connect and use the Client with 


### PR DESCRIPTION
## Overview

The Connecting section section ID contains a type (`connceting` instead of `connecting`) on 8.1 and 8.0 which causes the docs build to fail. The rest of the branches are not effected. This PR and its backport fix the issue.