### PR TITLE
Fix `Response\Elasticsearch::offsetGet()` return type declaration

### DIFF
--- a/src/Response/Elasticsearch.php
+++ b/src/Response/Elasticsearch.php
@@ -196,6 +196,8 @@ class Elasticsearch implements ElasticsearchInterface, ResponseInterface, ArrayA
      * ArrayAccess interface
      * 
      * @see https://www.php.net/manual/en/class.arrayaccess.php
+     *
+     * @return mixed
      */
     #[\ReturnTypeWillChange]
     public function offsetGet($offset)


### PR DESCRIPTION
Fixes #1384
