### PR TITLE
Added the array support for text/plain

### DIFF
--- a/src/Response/Elasticsearch.php
+++ b/src/Response/Elasticsearch.php
@@ -24,6 +24,7 @@ use Elastic\Transport\Exception\UnknownContentTypeException;
 use Elastic\Transport\Serializer\CsvSerializer;
 use Elastic\Transport\Serializer\JsonSerializer;
 use Elastic\Transport\Serializer\NDJsonSerializer;
+use Elastic\Transport\Serializer\TextSerializer;
 use Elastic\Transport\Serializer\XmlSerializer;
 use Psr\Http\Message\ResponseInterface;
 
@@ -111,6 +112,10 @@ class Elasticsearch implements ElasticsearchInterface, ResponseInterface, ArrayA
         }
         if (strpos($contentType, 'text/csv') !== false) {
             $this->asArray = CsvSerializer::unserialize($this->asString());
+            return $this->asArray;
+        }
+        if (strpos($contentType, 'text/plain') !== false) {
+            $this->asArray = [$this->asString()];
             return $this->asArray;
         }
         throw new UnknownContentTypeException(sprintf(

--- a/tests/Response/ElasticsearchTest.php
+++ b/tests/Response/ElasticsearchTest.php
@@ -200,4 +200,20 @@ class ElasticsearchTest extends TestCase
 
         $this->assertEquals($array['foo'], $this->elasticsearch->foo);
     }
+
+    /**
+     * @see https://github.com/elastic/elasticsearch-php/issues/1218
+     */
+    public function testAccessAsArrayWithTextPlainResponse()
+    {
+        $msg = "This is a text/plain response";
+        $body = $this->psr17Factory->createStream($msg);
+        $this->elasticsearch->setResponse(
+            $this->response200
+                ->withBody($body)
+                ->withHeader('Content-Type', 'text/plain')
+        );
+
+        $this->assertEquals($msg, $this->elasticsearch[0]);
+    }
 }


### PR DESCRIPTION
This PR adds the support of array in Elasticsearch response when the `Content-Type` is `text/plain`. This should solve #1218 