### PR TITLE
6.8.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [7.3, 7.4, 8.0, 8.1, 8.2, 8.3]
+        php-version: [7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
         os: [ubuntu-latest]
         es-version: [6.8-SNAPSHOT]
 

--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -394,7 +394,7 @@ class ClientBuilder
      * @param null|string $password
      * @return $this
      */
-    public function setSSLCert(string $cert, string $password = null): ClientBuilder
+    public function setSSLCert(string $cert, ?string $password = null): ClientBuilder
     {
         $this->sslCert = [$cert, $password];
 
@@ -406,7 +406,7 @@ class ClientBuilder
      * @param null|string $password
      * @return $this
      */
-    public function setSSLKey(string $key, string $password = null): ClientBuilder
+    public function setSSLKey(string $key, ?string $password = null): ClientBuilder
     {
         $this->sslKey = [$key, $password];
 

--- a/src/Elasticsearch/Connections/Connection.php
+++ b/src/Elasticsearch/Connections/Connection.php
@@ -174,7 +174,7 @@ class Connection implements ConnectionInterface
      * @param \Elasticsearch\Transport $transport
      * @return mixed
      */
-    public function performRequest($method, $uri, $params = null, $body = null, $options = [], Transport $transport = null)
+    public function performRequest($method, $uri, $params = null, $body = null, $options = [], ?Transport $transport = null)
     {
         if ($body !== null) {
             $body = $this->serializer->serialize($body);
@@ -226,7 +226,7 @@ class Connection implements ConnectionInterface
 
     private function wrapHandler(callable $handler)
     {
-        return function (array $request, Connection $connection, Transport $transport = null, $options) use ($handler) {
+        return function (array $request, Connection $connection, ?Transport $transport = null, $options = []) use ($handler) {
 
             $this->lastRequest = [];
             $this->lastRequest['request'] = $request;

--- a/src/Elasticsearch/Connections/ConnectionInterface.php
+++ b/src/Elasticsearch/Connections/ConnectionInterface.php
@@ -112,6 +112,6 @@ interface ConnectionInterface
      */
 	// @codingStandardsIgnoreStart
 	// "Arguments with default values must be at the end of the argument list" - cannot change the interface
-    public function performRequest(string $method, string $uri, ?array $params = [], $body = null, array $options = [], Transport $transport = null);
+    public function performRequest(string $method, string $uri, ?array $params = [], $body = null, array $options = [], ?Transport $transport = null);
 	// @codingStandardsIgnoreEnd
 }


### PR DESCRIPTION
This PR goes in line with #1417 to add PHP 8.4 support to the 6.8.x branch.

It fixes a common problem with [implicitly nullable parameters being deprecated in PHP 8.4](https://www.php.net/manual/en/migration84.deprecated.php#migration84.deprecated.core.implicitly-nullable-parameter).

The changes are backwards compatible till PHP 7.1 and should be good to go.

Thank you in advance!