### PR TITLE
7.x - Run CI against PHP 8.3

### DIFF
--- a/.ci/test-matrix.yml
+++ b/.ci/test-matrix.yml
@@ -3,6 +3,7 @@ STACK_VERSION:
   - 7.17-SNAPSHOT
   
 PHP_VERSION:
+  - 8.3-cli
   - 8.2-cli
   - 8.1-cli
   - 8.0-cli

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [7.3, 7.4, 8.0, 8.1, 8.2]
+        php-version: [7.3, 7.4, 8.0, 8.1, 8.2, 8.3]
         os: [ubuntu-latest]
         es-version: [7.17-SNAPSHOT]
 


### PR DESCRIPTION
<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you signed [Contributor License Agreement](https://www.elastic.co/contributor-agreement)?
PR's (no matter how small) cannot be merged until the CLA has been signed.  It only needs to be signed once,
however.

- Have you read the [Contributing Guidelines](https://github.com/elastic/elasticsearch-php/blob/master/.github/CONTRIBUTING.md)?

If you answered yes to both, thanks for the PR and we'll get to it ASAP! :)

-->

This runs `elasticsearch/elasticsearch` 7.x CI against PHP 8.3. `composer.json` allows PHP 8.3 (`"php": "^7.3 || ^8.0",`) but the tests are not currently being executed against 8.3.

Please let me know if I missed/forgot anything in this PR.