### PR TITLE
Removed the usage of getenv, fixed #1237

### DIFF
--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -637,7 +637,9 @@ class ClientBuilder
             if (! isset($this->connectionParams['client']['headers'])) {
                 $this->connectionParams['client']['headers'] = [];
             }
-            $apiVersioning = $_SERVER['ELASTIC_CLIENT_APIVERSIONING'] ?? $_ENV['ELASTIC_CLIENT_APIVERSIONING'] ?? 'false';
+            $apiVersioning = $_SERVER['ELASTIC_CLIENT_APIVERSIONING']
+                ?? $_ENV['ELASTIC_CLIENT_APIVERSIONING']
+                ?? getenv('ELASTIC_CLIENT_APIVERSIONING');
             if (! isset($this->connectionParams['client']['headers']['Content-Type'])) {
                 if ($apiVersioning === 'true' || $apiVersioning === '1') {
                     $this->connectionParams['client']['headers']['Content-Type'] = ['application/vnd.elasticsearch+json;compatible-with=7'];

--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -637,7 +637,7 @@ class ClientBuilder
             if (! isset($this->connectionParams['client']['headers'])) {
                 $this->connectionParams['client']['headers'] = [];
             }
-            $apiVersioning = getenv('ELASTIC_CLIENT_APIVERSIONING');
+            $apiVersioning = $_SERVER['ELASTIC_CLIENT_APIVERSIONING'] ?? $_ENV['ELASTIC_CLIENT_APIVERSIONING'] ?? 'false';
             if (! isset($this->connectionParams['client']['headers']['Content-Type'])) {
                 if ($apiVersioning === 'true' || $apiVersioning === '1') {
                     $this->connectionParams['client']['headers']['Content-Type'] = ['application/vnd.elasticsearch+json;compatible-with=7'];

--- a/tests/Elasticsearch/Tests/ClientIntegrationTest.php
+++ b/tests/Elasticsearch/Tests/ClientIntegrationTest.php
@@ -59,7 +59,9 @@ class ClientIntegrationTest extends \PHPUnit\Framework\TestCase
             ->setHosts([$this->host])
             ->setLogger($this->logger);
 
-        $testSuite = $_SERVER['TEST_SUITE'] ?? $_ENV['TEST_SUITE'];
+        $testSuite = $_SERVER['TEST_SUITE'] 
+            ?? $_ENV['TEST_SUITE']
+            ?? getenv('TEST_SUITE');
         if ($testSuite === 'platinum') {
             $client->setSSLVerification(false);
         }

--- a/tests/Elasticsearch/Tests/ClientIntegrationTest.php
+++ b/tests/Elasticsearch/Tests/ClientIntegrationTest.php
@@ -59,7 +59,8 @@ class ClientIntegrationTest extends \PHPUnit\Framework\TestCase
             ->setHosts([$this->host])
             ->setLogger($this->logger);
 
-        if (getenv('TEST_SUITE') === 'platinum') {
+        $testSuite = $_SERVER['TEST_SUITE'] ?? $_ENV['TEST_SUITE'];
+        if ($testSuite === 'platinum') {
             $client->setSSLVerification(false);
         }
         return $client->build();

--- a/tests/Elasticsearch/Tests/Utility.php
+++ b/tests/Elasticsearch/Tests/Utility.php
@@ -60,7 +60,9 @@ class Utility
      */
     public static function getHost(): ?string
     {
-        $url = $_SERVER['ELASTICSEARCH_URL'] ?? $_ENV['ELASTICSEARCH_URL'];
+        $url = $_SERVER['ELASTICSEARCH_URL'] 
+            ?? $_ENV['ELASTICSEARCH_URL']
+            ?? getenv('ELASTICSEARCH_URL');
         if (false !== $url) {
             return $url;
         }

--- a/tests/Elasticsearch/Tests/Utility.php
+++ b/tests/Elasticsearch/Tests/Utility.php
@@ -60,7 +60,7 @@ class Utility
      */
     public static function getHost(): ?string
     {
-        $url = getenv('ELASTICSEARCH_URL');
+        $url = $_SERVER['ELASTICSEARCH_URL'] ?? $_ENV['ELASTICSEARCH_URL'];
         if (false !== $url) {
             return $url;
         }

--- a/util/build_tests.php
+++ b/util/build_tests.php
@@ -43,7 +43,7 @@ if (!is_dir(sprintf("%s/rest-spec/%s", __DIR__, $buildHash))) {
     exit(1);
 }
 
-$stack = getenv('TEST_SUITE');
+$stack = $_SERVER['TEST_SUITE'] ?? $_ENV['TEST_SUITE'];
 printf ("*****************************************\n");
 printf ("** Bulding YAML tests for %s suite\n", strtoupper($stack));
 printf ("*****************************************\n");


### PR DESCRIPTION
This PR removes the usage of `getenv()` because it's not thread safe. Fixes for #1237 