### PR TITLE
Added ELASTIC_CLIENT_URL_PLUS_AS_SPACE env variable for URL encode

### DIFF
--- a/.ci/test-matrix.yml
+++ b/.ci/test-matrix.yml
@@ -3,6 +3,7 @@ STACK_VERSION:
   - 7.17-SNAPSHOT
   
 PHP_VERSION:
+  - 8.2-cli
   - 8.1-cli
   - 8.0-cli
   - 7.4-cli

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,10 +41,6 @@ jobs:
       run: |
         composer install --prefer-dist
 
-    - name: ignore ignore-platform-reqs if it is using php 8
-      run: |
-        composer install --prefer-dist
-
     - name: PHP Coding Standards
       run: |
         composer run-script phpcs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,5 +71,5 @@ jobs:
       run: |
         vendor/bin/phpunit -c phpunit-integration-tests.xml
       env:
-        TEST_SUITE: platinum
+        ELASTICSEARCH_URL: http://localhost:9200
         

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,42 +9,41 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [7.3, 7.4, 8.0, 8.1]
+        php-version: [7.3, 7.4, 8.0, 8.1, 8.2]
         os: [ubuntu-latest]
         es-version: [7.17-SNAPSHOT]
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Use PHP ${{ matrix.php-version }}
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-version }}
-        extensions: yaml
+        extensions: yaml, zip, curl
+        coverage: none
       env:
         COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+   
     - name: Get composer cache directory
       id: composercache
-      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ steps.composercache.outputs.dir }}
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-        restore-keys: ${{ runner.os }}-composer-
+        key: ${{ runner.os }}-php-${{ matrix.php-version }}-${{ hashFiles('**/composer.json') }}
+        restore-keys: ${{ runner.os }}-php-${{ matrix.php-version }}-
 
     - name: Install dependencies
-      if: ${{ matrix.php-version != '8.0' }}
       run: |
         composer install --prefer-dist
 
     - name: ignore ignore-platform-reqs if it is using php 8
-      if: ${{ matrix.php-version == '8.0' }}
       run: |
-        composer install --prefer-dist --ignore-platform-reqs
+        composer install --prefer-dist
 
     - name: PHP Coding Standards
       run: |
@@ -68,7 +67,7 @@ jobs:
         sudo sysctl -w vm.max_map_count=262144
 
     - name: Runs Elasticsearch ${{ matrix.es-version }}
-      uses: elastic/elastic-github-actions/elasticsearch@master
+      uses: elastic/elastic-github-actions/elasticsearch@trial-license
       with:
         stack-version: ${{ matrix.es-version }}
 
@@ -76,5 +75,5 @@ jobs:
       run: |
         vendor/bin/phpunit -c phpunit-integration-tests.xml
       env:
-        ELASTICSEARCH_URL: http://localhost:9200
+        TEST_SUITE: platinum
         

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "ext-yaml": "*",
     "ext-zip": "*",
     "mockery/mockery": "^1.2",
-    "phpstan/phpstan": "^0.12",
+    "phpstan/phpstan": "^1.10",
     "phpunit/phpunit": "^9.3",
     "squizlabs/php_codesniffer": "^3.4",
     "symfony/finder": "~4.0"
@@ -50,7 +50,10 @@
     }
   },
   "config": {
-    "sort-packages": true
+    "sort-packages": true,
+    "allow-plugins": {
+      "php-http/discovery": true
+    }
   },
   "scripts": {
     "phpcs": [

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,3 +7,4 @@ parameters:
         - '#Constant JSON_THROW_ON_ERROR not found#'
         - '#Caught class JsonException not found#'
         - '#Call to method getCode\(\) on an unknown class JsonException#'
+        - '#Variable \$\w+ in isset\(\) always exists and is not nullable#'

--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -372,7 +372,7 @@ class Connection implements ConnectionInterface
             $uri = $this->path . $uri;
         }
 
-        return $uri ?? '';
+        return $uri;
     }
 
     public function getHeaders(): array

--- a/src/Elasticsearch/Endpoints/AbstractEndpoint.php
+++ b/src/Elasticsearch/Endpoints/AbstractEndpoint.php
@@ -20,9 +20,7 @@ namespace Elasticsearch\Endpoints;
 
 use Elasticsearch\Common\Exceptions\UnexpectedValueException;
 use Elasticsearch\Serializers\SerializerInterface;
-use Elasticsearch\Transport;
-use Exception;
-use GuzzleHttp\Ring\Future\FutureArrayInterface;
+use Elasticsearch\Utility;
 
 abstract class AbstractEndpoint
 {
@@ -127,7 +125,7 @@ abstract class AbstractEndpoint
             $index = implode(",", $index);
         }
 
-        $this->index = urlencode($index);
+        $this->index = Utility::urlencode($index);
 
         return $this;
     }
@@ -155,7 +153,7 @@ abstract class AbstractEndpoint
             $type = implode(",", $type);
         }
 
-        $this->type = urlencode($type);
+        $this->type = Utility::urlencode($type);
 
         return $this;
     }
@@ -175,7 +173,7 @@ abstract class AbstractEndpoint
             $docID = (string) $docID;
         }
         
-        $this->id = urlencode($docID);
+        $this->id = Utility::urlencode($docID);
 
         return $this;
     }

--- a/src/Elasticsearch/Serializers/SmartSerializer.php
+++ b/src/Elasticsearch/Serializers/SmartSerializer.php
@@ -93,10 +93,10 @@ class SmartSerializer implements SerializerInterface
                             $result = json_decode($data, true, 512, JSON_THROW_ON_ERROR);
                             return $result;
                         } catch (JsonException $e) {
-                            throw new JsonErrorException($e->getCode(), $data, $result ?? []);
+                            throw new JsonErrorException($e->getCode(), $data, []);
                         }
                 }
-                throw new JsonErrorException($e->getCode(), $data, $result ?? []);
+                throw new JsonErrorException($e->getCode(), $data, []);
             }
         }
 

--- a/src/Elasticsearch/Utility.php
+++ b/src/Elasticsearch/Utility.php
@@ -18,7 +18,7 @@ namespace Elasticsearch;
 
 class Utility
 {
-    const ENV_URL_PLUS_AS_SPACE = 'ES_URL_PLUS_AS_SPACE';
+    const ENV_URL_PLUS_AS_SPACE = 'ELASTIC_CLIENT_URL_PLUS_AS_SPACE';
 
     /**
      * Get the ENV variable with a thread safe fallback criteria

--- a/src/Elasticsearch/Utility.php
+++ b/src/Elasticsearch/Utility.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Elasticsearch PHP client
+ *
+ * @link      https://github.com/elastic/elasticsearch-php/
+ * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
+ * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1 
+ * 
+ * Licensed to Elasticsearch B.V under one or more agreements.
+ * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
+ * the GNU Lesser General Public License, Version 2.1, at your option.
+ * See the LICENSE file in the project root for more information.
+ */
+declare(strict_types = 1);
+
+namespace Elasticsearch;
+
+class Utility
+{
+    const ENV_URL_PLUS_AS_SPACE = 'ES_URL_PLUS_AS_SPACE';
+
+    /**
+     * Get the ENV variable with a thread safe fallback criteria
+     * @see https://github.com/elastic/elasticsearch-php/issues/1237
+     * 
+     * @return string | false
+     */
+    public static function getEnv(string $env)
+    {
+        return $_SERVER[$env] ?? $_ENV[$env] ?? getenv($env);
+    }
+
+    /**
+     * Encode a string in URL using urlencode() or rawurlencode()
+     * according to env variable ES_URL_PLUS_AS_SPACE.
+     * If ES_URL_PLUS_AS_SPACE is true use urlencode(), otherwise rawurlencode()
+     * 
+     * @see https://github.com/elastic/elasticsearch-php/issues/1278
+     */
+    public static function urlencode(string $url): string
+    {
+        return self::getEnv(self::ENV_URL_PLUS_AS_SPACE) === 'true'
+            ? rawurlencode($url)
+            : urlencode($url);
+    }
+}

--- a/tests/Elasticsearch/Tests/ConnectionPool/Selectors/RoundRobinSelectorTest.php
+++ b/tests/Elasticsearch/Tests/ConnectionPool/Selectors/RoundRobinSelectorTest.php
@@ -22,7 +22,7 @@ use Elasticsearch;
 use Elasticsearch\Connections\ConnectionInterface;
 
 /**
- * Class SnifferTest
+ * Class RoundRobinSelectorTest
  *
  * @subpackage Tests\ConnectionPool\RoundRobinSelectorTest
  */

--- a/tests/Elasticsearch/Tests/ConnectionPool/Selectors/StickyRoundRobinSelectorTest.php
+++ b/tests/Elasticsearch/Tests/ConnectionPool/Selectors/StickyRoundRobinSelectorTest.php
@@ -29,6 +29,11 @@ use Mockery as m;
  */
 class StickyRoundRobinSelectorTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @var Elasticsearch\ConnectionPool\Selectors\StickyRoundRobinSelector
+     */
+    protected $roundRobin;
+
     public function setUp(): void
     {
         $this->roundRobin = new Elasticsearch\ConnectionPool\Selectors\StickyRoundRobinSelector();

--- a/tests/Elasticsearch/Tests/Serializers/SmartSerializerTest.php
+++ b/tests/Elasticsearch/Tests/Serializers/SmartSerializerTest.php
@@ -20,7 +20,6 @@ namespace Elasticsearch\Tests\Serializers;
 
 use Elasticsearch\Common\Exceptions\Serializer\JsonErrorException;
 use Elasticsearch\Serializers\SmartSerializer;
-use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -29,6 +28,11 @@ use PHPUnit\Framework\TestCase;
  */
 class SmartSerializerTest extends TestCase
 {
+    /**
+     * @var SmartSerializer
+     */
+    protected $serializer;
+
     public function setUp(): void
     {
         $this->serializer = new SmartSerializer();

--- a/tests/Elasticsearch/Tests/TransportTest.php
+++ b/tests/Elasticsearch/Tests/TransportTest.php
@@ -32,6 +32,27 @@ use React\Promise\Promise;
 
 class TransportTest extends TestCase
 {
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+    /**
+     * @var LoggerInterface
+     */
+    protected $trace;
+    /**
+     * @var SerializerInterface
+     */
+    protected $serializer;
+    /**
+     * @var AbstractConnectionPool
+     */
+    protected $connectionPool;
+    /**
+     * @var Connection
+     */
+    protected $connection;
+
     public function setUp(): void
     {
         $this->logger = $this->createMock(LoggerInterface::class);

--- a/tests/Elasticsearch/Tests/UtilityTest.php
+++ b/tests/Elasticsearch/Tests/UtilityTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Elasticsearch PHP client
+ *
+ * @link      https://github.com/elastic/elasticsearch-php/
+ * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
+ * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
+ *
+ * Licensed to Elasticsearch B.V under one or more agreements.
+ * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
+ * the GNU Lesser General Public License, Version 2.1, at your option.
+ * See the LICENSE file in the project root for more information.
+ */
+
+
+declare(strict_types = 1);
+
+namespace Elasticsearch\Tests;
+
+use Elasticsearch\Utility;
+use PHPUnit\Framework\TestCase;
+
+class UtilityTest extends TestCase
+{
+    public function tearDown(): void
+    {
+        unset($_SERVER[Utility::ENV_URL_PLUS_AS_SPACE]);
+        unset($_ENV[Utility::ENV_URL_PLUS_AS_SPACE]);
+        putenv(Utility::ENV_URL_PLUS_AS_SPACE);
+    }
+
+    public function testGetEnvWithDollarServer()
+    {
+        $_SERVER[Utility::ENV_URL_PLUS_AS_SPACE] = 'true';
+        $this->assertEquals('true', Utility::getEnv(Utility::ENV_URL_PLUS_AS_SPACE));
+    }
+
+    public function testGetEnvWithDollarEnv()
+    {
+        $_ENV[Utility::ENV_URL_PLUS_AS_SPACE] = 'true';
+        $this->assertEquals('true', Utility::getEnv(Utility::ENV_URL_PLUS_AS_SPACE));
+    }
+
+    public function testGetEnvWithPutEnv()
+    {
+        putenv(Utility::ENV_URL_PLUS_AS_SPACE . '=true');
+        $this->assertEquals('true', Utility::getEnv(Utility::ENV_URL_PLUS_AS_SPACE));
+    }
+
+    public function testUrlencodeWithDefault()
+    {
+        $url = Utility::urlencode('bar baz');
+        $this->assertEquals('bar+baz', $url);
+    }
+
+    public function testUrlencodeWithDollarServer()
+    {
+        $_SERVER[Utility::ENV_URL_PLUS_AS_SPACE] = 'true';   
+        $url = Utility::urlencode('bar baz');
+        $this->assertEquals('bar%20baz', $url);
+    }
+
+    public function testUrlencodeWithDollarEnv()
+    {
+        $_ENV[Utility::ENV_URL_PLUS_AS_SPACE] = 'true';   
+        $url = Utility::urlencode('bar baz');
+        $this->assertEquals('bar%20baz', $url);
+    }
+
+    public function testUrlencodeWithPutEnv()
+    {
+        putenv(Utility::ENV_URL_PLUS_AS_SPACE . '=true');   
+        $url = Utility::urlencode('bar baz');
+        $this->assertEquals('bar%20baz', $url);
+    }
+}


### PR DESCRIPTION
This PR should fix #1278 adding an env variable `ELASTIC_CLIENT_URL_PLUS_AS_SPACE` that can be used to enable the URL encoder for translate a space character with `%20` instead of `+`. The default value for the space character is `+`, to prevent BC break.
