### PR TITLE
Updates bump action in make.sh for 8.5

### DIFF
--- a/.ci/make.sh
+++ b/.ci/make.sh
@@ -161,9 +161,6 @@ if [[ "$CMD" == "bump" ]]; then
     # Change version to src/Client.php
     sed -i "s/const VERSION = '[0-9]\+\.[0-9]\+\.[0-9]\+'/const VERSION = '$VERSION'/" $repo/src/Client.php
 
-    # Change version to .github/workflows/unified-release.yml
-    sed -i "s/[0-9]\+\.[0-9]\+\.[0-9]\+-SNAPSHOT/$VERSION-SNAPSHOT/" $repo/.github/workflows/unified-release.yml
-
     MINOR_VERSION=`echo $VERSION | grep -Eo "[0-9]+.[0-9]+"`
 
     # Change version to .ci/test-matrix.yml

--- a/.ci/test-matrix.yml
+++ b/.ci/test-matrix.yml
@@ -1,6 +1,6 @@
 ---
 STACK_VERSION:
-  - 8.4-SNAPSHOT
+  - 8.5-SNAPSHOT
 
 PHP_VERSION:
   - 8.1-cli

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         php-version: [7.4, 8.0, 8.1]
         os: [ubuntu-latest]
-        es-version: [8.4-SNAPSHOT]
+        es-version: [8.5-SNAPSHOT]
 
     steps:
     - name: Checkout

--- a/src/Client.php
+++ b/src/Client.php
@@ -28,7 +28,7 @@ use Psr\Log\LoggerInterface;
 final class Client implements ClientInterface
 {
     const CLIENT_NAME = 'es';
-    const VERSION = '8.5.1';
+    const VERSION = '8.5.2';
     const API_COMPATIBILITY_HEADER = '%s/vnd.elasticsearch+%s; compatible-with=8';
     
     use ClientEndpointsTrait;


### PR DESCRIPTION
The bump action failed since `unified-release.yml` is only present in `main`.
This PR updates `make.sh` and bumps the version for 8.5 after running `make.sh bump` locally.

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you signed [Contributor License Agreement](https://www.elastic.co/contributor-agreement)?
PR's (no matter how small) cannot be merged until the CLA has been signed.  It only needs to be signed once,
however.

- Have you read the [Contributing Guidelines](https://github.com/elastic/elasticsearch-php/blob/master/.github/CONTRIBUTING.md)?

If you answered yes to both, thanks for the PR and we'll get to it ASAP! :)

-->
