### PR TITLE
Restore IndicesNamespace::deleteMapping() to keep backwards compatibility

### DIFF
--- a/src/Elasticsearch/Namespaces/IndicesNamespace.php
+++ b/src/Elasticsearch/Namespaces/IndicesNamespace.php
@@ -5,8 +5,8 @@
  * @link      https://github.com/elastic/elasticsearch-php/
  * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
- * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1 
- * 
+ * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
+ *
  * Licensed to Elasticsearch B.V under one or more agreements.
  * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
  * the GNU Lesser General Public License, Version 2.1, at your option.
@@ -1008,11 +1008,23 @@ class IndicesNamespace extends AbstractNamespace
 
     /**
      * Proxy to getAlias()
-     * 
+     *
      * @see https://github.com/elastic/elasticsearch-php/issues/1112
      */
     public function getAliases(array $params = [])
     {
         return $this->getAlias($params);
+    }
+
+    /**
+     * Does nothing. Only kept for backwards compatibility.
+     *
+     * @param array $params Associative array of parameters
+     *
+     * @return array
+     */
+    public function deleteMapping($params)
+    {
+        return [];
     }
 }


### PR DESCRIPTION
With 6.8.0, this method got removed, which broke the semantic
versioning contract.

This commit restores the method so that applications using that method do
not break.

See https://www.drupal.org/project/elasticsearch_connector/issues/2824539

Resolves: https://github.com/elastic/elasticsearch-php/issues/1235