### PR TITLE
Added PHP 8.4 Support for Elasticsearch 7.17 || 7.x Compatibility

### DIFF
--- a/.ci/test-matrix.yml
+++ b/.ci/test-matrix.yml
@@ -3,6 +3,7 @@ STACK_VERSION:
   - 7.17-SNAPSHOT
   
 PHP_VERSION:
+  - 8.4-cli
   - 8.3-cli
   - 8.2-cli
   - 8.1-cli

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [7.3, 7.4, 8.0, 8.1, 8.2, 8.3]
+        php-version: [7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
         os: [ubuntu-latest]
         es-version: [7.17-SNAPSHOT]
 

--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -527,7 +527,7 @@ class ClientBuilder
      * @param string $cert The name of a file containing a PEM formatted certificate.
      * @param string $password if the certificate requires a password
      */
-    public function setSSLCert(string $cert, string $password = null): ClientBuilder
+    public function setSSLCert(string $cert, ?string $password = null): ClientBuilder
     {
         $this->sslCert = [$cert, $password];
 
@@ -540,7 +540,7 @@ class ClientBuilder
      * @param string $key The name of a file containing a private SSL key
      * @param string $password if the private key requires a password
      */
-    public function setSSLKey(string $key, string $password = null): ClientBuilder
+    public function setSSLKey(string $key, ?string $password = null): ClientBuilder
     {
         $this->sslKey = [$key, $password];
 

--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -255,7 +255,7 @@ class Connection implements ConnectionInterface
 
     private function wrapHandler(callable $handler): callable
     {
-        return function (array $request, Connection $connection, ?Transport $transport = null, $options) use ($handler) {
+        return function (array $request, Connection $connection, $options, ?Transport $transport = null) use ($handler) {
 
             $this->lastRequest = [];
             $this->lastRequest['request'] = $request;

--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -201,7 +201,7 @@ class Connection implements ConnectionInterface
      * @param  Transport $transport
      * @return mixed
      */
-    public function performRequest(string $method, string $uri, ?array $params = [], $body = null, array $options = [], Transport $transport = null)
+    public function performRequest(string $method, string $uri, ?array $params = [], $body = null, array $options = [], ?Transport $transport = null)
     {
         if ($body !== null) {
             $body = $this->serializer->serialize($body);
@@ -255,7 +255,7 @@ class Connection implements ConnectionInterface
 
     private function wrapHandler(callable $handler): callable
     {
-        return function (array $request, Connection $connection, Transport $transport = null, $options) use ($handler) {
+        return function (array $request, Connection $connection, ?Transport $transport = null, $options) use ($handler) {
 
             $this->lastRequest = [];
             $this->lastRequest['request'] = $request;

--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -255,7 +255,7 @@ class Connection implements ConnectionInterface
 
     private function wrapHandler(callable $handler): callable
     {
-        return function (array $request, Connection $connection, $options, ?Transport $transport = null) use ($handler) {
+        return function (array $request, Connection $connection, ?Transport $transport = null, array $options = []) use ($handler) {
 
             $this->lastRequest = [];
             $this->lastRequest['request'] = $request;

--- a/src/Elasticsearch/Connections/ConnectionInterface.php
+++ b/src/Elasticsearch/Connections/ConnectionInterface.php
@@ -75,5 +75,5 @@ interface ConnectionInterface
      * @param  null $body
      * @return mixed
      */
-    public function performRequest(string $method, string $uri, ?array $params = [], $body = null, array $options = [], Transport $transport = null);
+    public function performRequest(string $method, string $uri, ?array $params = [], $body = null, array $options = [], ?Transport $transport = null);
 }


### PR DESCRIPTION
This MR introduces support for PHP 8.4 in conjunction with Elasticsearch 7.17. The changes ensure compatibility between the latest PHP features and the Elasticsearch client. Key updates include:

- Adjustments to type declarations and method signatures to align with PHP 8.4 standards.
- Updated dependencies and configurations to support PHP 8.4 runtime.
- Verified backward compatibility with PHP 8.3 and earlier versions.

These changes were thoroughly tested to maintain the stability and reliability of the integration while leveraging the latest PHP advancements.