### PR TITLE
(Code) docs: Add inline PHPDoc with endpoint var type

### DIFF
--- a/util/template/endpoint-function
+++ b/util/template/endpoint-function
@@ -3,6 +3,7 @@
     {
 :extract
         $endpointBuilder = $this->endpoints;
+        /** @var \Elasticsearch\Endpoints\:EndpointClass $endpoint */
         $endpoint = $endpointBuilder(':EndpointClass');
         $endpoint->setParams($params);
 :setparam

--- a/util/template/endpoint-function-bool
+++ b/util/template/endpoint-function-bool
@@ -6,6 +6,7 @@
         $params['client']['verbose'] = true;
 
         $endpointBuilder = $this->endpoints;
+        /** @var \Elasticsearch\Endpoints\:EndpointClass $endpoint */
         $endpoint = $endpointBuilder(':EndpointClass');
         $endpoint->setParams($params);
 :setparam


### PR DESCRIPTION
Added inline PHPDoc with variable type for `$endpoint` so it can be navigated to easily, for example when debugging what request URI is called, etc.