### PR TITLE
[7.x][DOCS] References shared/version and adds doctype to index file (#1280) 

### DIFF
--- a/docs/community.asciidoc
+++ b/docs/community.asciidoc
@@ -151,6 +151,6 @@ _____________________
 This helper is a light library which wrap the official client elasticsearch-php. 
 It will help you to manage your ES Indices with no downtime. This helper 
 implements the philosophy described in the 
-https://www.elastic.co/guide/en/elasticsearch/guide/{branch}/index-aliases.html[official documentation]
+https://www.elastic.co/guide/en/elasticsearch/guide/current/index-aliases.html[official documentation]
 which can be summarized in a few words : *use alias instead of index directly*.
 _____________________

--- a/docs/community.asciidoc
+++ b/docs/community.asciidoc
@@ -151,6 +151,6 @@ _____________________
 This helper is a light library which wrap the official client elasticsearch-php. 
 It will help you to manage your ES Indices with no downtime. This helper 
 implements the philosophy described in the 
-https://www.elastic.co/guide/en/elasticsearch/guide/master/index-aliases.html[official documentation]
+https://www.elastic.co/guide/en/elasticsearch/guide/{branch}/index-aliases.html[official documentation]
 which can be summarized in a few words : *use alias instead of index directly*.
 _____________________

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,6 +1,9 @@
 
 = Elasticsearch PHP Client
 
+:doctype:           book
+
+include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 include::overview.asciidoc[]

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -255,7 +255,7 @@
   the phpdoc section (for example, 
   https://github.com/elastic/elasticsearch-php/blob/master/src/Elasticsearch/Client.php[$client->rankEval()]). 
   For more information read the 
-  https://www.elastic.co/guide/en/elasticsearch/client/php-api/master/experimental_and_beta_apis.html[experimental and beta APIs] 
+  https://www.elastic.co/guide/en/elasticsearch/client/php-api/{branch}/experimental_and_beta_apis.html[experimental and beta APIs] 
   section in the documentation. 
   https://github.com/elastic/elasticsearch-php/pull/966[#966]
 * Removed `AlreadyExpiredException` since it has been removed

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -255,7 +255,7 @@
   the phpdoc section (for example, 
   https://github.com/elastic/elasticsearch-php/blob/master/src/Elasticsearch/Client.php[$client->rankEval()]). 
   For more information read the 
-  https://www.elastic.co/guide/en/elasticsearch/client/php-api/{branch}/experimental_and_beta_apis.html[experimental and beta APIs] 
+  https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/experimental_and_beta_apis.html[experimental and beta APIs] 
   section in the documentation. 
   https://github.com/elastic/elasticsearch-php/pull/966[#966]
 * Removed `AlreadyExpiredException` since it has been removed


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.x`:
 - [[DOCS] References shared/version and adds doctype to index file (#1280)](https://github.com/elastic/elasticsearch-php/pull/1280)

It also changes a link in community integrations to use `current` instead of `master`.