### PR TITLE
[8.2][DOCS] References shared/version and adds doctype to index file (#1280)

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,6 +1,9 @@
 
 = Elasticsearch-PHP
 
+:doctype:           book
+
+include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 include::overview.asciidoc[]

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -326,7 +326,7 @@ online document for more information.
   the phpdoc section (for example, 
   https://github.com/elastic/elasticsearch-php/blob/master/src/Elasticsearch/Client.php[$client->rankEval()]). 
   For more information read the 
-  https://www.elastic.co/guide/en/elasticsearch/client/php-api/master/experimental_and_beta_apis.html[experimental and beta APIs] 
+  https://www.elastic.co/guide/en/elasticsearch/client/php-api/{branch}/experimental_and_beta_apis.html[experimental and beta APIs] 
   section in the documentation. 
   https://github.com/elastic/elasticsearch-php/pull/966[#966]
 * Removed `AlreadyExpiredException` since it has been removed


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[DOCS] References shared/version and adds doctype to index file (#1280)](https://github.com/elastic/elasticsearch-php/pull/1280)
