### PR TITLE
[DOCS] Adds section about version compatibility to overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,25 @@ the major version of the corresponding Enterprise Search implementation.
 For example, for Elasticsearch `7.16`, use `7.16` of this library or above, but
 not `8.0`.
 
+## Compatibility
+
+The Elasticsearch client is compatible with currently maintained PHP versions.
+
+Language clients are forward compatible; meaning that clients support
+communicating with greater or equal minor versions of Elasticsearch without
+breaking. It does not mean that the client automatically supports new features
+of newer Elasticsearch versions; it is only possible after a release of a new
+client version. For example, a 8.12 client version won't automatically support
+the new features of the 8.13 version of Elasticsearch, the 8.13 client version
+is required for that. Elasticsearch language clients are only backwards
+compatible with default distributions and without guarantees made.
+
+| Elasticsearch Version | Elasticsearch-PHP Branch | Supported |
+| --------------------- | ------------------------ | --------- |
+| main                  | main                     |           |
+| 8.x                   | 8.x                      | 8.x       |
+| 7.x                   | 7.x                      | 7.17      |
+
 ## Backward Incompatible Changes :boom:
 
 The 8.0.0 version of `elasticsearch-php` contains a new implementation compared

--- a/docs/overview.asciidoc
+++ b/docs/overview.asciidoc
@@ -24,6 +24,31 @@ standard is a community effort that contains a set of interfaces defined by the
 PHP Framework Interop Group. For more information, refer to the 
 https://www.php-fig.org/psr/psr-7/[PSR 7 standard documentation].
 
+
+[discrete]
+[[version-compatibility]]
+=== {es} and PHP version Compatibility
+
+The {es} client is compatible with currently maintained PHP versions.
+
+Language clients are forward compatible; meaning that clients support
+communicating with greater or equal minor versions of {es} without breaking. It
+does not mean that the client automatically supports new features of newer {es} 
+versions; it is only possible after a release of a new client version. For
+example, a 8.12 client version won't automatically support the new features of
+the 8.13 version of {es}, the 8.13 client version is required for that.
+{es} language clients are only backwards compatible with default distributions
+and without guarantees made.
+
+|===
+| Elasticsearch Version | Elasticsearch-PHP Branch | Supported
+
+| main                  | main                     | 
+| 8.x                   | 8.x                      | 8.x
+| 7.x                   | 7.x                      | 7.17
+|===
+
+
 * <<breaking_changes>>
 
 include::breaking-changes.asciidoc[]


### PR DESCRIPTION
## Overview

This PR adds a compatibility matrix to the Overview section of the PHP book and the repo README.

### Preview

[Version compatibility](https://elasticsearch-php_bk_1394.docs-preview.app.elstc.co/guide/en/elasticsearch/client/php-api/master/overview.html#version-compatibility)