### PR TITLE
Add the API compatibility header in v8

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -29,7 +29,8 @@ final class Client
 {
     const CLIENT_NAME = 'es';
     const VERSION = '8.3.0';
-
+    const API_COMPATIBILITY_HEADER = 'application/vnd.elasticsearch+%s; compatible-with=8';
+    
     use ClientEndpointsTrait;
     use EndpointTrait;
     use NamespaceTrait;

--- a/src/Response/Elasticsearch.php
+++ b/src/Response/Elasticsearch.php
@@ -105,7 +105,8 @@ class Elasticsearch implements ElasticsearchInterface, ResponseInterface, ArrayA
             $this->asArray = JsonSerializer::unserialize($this->asString());
             return $this->asArray;
         }
-        if (strpos($contentType, 'application/x-ndjson') !== false) {
+        if (strpos($contentType, 'application/x-ndjson') !== false ||
+            strpos($contentType, 'application/vnd.elasticsearch+x-ndjson') !== false) {
             $this->asArray = NDJsonSerializer::unserialize($this->asString());
             return $this->asArray;
         }
@@ -132,12 +133,13 @@ class Elasticsearch implements ElasticsearchInterface, ResponseInterface, ArrayA
             return $this->asObject;
         }
         $contentType = $this->response->getHeaderLine('Content-Type');
-        if (strpos($contentType, 'application/json') !== false||
+        if (strpos($contentType, 'application/json') !== false ||
             strpos($contentType, 'application/vnd.elasticsearch+json') !== false) {
             $this->asObject = JsonSerializer::unserialize($this->asString(), ['type' => 'object']);
             return $this->asObject;
         }
-        if (strpos($contentType, 'application/x-ndjson') !== false) {
+        if (strpos($contentType, 'application/x-ndjson') !== false ||
+            strpos($contentType, 'application/vnd.elasticsearch+x-ndjson') !== false) {
             $this->asObject = NDJsonSerializer::unserialize($this->asString(), ['type' => 'object']);
             return $this->asObject;
         }

--- a/tests/Integration/MlTest.php
+++ b/tests/Integration/MlTest.php
@@ -14,6 +14,7 @@ declare(strict_types = 1);
 
 namespace Elastic\Elasticsearch\Tests\Integration;
 
+use Elastic\Elasticsearch\Client;
 use Elastic\Elasticsearch\Tests\Utility;
 use PHPUnit\Framework\TestCase;
 
@@ -88,7 +89,7 @@ class MlTest extends TestCase
 
         $this->assertEquals(202, $response->getStatusCode());
         $request = $this->client->getTransport()->getLastRequest();
-        $this->assertEquals(['application/json'], $request->getHeader('Content-Type'));
+        $this->assertEquals([sprintf(Client::API_COMPATIBILITY_HEADER, 'json')], $request->getHeader('Content-Type'));
     }
 
     /**
@@ -107,7 +108,7 @@ class MlTest extends TestCase
 
         $this->assertEquals(202, $response->getStatusCode());
         $request = $this->client->getTransport()->getLastRequest();
-        $this->assertEquals(['application/x-ndjson'], $request->getHeader('Content-Type'));
+        $this->assertEquals([sprintf(Client::API_COMPATIBILITY_HEADER, 'x-ndjson')], $request->getHeader('Content-Type'));
     }
 
     /**


### PR DESCRIPTION
This PR adds the API compatibility header in client v8. This should solve issue https://github.com/elastic/elasticsearch-php/issues/1221