### PR TITLE
Add big `/docs` dir back to export-ignore in gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,5 +10,5 @@
 /phpunit-yaml-free-tests.xml export-ignore
 /phpunit-yaml-platinum-tests.xml export-ignore
 /phpunit.xml.dist export-ignore
-#/docs export-ignore
+/docs export-ignore
 /.buildkite export-ignore


### PR DESCRIPTION
The directory is quite big, no need to package that along with the SDK when installing using composer

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you signed [Contributor License Agreement](https://www.elastic.co/contributor-agreement)?
PR's (no matter how small) cannot be merged until the CLA has been signed.  It only needs to be signed once,
however.

- Have you read the [Contributing Guidelines](https://github.com/elastic/elasticsearch-php/blob/master/.github/CONTRIBUTING.md)?

If you answered yes to both, thanks for the PR and we'll get to it ASAP! :)

-->
