### PR TITLE
Fix Response\Elasticsearch::offsetGet return type deprecation

### DIFF
--- a/src/Response/Elasticsearch.php
+++ b/src/Response/Elasticsearch.php
@@ -196,6 +196,8 @@ class Elasticsearch implements ElasticsearchInterface, ResponseInterface, ArrayA
      * ArrayAccess interface
      * 
      * @see https://www.php.net/manual/en/class.arrayaccess.php
+     *
+     * @return mixed
      */
     #[\ReturnTypeWillChange]
     public function offsetGet($offset)


### PR DESCRIPTION
"ArrayAccess::offsetGet()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "Elastic\Elasticsearch\Response\Elasticsearch" now to avoid errors or add an explicit @return annotation to suppress this message.