### PR TITLE
[DOCS] Changes getting started button link on landing page

### DIFF
--- a/docs/index-custom-title-page.html
+++ b/docs/index-custom-title-page.html
@@ -63,7 +63,7 @@
         The official PHP client provides a low-level client for communicating with an Elasticsearch cluster.
       </p>
       <p>
-        <a href="https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/overview.html">
+        <a href="https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/getting-started-php.html">
           <button class="btn btn-primary">Get started</button>
         </a>
       </p>


### PR DESCRIPTION
## Overview

This PR changes the URL of the getting started button on the landing page.

