### PR TITLE
Fix optional array keys in PHPDocs

### DIFF
--- a/src/Endpoints/Indices.php
+++ b/src/Endpoints/Indices.php
@@ -36,16 +36,16 @@ class Indices extends AbstractEndpoint
 	 * @param array{
 	 *     index: list, // (REQUIRED) A comma separated list of indices to add a block to
 	 *     block: string, // (REQUIRED) The block to add (one of read, write, read_only or metadata)
-	 *     timeout: time, // Explicit operation timeout
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     allow_no_indices: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-	 *     expand_wildcards: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     timeout?: time, // Explicit operation timeout
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     allow_no_indices?: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+	 *     expand_wildcards?: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -77,13 +77,13 @@ class Indices extends AbstractEndpoint
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html
 	 *
 	 * @param array{
-	 *     index: string, //  The name of the index to scope the operation
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
-	 *     body: array, //  Define analyzer/tokenizer parameters and the text on which the analysis should be performed
+	 *     index?: string, //  The name of the index to scope the operation
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
+	 *     body?: array, //  Define analyzer/tokenizer parameters and the text on which the analysis should be performed
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -118,19 +118,19 @@ class Indices extends AbstractEndpoint
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html
 	 *
 	 * @param array{
-	 *     index: list, //  A comma-separated list of index name to limit the operation
-	 *     fielddata: boolean, // Clear field data
-	 *     fields: list, // A comma-separated list of fields to clear when using the `fielddata` parameter (default: all)
-	 *     query: boolean, // Clear query caches
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     allow_no_indices: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-	 *     expand_wildcards: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
-	 *     request: boolean, // Clear request cache
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     index?: list, //  A comma-separated list of index name to limit the operation
+	 *     fielddata?: boolean, // Clear field data
+	 *     fields?: list, // A comma-separated list of fields to clear when using the `fielddata` parameter (default: all)
+	 *     query?: boolean, // Clear query caches
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     allow_no_indices?: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+	 *     expand_wildcards?: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
+	 *     request?: boolean, // Clear request cache
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -166,15 +166,15 @@ class Indices extends AbstractEndpoint
 	 * @param array{
 	 *     index: string, // (REQUIRED) The name of the source index to clone
 	 *     target: string, // (REQUIRED) The name of the target index to clone into
-	 *     timeout: time, // Explicit operation timeout
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     wait_for_active_shards: string, // Set the number of active shards to wait for on the cloned index before the operation returns.
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
-	 *     body: array, //  The configuration for the target index (`settings` and `aliases`)
+	 *     timeout?: time, // Explicit operation timeout
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     wait_for_active_shards?: string, // Set the number of active shards to wait for on the cloned index before the operation returns.
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
+	 *     body?: array, //  The configuration for the target index (`settings` and `aliases`)
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -208,17 +208,17 @@ class Indices extends AbstractEndpoint
 	 *
 	 * @param array{
 	 *     index: list, // (REQUIRED) A comma separated list of indices to close
-	 *     timeout: time, // Explicit operation timeout
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     allow_no_indices: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-	 *     expand_wildcards: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
-	 *     wait_for_active_shards: string, // Sets the number of active shards to wait for before the operation returns.
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     timeout?: time, // Explicit operation timeout
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     allow_no_indices?: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+	 *     expand_wildcards?: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
+	 *     wait_for_active_shards?: string, // Sets the number of active shards to wait for before the operation returns.
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -251,15 +251,15 @@ class Indices extends AbstractEndpoint
 	 *
 	 * @param array{
 	 *     index: string, // (REQUIRED) The name of the index
-	 *     wait_for_active_shards: string, // Set the number of active shards to wait for before the operation returns.
-	 *     timeout: time, // Explicit operation timeout
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
-	 *     body: array, //  The configuration for the index (`settings` and `mappings`)
+	 *     wait_for_active_shards?: string, // Set the number of active shards to wait for before the operation returns.
+	 *     timeout?: time, // Explicit operation timeout
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
+	 *     body?: array, //  The configuration for the index (`settings` and `mappings`)
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -293,13 +293,13 @@ class Indices extends AbstractEndpoint
 	 *
 	 * @param array{
 	 *     name: string, // (REQUIRED) The name of the data stream
-	 *     timeout: time, // Specify timeout for acknowledging the cluster state update
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     timeout?: time, // Specify timeout for acknowledging the cluster state update
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -331,12 +331,12 @@ class Indices extends AbstractEndpoint
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html
 	 *
 	 * @param array{
-	 *     name: list, //  A comma-separated list of data stream names; use `_all` or empty string to perform the operation on all data streams
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     name?: list, //  A comma-separated list of data stream names; use `_all` or empty string to perform the operation on all data streams
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -371,16 +371,16 @@ class Indices extends AbstractEndpoint
 	 *
 	 * @param array{
 	 *     index: list, // (REQUIRED) A comma-separated list of indices to delete; use `_all` or `*` string to delete all indices
-	 *     timeout: time, // Explicit operation timeout
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     ignore_unavailable: boolean, // Ignore unavailable indexes (default: false)
-	 *     allow_no_indices: boolean, // Ignore if a wildcard expression resolves to no concrete indices (default: false)
-	 *     expand_wildcards: enum, // Whether wildcard expressions should get expanded to open, closed, or hidden indices
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     timeout?: time, // Explicit operation timeout
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     ignore_unavailable?: boolean, // Ignore unavailable indexes (default: false)
+	 *     allow_no_indices?: boolean, // Ignore if a wildcard expression resolves to no concrete indices (default: false)
+	 *     expand_wildcards?: enum, // Whether wildcard expressions should get expanded to open, closed, or hidden indices
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -414,13 +414,13 @@ class Indices extends AbstractEndpoint
 	 * @param array{
 	 *     index: list, // (REQUIRED) A comma-separated list of index names (supports wildcards); use `_all` for all indices
 	 *     name: list, // (REQUIRED) A comma-separated list of aliases to delete (supports wildcards); use `_all` to delete all aliases for the specified indices.
-	 *     timeout: time, // Explicit timestamp for the document
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     timeout?: time, // Explicit timestamp for the document
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -453,14 +453,14 @@ class Indices extends AbstractEndpoint
 	 *
 	 * @param array{
 	 *     name: list, // (REQUIRED) A comma-separated list of data streams of which the data stream lifecycle will be deleted; use `*` to get all data streams
-	 *     expand_wildcards: enum, // Whether wildcard expressions should get expanded to open or closed indices (default: open)
-	 *     timeout: time, // Explicit timestamp for the document
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     expand_wildcards?: enum, // Whether wildcard expressions should get expanded to open or closed indices (default: open)
+	 *     timeout?: time, // Explicit timestamp for the document
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -493,13 +493,13 @@ class Indices extends AbstractEndpoint
 	 *
 	 * @param array{
 	 *     name: list, // (REQUIRED) A comma-separated list of data streams to delete; use `*` to delete all data streams
-	 *     expand_wildcards: enum, // Whether wildcard expressions should get expanded to open or closed indices (default: open)
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     expand_wildcards?: enum, // Whether wildcard expressions should get expanded to open or closed indices (default: open)
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -532,13 +532,13 @@ class Indices extends AbstractEndpoint
 	 *
 	 * @param array{
 	 *     name: string, // (REQUIRED) The name of the template
-	 *     timeout: time, // Explicit operation timeout
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     timeout?: time, // Explicit operation timeout
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -571,13 +571,13 @@ class Indices extends AbstractEndpoint
 	 *
 	 * @param array{
 	 *     name: string, // (REQUIRED) The name of the template
-	 *     timeout: time, // Explicit operation timeout
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     timeout?: time, // Explicit operation timeout
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -611,16 +611,16 @@ class Indices extends AbstractEndpoint
 	 *
 	 * @param array{
 	 *     index: string, // (REQUIRED) Comma-separated list of indices or data streams to analyze the disk usage
-	 *     run_expensive_tasks: boolean, // Must be set to [true] in order for the task to be performed. Defaults to false.
-	 *     flush: boolean, // Whether flush or not before analyzing the index disk usage. Defaults to true
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     allow_no_indices: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-	 *     expand_wildcards: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     run_expensive_tasks?: boolean, // Must be set to [true] in order for the task to be performed. Defaults to false.
+	 *     flush?: boolean, // Whether flush or not before analyzing the index disk usage. Defaults to true
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     allow_no_indices?: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+	 *     expand_wildcards?: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -655,11 +655,11 @@ class Indices extends AbstractEndpoint
 	 * @param array{
 	 *     index: string, // (REQUIRED) The index to downsample
 	 *     target_index: string, // (REQUIRED) The name of the target index to store downsampled data
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 *     body: array, // (REQUIRED) The downsampling configuration
 	 * } $params
 	 *
@@ -694,17 +694,17 @@ class Indices extends AbstractEndpoint
 	 *
 	 * @param array{
 	 *     index: list, // (REQUIRED) A comma-separated list of index names
-	 *     local: boolean, // Return local information, do not retrieve the state from master node (default: false)
-	 *     ignore_unavailable: boolean, // Ignore unavailable indexes (default: false)
-	 *     allow_no_indices: boolean, // Ignore if a wildcard expression resolves to no concrete indices (default: false)
-	 *     expand_wildcards: enum, // Whether wildcard expressions should get expanded to open or closed indices (default: open)
-	 *     flat_settings: boolean, // Return settings in flat format (default: false)
-	 *     include_defaults: boolean, // Whether to return all default setting for each of the indices.
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     local?: boolean, // Return local information, do not retrieve the state from master node (default: false)
+	 *     ignore_unavailable?: boolean, // Ignore unavailable indexes (default: false)
+	 *     allow_no_indices?: boolean, // Ignore if a wildcard expression resolves to no concrete indices (default: false)
+	 *     expand_wildcards?: enum, // Whether wildcard expressions should get expanded to open or closed indices (default: open)
+	 *     flat_settings?: boolean, // Return settings in flat format (default: false)
+	 *     include_defaults?: boolean, // Whether to return all default setting for each of the indices.
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -737,16 +737,16 @@ class Indices extends AbstractEndpoint
 	 *
 	 * @param array{
 	 *     name: list, // (REQUIRED) A comma-separated list of alias names to return
-	 *     index: list, //  A comma-separated list of index names to filter aliases
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     allow_no_indices: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-	 *     expand_wildcards: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
-	 *     local: boolean, // Return local information, do not retrieve the state from master node (default: false)
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     index?: list, //  A comma-separated list of index names to filter aliases
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     allow_no_indices?: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+	 *     expand_wildcards?: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
+	 *     local?: boolean, // Return local information, do not retrieve the state from master node (default: false)
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -783,14 +783,14 @@ class Indices extends AbstractEndpoint
 	 *
 	 * @param array{
 	 *     name: string, // (REQUIRED) The name of the template
-	 *     flat_settings: boolean, // Return settings in flat format (default: false)
-	 *     master_timeout: time, // Explicit operation timeout for connection to master node
-	 *     local: boolean, // Return local information, do not retrieve the state from master node (default: false)
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     flat_settings?: boolean, // Return settings in flat format (default: false)
+	 *     master_timeout?: time, // Explicit operation timeout for connection to master node
+	 *     local?: boolean, // Return local information, do not retrieve the state from master node (default: false)
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -823,14 +823,14 @@ class Indices extends AbstractEndpoint
 	 *
 	 * @param array{
 	 *     name: list, // (REQUIRED) The comma separated names of the index templates
-	 *     flat_settings: boolean, // Return settings in flat format (default: false)
-	 *     master_timeout: time, // Explicit operation timeout for connection to master node
-	 *     local: boolean, // Return local information, do not retrieve the state from master node (default: false)
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     flat_settings?: boolean, // Return settings in flat format (default: false)
+	 *     master_timeout?: time, // Explicit operation timeout for connection to master node
+	 *     local?: boolean, // Return local information, do not retrieve the state from master node (default: false)
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -863,13 +863,13 @@ class Indices extends AbstractEndpoint
 	 *
 	 * @param array{
 	 *     index: string, // (REQUIRED) The name of the index to explain
-	 *     include_defaults: boolean, // indicates if the API should return the default values the system uses for the index's lifecycle
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     include_defaults?: boolean, // indicates if the API should return the default values the system uses for the index's lifecycle
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -903,15 +903,15 @@ class Indices extends AbstractEndpoint
 	 *
 	 * @param array{
 	 *     index: string, // (REQUIRED) A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
-	 *     fields: list, // A comma-separated list of fields to include in the stats if only a subset of fields should be returned (supports wildcards)
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     allow_no_indices: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-	 *     expand_wildcards: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     fields?: list, // A comma-separated list of fields to include in the stats if only a subset of fields should be returned (supports wildcards)
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     allow_no_indices?: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+	 *     expand_wildcards?: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -943,17 +943,17 @@ class Indices extends AbstractEndpoint
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html
 	 *
 	 * @param array{
-	 *     index: list, //  A comma-separated list of index names; use `_all` or empty string for all indices
-	 *     force: boolean, // Whether a flush should be forced even if it is not necessarily needed ie. if no changes will be committed to the index. This is useful if transaction log IDs should be incremented even if no uncommitted changes are present. (This setting can be considered as internal)
-	 *     wait_if_ongoing: boolean, // If set to true the flush operation will block until the flush can be executed if another flush operation is already executing. The default is true. If set to false the flush will be skipped iff if another flush operation is already running.
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     allow_no_indices: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-	 *     expand_wildcards: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     index?: list, //  A comma-separated list of index names; use `_all` or empty string for all indices
+	 *     force?: boolean, // Whether a flush should be forced even if it is not necessarily needed ie. if no changes will be committed to the index. This is useful if transaction log IDs should be incremented even if no uncommitted changes are present. (This setting can be considered as internal)
+	 *     wait_if_ongoing?: boolean, // If set to true the flush operation will block until the flush can be executed if another flush operation is already executing. The default is true. If set to false the flush will be skipped iff if another flush operation is already running.
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     allow_no_indices?: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+	 *     expand_wildcards?: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -987,19 +987,19 @@ class Indices extends AbstractEndpoint
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html
 	 *
 	 * @param array{
-	 *     index: list, //  A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
-	 *     flush: boolean, // Specify whether the index should be flushed after performing the operation (default: true)
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     allow_no_indices: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-	 *     expand_wildcards: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
-	 *     max_num_segments: number, // The number of segments the index should be merged into (default: dynamic)
-	 *     only_expunge_deletes: boolean, // Specify whether the operation should only expunge deleted documents
-	 *     wait_for_completion: boolean, // Should the request wait until the force merge is completed.
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     index?: list, //  A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
+	 *     flush?: boolean, // Specify whether the index should be flushed after performing the operation (default: true)
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     allow_no_indices?: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+	 *     expand_wildcards?: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
+	 *     max_num_segments?: number, // The number of segments the index should be merged into (default: dynamic)
+	 *     only_expunge_deletes?: boolean, // Specify whether the operation should only expunge deleted documents
+	 *     wait_for_completion?: boolean, // Should the request wait until the force merge is completed.
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -1034,19 +1034,19 @@ class Indices extends AbstractEndpoint
 	 *
 	 * @param array{
 	 *     index: list, // (REQUIRED) A comma-separated list of index names
-	 *     local: boolean, // Return local information, do not retrieve the state from master node (default: false)
-	 *     ignore_unavailable: boolean, // Ignore unavailable indexes (default: false)
-	 *     allow_no_indices: boolean, // Ignore if a wildcard expression resolves to no concrete indices (default: false)
-	 *     expand_wildcards: enum, // Whether wildcard expressions should get expanded to open or closed indices (default: open)
-	 *     features: enum, // Return only information on specified index features
-	 *     flat_settings: boolean, // Return settings in flat format (default: false)
-	 *     include_defaults: boolean, // Whether to return all default setting for each of the indices.
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     local?: boolean, // Return local information, do not retrieve the state from master node (default: false)
+	 *     ignore_unavailable?: boolean, // Ignore unavailable indexes (default: false)
+	 *     allow_no_indices?: boolean, // Ignore if a wildcard expression resolves to no concrete indices (default: false)
+	 *     expand_wildcards?: enum, // Whether wildcard expressions should get expanded to open or closed indices (default: open)
+	 *     features?: enum, // Return only information on specified index features
+	 *     flat_settings?: boolean, // Return settings in flat format (default: false)
+	 *     include_defaults?: boolean, // Whether to return all default setting for each of the indices.
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -1078,17 +1078,17 @@ class Indices extends AbstractEndpoint
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html
 	 *
 	 * @param array{
-	 *     name: list, //  A comma-separated list of alias names to return
-	 *     index: list, //  A comma-separated list of index names to filter aliases
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     allow_no_indices: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-	 *     expand_wildcards: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
-	 *     local: boolean, // Return local information, do not retrieve the state from master node (default: false)
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     name?: list, //  A comma-separated list of alias names to return
+	 *     index?: list, //  A comma-separated list of index names to filter aliases
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     allow_no_indices?: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+	 *     expand_wildcards?: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
+	 *     local?: boolean, // Return local information, do not retrieve the state from master node (default: false)
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -1129,14 +1129,14 @@ class Indices extends AbstractEndpoint
 	 *
 	 * @param array{
 	 *     name: list, // (REQUIRED) A comma-separated list of data streams to get; use `*` to get all data streams
-	 *     expand_wildcards: enum, // Whether wildcard expressions should get expanded to open or closed indices (default: open)
-	 *     include_defaults: boolean, // Return all relevant default configurations for the data stream (default: false)
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     expand_wildcards?: enum, // Whether wildcard expressions should get expanded to open or closed indices (default: open)
+	 *     include_defaults?: boolean, // Return all relevant default configurations for the data stream (default: false)
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -1168,16 +1168,16 @@ class Indices extends AbstractEndpoint
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html
 	 *
 	 * @param array{
-	 *     name: list, //  A comma-separated list of data streams to get; use `*` to get all data streams
-	 *     expand_wildcards: enum, // Whether wildcard expressions should get expanded to open or closed indices (default: open)
-	 *     include_defaults: boolean, // Return all relevant default configurations for the data stream (default: false)
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     verbose: boolean, // Whether the maximum timestamp for each data stream should be calculated and returned (default: false)
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     name?: list, //  A comma-separated list of data streams to get; use `*` to get all data streams
+	 *     expand_wildcards?: enum, // Whether wildcard expressions should get expanded to open or closed indices (default: open)
+	 *     include_defaults?: boolean, // Return all relevant default configurations for the data stream (default: false)
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     verbose?: boolean, // Whether the maximum timestamp for each data stream should be calculated and returned (default: false)
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -1212,17 +1212,17 @@ class Indices extends AbstractEndpoint
 	 *
 	 * @param array{
 	 *     fields: list, // (REQUIRED) A comma-separated list of fields
-	 *     index: list, //  A comma-separated list of index names
-	 *     include_defaults: boolean, // Whether the default mapping values should be returned as well
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     allow_no_indices: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-	 *     expand_wildcards: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
-	 *     local: boolean, // Return local information, do not retrieve the state from master node (default: false)
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     index?: list, //  A comma-separated list of index names
+	 *     include_defaults?: boolean, // Whether the default mapping values should be returned as well
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     allow_no_indices?: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+	 *     expand_wildcards?: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
+	 *     local?: boolean, // Return local information, do not retrieve the state from master node (default: false)
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -1258,16 +1258,16 @@ class Indices extends AbstractEndpoint
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-template.html
 	 *
 	 * @param array{
-	 *     name: string, //  A pattern that returned template names must match
-	 *     flat_settings: boolean, // Return settings in flat format (default: false)
-	 *     master_timeout: time, // Explicit operation timeout for connection to master node
-	 *     local: boolean, // Return local information, do not retrieve the state from master node (default: false)
-	 *     include_defaults: boolean, // Return all relevant default configurations for the index template (default: false)
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     name?: string, //  A pattern that returned template names must match
+	 *     flat_settings?: boolean, // Return settings in flat format (default: false)
+	 *     master_timeout?: time, // Explicit operation timeout for connection to master node
+	 *     local?: boolean, // Return local information, do not retrieve the state from master node (default: false)
+	 *     include_defaults?: boolean, // Return all relevant default configurations for the index template (default: false)
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -1301,17 +1301,17 @@ class Indices extends AbstractEndpoint
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html
 	 *
 	 * @param array{
-	 *     index: list, //  A comma-separated list of index names
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     allow_no_indices: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-	 *     expand_wildcards: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     local: boolean, // Return local information, do not retrieve the state from master node (default: false)
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     index?: list, //  A comma-separated list of index names
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     allow_no_indices?: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+	 *     expand_wildcards?: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     local?: boolean, // Return local information, do not retrieve the state from master node (default: false)
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -1345,20 +1345,20 @@ class Indices extends AbstractEndpoint
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html
 	 *
 	 * @param array{
-	 *     index: list, //  A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
-	 *     name: list, //  The name of the settings that should be included
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     allow_no_indices: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-	 *     expand_wildcards: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
-	 *     flat_settings: boolean, // Return settings in flat format (default: false)
-	 *     local: boolean, // Return local information, do not retrieve the state from master node (default: false)
-	 *     include_defaults: boolean, // Whether to return all default setting for each of the indices.
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     index?: list, //  A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
+	 *     name?: list, //  The name of the settings that should be included
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     allow_no_indices?: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+	 *     expand_wildcards?: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
+	 *     flat_settings?: boolean, // Return settings in flat format (default: false)
+	 *     local?: boolean, // Return local information, do not retrieve the state from master node (default: false)
+	 *     include_defaults?: boolean, // Whether to return all default setting for each of the indices.
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -1398,15 +1398,15 @@ class Indices extends AbstractEndpoint
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-template-v1.html
 	 *
 	 * @param array{
-	 *     name: list, //  The comma separated names of the index templates
-	 *     flat_settings: boolean, // Return settings in flat format (default: false)
-	 *     master_timeout: time, // Explicit operation timeout for connection to master node
-	 *     local: boolean, // Return local information, do not retrieve the state from master node (default: false)
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     name?: list, //  The comma separated names of the index templates
+	 *     flat_settings?: boolean, // Return settings in flat format (default: false)
+	 *     master_timeout?: time, // Explicit operation timeout for connection to master node
+	 *     local?: boolean, // Return local information, do not retrieve the state from master node (default: false)
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -1441,13 +1441,13 @@ class Indices extends AbstractEndpoint
 	 *
 	 * @param array{
 	 *     name: string, // (REQUIRED) The name of the alias to migrate
-	 *     timeout: time, // Specify timeout for acknowledging the cluster state update
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     timeout?: time, // Specify timeout for acknowledging the cluster state update
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -1479,12 +1479,12 @@ class Indices extends AbstractEndpoint
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html
 	 *
 	 * @param array{
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
-	 *     body: array, // (REQUIRED) The data stream modifications
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
+	 *     body?: array, // (REQUIRED) The data stream modifications
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -1517,17 +1517,17 @@ class Indices extends AbstractEndpoint
 	 *
 	 * @param array{
 	 *     index: list, // (REQUIRED) A comma separated list of indices to open
-	 *     timeout: time, // Explicit operation timeout
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     allow_no_indices: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-	 *     expand_wildcards: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
-	 *     wait_for_active_shards: string, // Sets the number of active shards to wait for before the operation returns.
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     timeout?: time, // Explicit operation timeout
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     allow_no_indices?: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+	 *     expand_wildcards?: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
+	 *     wait_for_active_shards?: string, // Sets the number of active shards to wait for before the operation returns.
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -1560,12 +1560,12 @@ class Indices extends AbstractEndpoint
 	 *
 	 * @param array{
 	 *     name: string, // (REQUIRED) The name of the data stream
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -1599,14 +1599,14 @@ class Indices extends AbstractEndpoint
 	 * @param array{
 	 *     index: list, // (REQUIRED) A comma-separated list of index names the alias should point to (supports wildcards); use `_all` to perform the operation on all indices.
 	 *     name: string, // (REQUIRED) The name of the alias to be created or updated
-	 *     timeout: time, // Explicit timestamp for the document
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
-	 *     body: array, //  The settings for the alias, such as `routing` or `filter`
+	 *     timeout?: time, // Explicit timestamp for the document
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
+	 *     body?: array, //  The settings for the alias, such as `routing` or `filter`
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -1640,15 +1640,15 @@ class Indices extends AbstractEndpoint
 	 *
 	 * @param array{
 	 *     name: list, // (REQUIRED) A comma-separated list of data streams whose lifecycle will be updated; use `*` to set the lifecycle to all data streams
-	 *     expand_wildcards: enum, // Whether wildcard expressions should get expanded to open or closed indices (default: open)
-	 *     timeout: time, // Explicit timestamp for the document
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
-	 *     body: array, //  The data stream lifecycle configuration that consist of the data retention
+	 *     expand_wildcards?: enum, // Whether wildcard expressions should get expanded to open or closed indices (default: open)
+	 *     timeout?: time, // Explicit timestamp for the document
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
+	 *     body?: array, //  The data stream lifecycle configuration that consist of the data retention
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -1682,14 +1682,14 @@ class Indices extends AbstractEndpoint
 	 *
 	 * @param array{
 	 *     name: string, // (REQUIRED) The name of the template
-	 *     create: boolean, // Whether the index template should only be added if new or can also replace an existing one
-	 *     cause: string, // User defined reason for creating/updating the index template
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     create?: boolean, // Whether the index template should only be added if new or can also replace an existing one
+	 *     cause?: string, // User defined reason for creating/updating the index template
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 *     body: array, // (REQUIRED) The template definition
 	 * } $params
 	 *
@@ -1724,17 +1724,17 @@ class Indices extends AbstractEndpoint
 	 *
 	 * @param array{
 	 *     index: list, // (REQUIRED) A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indices.
-	 *     timeout: time, // Explicit operation timeout
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     allow_no_indices: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-	 *     expand_wildcards: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
-	 *     write_index_only: boolean, // When true, applies mappings only to the write index of an alias or data stream
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     timeout?: time, // Explicit operation timeout
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     allow_no_indices?: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+	 *     expand_wildcards?: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
+	 *     write_index_only?: boolean, // When true, applies mappings only to the write index of an alias or data stream
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 *     body: array, // (REQUIRED) The mapping definition
 	 * } $params
 	 *
@@ -1768,20 +1768,20 @@ class Indices extends AbstractEndpoint
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html
 	 *
 	 * @param array{
-	 *     index: list, //  A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     timeout: time, // Explicit operation timeout
-	 *     preserve_existing: boolean, // Whether to update existing settings. If set to `true` existing settings on an index remain unchanged, the default is `false`
-	 *     reopen: boolean, // Whether to close and reopen the index to apply non-dynamic settings. If set to `true` the indices to which the settings are being applied will be closed temporarily and then reopened in order to apply the changes. The default is `false`
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     allow_no_indices: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-	 *     expand_wildcards: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
-	 *     flat_settings: boolean, // Return settings in flat format (default: false)
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     index?: list, //  A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     timeout?: time, // Explicit operation timeout
+	 *     preserve_existing?: boolean, // Whether to update existing settings. If set to `true` existing settings on an index remain unchanged, the default is `false`
+	 *     reopen?: boolean, // Whether to close and reopen the index to apply non-dynamic settings. If set to `true` the indices to which the settings are being applied will be closed temporarily and then reopened in order to apply the changes. The default is `false`
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     allow_no_indices?: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+	 *     expand_wildcards?: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
+	 *     flat_settings?: boolean, // Return settings in flat format (default: false)
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 *     body: array, // (REQUIRED) The index settings to be updated
 	 * } $params
 	 *
@@ -1819,14 +1819,14 @@ class Indices extends AbstractEndpoint
 	 *
 	 * @param array{
 	 *     name: string, // (REQUIRED) The name of the template
-	 *     order: number, // The order for this template when merging multiple matching ones (higher numbers are merged later, overriding the lower numbers)
-	 *     create: boolean, // Whether the index template should only be added if new or can also replace an existing one
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     order?: number, // The order for this template when merging multiple matching ones (higher numbers are merged later, overriding the lower numbers)
+	 *     create?: boolean, // Whether the index template should only be added if new or can also replace an existing one
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 *     body: array, // (REQUIRED) The template definition
 	 * } $params
 	 *
@@ -1860,14 +1860,14 @@ class Indices extends AbstractEndpoint
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html
 	 *
 	 * @param array{
-	 *     index: list, //  A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
-	 *     detailed: boolean, // Whether to display detailed information about shard recovery
-	 *     active_only: boolean, // Display only those recoveries that are currently on-going
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     index?: list, //  A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
+	 *     detailed?: boolean, // Whether to display detailed information about shard recovery
+	 *     active_only?: boolean, // Display only those recoveries that are currently on-going
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -1901,15 +1901,15 @@ class Indices extends AbstractEndpoint
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html
 	 *
 	 * @param array{
-	 *     index: list, //  A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     allow_no_indices: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-	 *     expand_wildcards: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     index?: list, //  A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     allow_no_indices?: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+	 *     expand_wildcards?: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -1944,15 +1944,15 @@ class Indices extends AbstractEndpoint
 	 *
 	 * @param array{
 	 *     index: list, // (REQUIRED) A comma-separated list of index names to reload analyzers for
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     allow_no_indices: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-	 *     expand_wildcards: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
-	 *     resource: string, // changed resource to reload analyzers from if applicable
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     allow_no_indices?: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+	 *     expand_wildcards?: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
+	 *     resource?: string, // changed resource to reload analyzers from if applicable
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -1985,15 +1985,15 @@ class Indices extends AbstractEndpoint
 	 *
 	 * @param array{
 	 *     name: list, // (REQUIRED) A comma-separated list of cluster:index names or wildcard expressions
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     ignore_throttled: boolean, // Whether specified concrete, expanded or aliased indices should be ignored when throttled
-	 *     allow_no_indices: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-	 *     expand_wildcards: enum, // Whether wildcard expressions should get expanded to open or closed indices (default: open)
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     ignore_throttled?: boolean, // Whether specified concrete, expanded or aliased indices should be ignored when throttled
+	 *     allow_no_indices?: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+	 *     expand_wildcards?: enum, // Whether wildcard expressions should get expanded to open or closed indices (default: open)
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -2026,14 +2026,14 @@ class Indices extends AbstractEndpoint
 	 *
 	 * @param array{
 	 *     name: list, // (REQUIRED) A comma-separated list of names or wildcard expressions
-	 *     expand_wildcards: enum, // Whether wildcard expressions should get expanded to open or closed indices (default: open)
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     allow_no_indices: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     expand_wildcards?: enum, // Whether wildcard expressions should get expanded to open or closed indices (default: open)
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     allow_no_indices?: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -2067,19 +2067,19 @@ class Indices extends AbstractEndpoint
 	 *
 	 * @param array{
 	 *     alias: string, // (REQUIRED) The name of the alias to rollover
-	 *     new_index: string, //  The name of the rollover index
-	 *     timeout: time, // Explicit operation timeout
-	 *     dry_run: boolean, // If set to true the rollover action will only be validated but not actually performed even if a condition matches. The default is false
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     wait_for_active_shards: string, // Set the number of active shards to wait for on the newly created rollover index before the operation returns.
-	 *     lazy: boolean, // If set to true, the rollover action will only mark a data stream to signal that it needs to be rolled over at the next write. Only allowed on data streams.
-	 *     target_failure_store: boolean, // If set to true, the rollover action will be applied on the failure store of the data stream.
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
-	 *     body: array, //  The conditions that needs to be met for executing rollover
+	 *     new_index?: string, //  The name of the rollover index
+	 *     timeout?: time, // Explicit operation timeout
+	 *     dry_run?: boolean, // If set to true the rollover action will only be validated but not actually performed even if a condition matches. The default is false
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     wait_for_active_shards?: string, // Set the number of active shards to wait for on the newly created rollover index before the operation returns.
+	 *     lazy?: boolean, // If set to true, the rollover action will only mark a data stream to signal that it needs to be rolled over at the next write. Only allowed on data streams.
+	 *     target_failure_store?: boolean, // If set to true, the rollover action will be applied on the failure store of the data stream.
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
+	 *     body?: array, //  The conditions that needs to be met for executing rollover
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -2116,16 +2116,16 @@ class Indices extends AbstractEndpoint
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html
 	 *
 	 * @param array{
-	 *     index: list, //  A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     allow_no_indices: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-	 *     expand_wildcards: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
-	 *     verbose: boolean, // Includes detailed memory usage by Lucene.
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     index?: list, //  A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     allow_no_indices?: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+	 *     expand_wildcards?: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
+	 *     verbose?: boolean, // Includes detailed memory usage by Lucene.
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -2159,16 +2159,16 @@ class Indices extends AbstractEndpoint
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html
 	 *
 	 * @param array{
-	 *     index: list, //  A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
-	 *     status: list, // A comma-separated list of statuses used to filter on shards to get store information for
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     allow_no_indices: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-	 *     expand_wildcards: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     index?: list, //  A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
+	 *     status?: list, // A comma-separated list of statuses used to filter on shards to get store information for
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     allow_no_indices?: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+	 *     expand_wildcards?: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -2204,15 +2204,15 @@ class Indices extends AbstractEndpoint
 	 * @param array{
 	 *     index: string, // (REQUIRED) The name of the source index to shrink
 	 *     target: string, // (REQUIRED) The name of the target index to shrink into
-	 *     timeout: time, // Explicit operation timeout
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     wait_for_active_shards: string, // Set the number of active shards to wait for on the shrunken index before the operation returns.
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
-	 *     body: array, //  The configuration for the target index (`settings` and `aliases`)
+	 *     timeout?: time, // Explicit operation timeout
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     wait_for_active_shards?: string, // Set the number of active shards to wait for on the shrunken index before the operation returns.
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
+	 *     body?: array, //  The configuration for the target index (`settings` and `aliases`)
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -2246,16 +2246,16 @@ class Indices extends AbstractEndpoint
 	 *
 	 * @param array{
 	 *     name: string, // (REQUIRED) The name of the index (it must be a concrete index name)
-	 *     create: boolean, // Whether the index template we optionally defined in the body should only be dry-run added if new or can also replace an existing one
-	 *     cause: string, // User defined reason for dry-run creating the new template for simulation purposes
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     include_defaults: boolean, // Return all relevant default configurations for this index template simulation (default: false)
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
-	 *     body: array, //  New index template definition, which will be included in the simulation, as if it already exists in the system
+	 *     create?: boolean, // Whether the index template we optionally defined in the body should only be dry-run added if new or can also replace an existing one
+	 *     cause?: string, // User defined reason for dry-run creating the new template for simulation purposes
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     include_defaults?: boolean, // Return all relevant default configurations for this index template simulation (default: false)
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
+	 *     body?: array, //  New index template definition, which will be included in the simulation, as if it already exists in the system
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -2288,17 +2288,17 @@ class Indices extends AbstractEndpoint
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-simulate-template.html
 	 *
 	 * @param array{
-	 *     name: string, //  The name of the index template
-	 *     create: boolean, // Whether the index template we optionally defined in the body should only be dry-run added if new or can also replace an existing one
-	 *     cause: string, // User defined reason for dry-run creating the new template for simulation purposes
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     include_defaults: boolean, // Return all relevant default configurations for this template simulation (default: false)
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
-	 *     body: array, //  New index template definition to be simulated, if no index template name is specified
+	 *     name?: string, //  The name of the index template
+	 *     create?: boolean, // Whether the index template we optionally defined in the body should only be dry-run added if new or can also replace an existing one
+	 *     cause?: string, // User defined reason for dry-run creating the new template for simulation purposes
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     include_defaults?: boolean, // Return all relevant default configurations for this template simulation (default: false)
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
+	 *     body?: array, //  New index template definition to be simulated, if no index template name is specified
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -2335,15 +2335,15 @@ class Indices extends AbstractEndpoint
 	 * @param array{
 	 *     index: string, // (REQUIRED) The name of the source index to split
 	 *     target: string, // (REQUIRED) The name of the target index to split into
-	 *     timeout: time, // Explicit operation timeout
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     wait_for_active_shards: string, // Set the number of active shards to wait for on the shrunken index before the operation returns.
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
-	 *     body: array, //  The configuration for the target index (`settings` and `aliases`)
+	 *     timeout?: time, // Explicit operation timeout
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     wait_for_active_shards?: string, // Set the number of active shards to wait for on the shrunken index before the operation returns.
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
+	 *     body?: array, //  The configuration for the target index (`settings` and `aliases`)
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -2376,22 +2376,22 @@ class Indices extends AbstractEndpoint
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html
 	 *
 	 * @param array{
-	 *     metric: list, //  Limit the information returned the specific metrics.
-	 *     index: list, //  A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
-	 *     completion_fields: list, // A comma-separated list of fields for the `completion` index metric (supports wildcards)
-	 *     fielddata_fields: list, // A comma-separated list of fields for the `fielddata` index metric (supports wildcards)
-	 *     fields: list, // A comma-separated list of fields for `fielddata` and `completion` index metric (supports wildcards)
-	 *     groups: list, // A comma-separated list of search groups for `search` index metric
-	 *     level: enum, // Return stats aggregated at cluster, index or shard level
-	 *     include_segment_file_sizes: boolean, // Whether to report the aggregated disk usage of each one of the Lucene index files (only applies if segment stats are requested)
-	 *     include_unloaded_segments: boolean, // If set to true segment stats will include stats for segments that are not currently loaded into memory
-	 *     expand_wildcards: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
-	 *     forbid_closed_indices: boolean, // If set to false stats will also collected from closed indices if explicitly specified or if expand_wildcards expands to closed indices
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     metric?: list, //  Limit the information returned the specific metrics.
+	 *     index?: list, //  A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
+	 *     completion_fields?: list, // A comma-separated list of fields for the `completion` index metric (supports wildcards)
+	 *     fielddata_fields?: list, // A comma-separated list of fields for the `fielddata` index metric (supports wildcards)
+	 *     fields?: list, // A comma-separated list of fields for `fielddata` and `completion` index metric (supports wildcards)
+	 *     groups?: list, // A comma-separated list of search groups for `search` index metric
+	 *     level?: enum, // Return stats aggregated at cluster, index or shard level
+	 *     include_segment_file_sizes?: boolean, // Whether to report the aggregated disk usage of each one of the Lucene index files (only applies if segment stats are requested)
+	 *     include_unloaded_segments?: boolean, // If set to true segment stats will include stats for segments that are not currently loaded into memory
+	 *     expand_wildcards?: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
+	 *     forbid_closed_indices?: boolean, // If set to false stats will also collected from closed indices if explicitly specified or if expand_wildcards expands to closed indices
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -2432,17 +2432,17 @@ class Indices extends AbstractEndpoint
 	 *
 	 * @param array{
 	 *     index: string, // (REQUIRED) The name of the index to unfreeze
-	 *     timeout: time, // Explicit operation timeout
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     allow_no_indices: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-	 *     expand_wildcards: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
-	 *     wait_for_active_shards: string, // Sets the number of active shards to wait for before the operation returns.
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     timeout?: time, // Explicit operation timeout
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     allow_no_indices?: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+	 *     expand_wildcards?: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
+	 *     wait_for_active_shards?: string, // Sets the number of active shards to wait for before the operation returns.
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -2474,13 +2474,13 @@ class Indices extends AbstractEndpoint
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html
 	 *
 	 * @param array{
-	 *     timeout: time, // Request timeout
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     timeout?: time, // Request timeout
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 *     body: array, // (REQUIRED) The definition of `actions` to perform
 	 * } $params
 	 *
@@ -2513,25 +2513,25 @@ class Indices extends AbstractEndpoint
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html
 	 *
 	 * @param array{
-	 *     index: list, //  A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices
-	 *     explain: boolean, // Return detailed information about the error
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     allow_no_indices: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-	 *     expand_wildcards: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
-	 *     q: string, // Query in the Lucene query string syntax
-	 *     analyzer: string, // The analyzer to use for the query string
-	 *     analyze_wildcard: boolean, // Specify whether wildcard and prefix queries should be analyzed (default: false)
-	 *     default_operator: enum, // The default operator for query string query (AND or OR)
-	 *     df: string, // The field to use as default where no field prefix is given in the query string
-	 *     lenient: boolean, // Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
-	 *     rewrite: boolean, // Provide a more detailed explanation showing the actual Lucene query that will be executed.
-	 *     all_shards: boolean, // Execute validation on all shards instead of one random shard per index
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
-	 *     body: array, //  The query definition specified with the Query DSL
+	 *     index?: list, //  A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices
+	 *     explain?: boolean, // Return detailed information about the error
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     allow_no_indices?: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+	 *     expand_wildcards?: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
+	 *     q?: string, // Query in the Lucene query string syntax
+	 *     analyzer?: string, // The analyzer to use for the query string
+	 *     analyze_wildcard?: boolean, // Specify whether wildcard and prefix queries should be analyzed (default: false)
+	 *     default_operator?: enum, // The default operator for query string query (AND or OR)
+	 *     df?: string, // The field to use as default where no field prefix is given in the query string
+	 *     lenient?: boolean, // Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
+	 *     rewrite?: boolean, // Provide a more detailed explanation showing the actual Lucene query that will be executed.
+	 *     all_shards?: boolean, // Execute validation on all shards instead of one random shard per index
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
+	 *     body?: array, //  The query definition specified with the Query DSL
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline

--- a/src/Traits/ClientEndpointsTrait.php
+++ b/src/Traits/ClientEndpointsTrait.php
@@ -34,24 +34,24 @@ trait ClientEndpointsTrait
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html
 	 *
 	 * @param array{
-	 *     index: string, //  Default index for items which don't provide one
-	 *     wait_for_active_shards: string, // Sets the number of shard copies that must be active before proceeding with the bulk operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
-	 *     refresh: enum, // If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes.
-	 *     routing: string, // Specific routing value
-	 *     timeout: time, // Explicit operation timeout
-	 *     type: string, // Default document type for items which don't provide one
-	 *     _source: list, // True or false to return the _source field or not, or default list of fields to return, can be overridden on each sub-request
-	 *     _source_excludes: list, // Default list of fields to exclude from the returned _source field, can be overridden on each sub-request
-	 *     _source_includes: list, // Default list of fields to extract and return from the _source field, can be overridden on each sub-request
-	 *     pipeline: string, // The pipeline id to preprocess incoming documents with
-	 *     require_alias: boolean, // Sets require_alias for all incoming documents. Defaults to unset (false)
-	 *     require_data_stream: boolean, // When true, requires the destination to be a data stream (existing or to-be-created). Default is false
-	 *     list_executed_pipelines: boolean, // Sets list_executed_pipelines for all incoming documents. Defaults to unset (false)
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     index?: string, //  Default index for items which don't provide one
+	 *     wait_for_active_shards?: string, // Sets the number of shard copies that must be active before proceeding with the bulk operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
+	 *     refresh?: enum, // If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes.
+	 *     routing?: string, // Specific routing value
+	 *     timeout?: time, // Explicit operation timeout
+	 *     type?: string, // Default document type for items which don't provide one
+	 *     _source?: list, // True or false to return the _source field or not, or default list of fields to return, can be overridden on each sub-request
+	 *     _source_excludes?: list, // Default list of fields to exclude from the returned _source field, can be overridden on each sub-request
+	 *     _source_includes?: list, // Default list of fields to extract and return from the _source field, can be overridden on each sub-request
+	 *     pipeline?: string, // The pipeline id to preprocess incoming documents with
+	 *     require_alias?: boolean, // Sets require_alias for all incoming documents. Defaults to unset (false)
+	 *     require_data_stream?: boolean, // When true, requires the destination to be a data stream (existing or to-be-created). Default is false
+	 *     list_executed_pipelines?: boolean, // Sets list_executed_pipelines for all incoming documents. Defaults to unset (false)
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 *     body: array, // (REQUIRED) The operation definition and data (action-data pairs), separated by newlines
 	 * } $params
 	 *
@@ -88,13 +88,13 @@ trait ClientEndpointsTrait
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/clear-scroll-api.html
 	 *
 	 * @param array{
-	 *     scroll_id: list, //  A comma-separated list of scroll IDs to clear
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
-	 *     body: array, //  A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter
+	 *     scroll_id?: list, //  A comma-separated list of scroll IDs to clear
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
+	 *     body?: array, //  A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -129,12 +129,12 @@ trait ClientEndpointsTrait
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/point-in-time-api.html
 	 *
 	 * @param array{
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
-	 *     body: array, //  a point-in-time id to close
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
+	 *     body?: array, //  a point-in-time id to close
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -165,27 +165,27 @@ trait ClientEndpointsTrait
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html
 	 *
 	 * @param array{
-	 *     index: list, //  A comma-separated list of indices to restrict the results
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     ignore_throttled: boolean, // Whether specified concrete, expanded or aliased indices should be ignored when throttled
-	 *     allow_no_indices: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-	 *     expand_wildcards: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
-	 *     min_score: number, // Include only documents with a specific `_score` value in the result
-	 *     preference: string, // Specify the node or shard the operation should be performed on (default: random)
-	 *     routing: list, // A comma-separated list of specific routing values
-	 *     q: string, // Query in the Lucene query string syntax
-	 *     analyzer: string, // The analyzer to use for the query string
-	 *     analyze_wildcard: boolean, // Specify whether wildcard and prefix queries should be analyzed (default: false)
-	 *     default_operator: enum, // The default operator for query string query (AND or OR)
-	 *     df: string, // The field to use as default where no field prefix is given in the query string
-	 *     lenient: boolean, // Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
-	 *     terminate_after: number, // The maximum count for each shard, upon reaching which the query execution will terminate early
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
-	 *     body: array, //  A query to restrict the results specified with the Query DSL (optional)
+	 *     index?: list, //  A comma-separated list of indices to restrict the results
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     ignore_throttled?: boolean, // Whether specified concrete, expanded or aliased indices should be ignored when throttled
+	 *     allow_no_indices?: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+	 *     expand_wildcards?: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
+	 *     min_score?: number, // Include only documents with a specific `_score` value in the result
+	 *     preference?: string, // Specify the node or shard the operation should be performed on (default: random)
+	 *     routing?: list, // A comma-separated list of specific routing values
+	 *     q?: string, // Query in the Lucene query string syntax
+	 *     analyzer?: string, // The analyzer to use for the query string
+	 *     analyze_wildcard?: boolean, // Specify whether wildcard and prefix queries should be analyzed (default: false)
+	 *     default_operator?: enum, // The default operator for query string query (AND or OR)
+	 *     df?: string, // The field to use as default where no field prefix is given in the query string
+	 *     lenient?: boolean, // Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
+	 *     terminate_after?: number, // The maximum count for each shard, upon reaching which the query execution will terminate early
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
+	 *     body?: array, //  A query to restrict the results specified with the Query DSL (optional)
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -224,18 +224,18 @@ trait ClientEndpointsTrait
 	 * @param array{
 	 *     id: string, // (REQUIRED) Document ID
 	 *     index: string, // (REQUIRED) The name of the index
-	 *     wait_for_active_shards: string, // Sets the number of shard copies that must be active before proceeding with the index operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
-	 *     refresh: enum, // If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes.
-	 *     routing: string, // Specific routing value
-	 *     timeout: time, // Explicit operation timeout
-	 *     version: number, // Explicit version number for concurrency control
-	 *     version_type: enum, // Specific version type
-	 *     pipeline: string, // The pipeline id to preprocess incoming documents with
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     wait_for_active_shards?: string, // Sets the number of shard copies that must be active before proceeding with the index operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
+	 *     refresh?: enum, // If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes.
+	 *     routing?: string, // Specific routing value
+	 *     timeout?: time, // Explicit operation timeout
+	 *     version?: number, // Explicit version number for concurrency control
+	 *     version_type?: enum, // Specific version type
+	 *     pipeline?: string, // The pipeline id to preprocess incoming documents with
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 *     body: array, // (REQUIRED) The document
 	 * } $params
 	 *
@@ -271,19 +271,19 @@ trait ClientEndpointsTrait
 	 * @param array{
 	 *     id: string, // (REQUIRED) The document ID
 	 *     index: string, // (REQUIRED) The name of the index
-	 *     wait_for_active_shards: string, // Sets the number of shard copies that must be active before proceeding with the delete operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
-	 *     refresh: enum, // If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes.
-	 *     routing: string, // Specific routing value
-	 *     timeout: time, // Explicit operation timeout
-	 *     if_seq_no: number, // only perform the delete operation if the last operation that has changed the document has the specified sequence number
-	 *     if_primary_term: number, // only perform the delete operation if the last operation that has changed the document has the specified primary term
-	 *     version: number, // Explicit version number for concurrency control
-	 *     version_type: enum, // Specific version type
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     wait_for_active_shards?: string, // Sets the number of shard copies that must be active before proceeding with the delete operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
+	 *     refresh?: enum, // If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes.
+	 *     routing?: string, // Specific routing value
+	 *     timeout?: time, // Explicit operation timeout
+	 *     if_seq_no?: number, // only perform the delete operation if the last operation that has changed the document has the specified sequence number
+	 *     if_primary_term?: number, // only perform the delete operation if the last operation that has changed the document has the specified primary term
+	 *     version?: number, // Explicit version number for concurrency control
+	 *     version_type?: enum, // Specific version type
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -316,40 +316,40 @@ trait ClientEndpointsTrait
 	 *
 	 * @param array{
 	 *     index: list, // (REQUIRED) A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices
-	 *     analyzer: string, // The analyzer to use for the query string
-	 *     analyze_wildcard: boolean, // Specify whether wildcard and prefix queries should be analyzed (default: false)
-	 *     default_operator: enum, // The default operator for query string query (AND or OR)
-	 *     df: string, // The field to use as default where no field prefix is given in the query string
-	 *     from: number, // Starting offset (default: 0)
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     allow_no_indices: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-	 *     conflicts: enum, // What to do when the delete by query hits version conflicts?
-	 *     expand_wildcards: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
-	 *     lenient: boolean, // Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
-	 *     preference: string, // Specify the node or shard the operation should be performed on (default: random)
-	 *     q: string, // Query in the Lucene query string syntax
-	 *     routing: list, // A comma-separated list of specific routing values
-	 *     scroll: time, // Specify how long a consistent view of the index should be maintained for scrolled search
-	 *     search_type: enum, // Search operation type
-	 *     search_timeout: time, // Explicit timeout for each search request. Defaults to no timeout.
-	 *     max_docs: number, // Maximum number of documents to process (default: all documents)
-	 *     sort: list, // A comma-separated list of <field>:<direction> pairs
-	 *     terminate_after: number, // The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early.
-	 *     stats: list, // Specific 'tag' of the request for logging and statistical purposes
-	 *     version: boolean, // Specify whether to return document version as part of a hit
-	 *     request_cache: boolean, // Specify if request cache should be used for this request or not, defaults to index level setting
-	 *     refresh: boolean, // Should the affected indexes be refreshed?
-	 *     timeout: time, // Time each individual bulk request should wait for shards that are unavailable.
-	 *     wait_for_active_shards: string, // Sets the number of shard copies that must be active before proceeding with the delete by query operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
-	 *     scroll_size: number, // Size on the scroll request powering the delete by query
-	 *     wait_for_completion: boolean, // Should the request should block until the delete by query is complete.
-	 *     requests_per_second: number, // The throttle for this request in sub-requests per second. -1 means no throttle.
-	 *     slices: number|string, // The number of slices this task should be divided into. Defaults to 1, meaning the task isn't sliced into subtasks. Can be set to `auto`.
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     analyzer?: string, // The analyzer to use for the query string
+	 *     analyze_wildcard?: boolean, // Specify whether wildcard and prefix queries should be analyzed (default: false)
+	 *     default_operator?: enum, // The default operator for query string query (AND or OR)
+	 *     df?: string, // The field to use as default where no field prefix is given in the query string
+	 *     from?: number, // Starting offset (default: 0)
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     allow_no_indices?: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+	 *     conflicts?: enum, // What to do when the delete by query hits version conflicts?
+	 *     expand_wildcards?: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
+	 *     lenient?: boolean, // Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
+	 *     preference?: string, // Specify the node or shard the operation should be performed on (default: random)
+	 *     q?: string, // Query in the Lucene query string syntax
+	 *     routing?: list, // A comma-separated list of specific routing values
+	 *     scroll?: time, // Specify how long a consistent view of the index should be maintained for scrolled search
+	 *     search_type?: enum, // Search operation type
+	 *     search_timeout?: time, // Explicit timeout for each search request. Defaults to no timeout.
+	 *     max_docs?: number, // Maximum number of documents to process (default: all documents)
+	 *     sort?: list, // A comma-separated list of <field>:<direction> pairs
+	 *     terminate_after?: number, // The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early.
+	 *     stats?: list, // Specific 'tag' of the request for logging and statistical purposes
+	 *     version?: boolean, // Specify whether to return document version as part of a hit
+	 *     request_cache?: boolean, // Specify if request cache should be used for this request or not, defaults to index level setting
+	 *     refresh?: boolean, // Should the affected indexes be refreshed?
+	 *     timeout?: time, // Time each individual bulk request should wait for shards that are unavailable.
+	 *     wait_for_active_shards?: string, // Sets the number of shard copies that must be active before proceeding with the delete by query operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
+	 *     scroll_size?: number, // Size on the scroll request powering the delete by query
+	 *     wait_for_completion?: boolean, // Should the request should block until the delete by query is complete.
+	 *     requests_per_second?: number, // The throttle for this request in sub-requests per second. -1 means no throttle.
+	 *     slices?: number|string, // The number of slices this task should be divided into. Defaults to 1, meaning the task isn't sliced into subtasks. Can be set to `auto`.
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 *     body: array, // (REQUIRED) The search definition using the Query DSL
 	 * } $params
 	 *
@@ -384,12 +384,12 @@ trait ClientEndpointsTrait
 	 *
 	 * @param array{
 	 *     task_id: string, // (REQUIRED) The task id to rethrottle
-	 *     requests_per_second: number, // The throttle to set on this request in floating sub-requests per second. -1 means set no throttle.
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     requests_per_second?: number, // The throttle to set on this request in floating sub-requests per second. -1 means set no throttle.
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -422,13 +422,13 @@ trait ClientEndpointsTrait
 	 *
 	 * @param array{
 	 *     id: string, // (REQUIRED) Script ID
-	 *     timeout: time, // Explicit operation timeout
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     timeout?: time, // Explicit operation timeout
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -462,21 +462,21 @@ trait ClientEndpointsTrait
 	 * @param array{
 	 *     id: string, // (REQUIRED) The document ID
 	 *     index: string, // (REQUIRED) The name of the index
-	 *     stored_fields: list, // A comma-separated list of stored fields to return in the response
-	 *     preference: string, // Specify the node or shard the operation should be performed on (default: random)
-	 *     realtime: boolean, // Specify whether to perform the operation in realtime or search mode
-	 *     refresh: boolean, // Refresh the shard containing the document before performing the operation
-	 *     routing: string, // Specific routing value
-	 *     _source: list, // True or false to return the _source field or not, or a list of fields to return
-	 *     _source_excludes: list, // A list of fields to exclude from the returned _source field
-	 *     _source_includes: list, // A list of fields to extract and return from the _source field
-	 *     version: number, // Explicit version number for concurrency control
-	 *     version_type: enum, // Specific version type
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     stored_fields?: list, // A comma-separated list of stored fields to return in the response
+	 *     preference?: string, // Specify the node or shard the operation should be performed on (default: random)
+	 *     realtime?: boolean, // Specify whether to perform the operation in realtime or search mode
+	 *     refresh?: boolean, // Refresh the shard containing the document before performing the operation
+	 *     routing?: string, // Specific routing value
+	 *     _source?: list, // True or false to return the _source field or not, or a list of fields to return
+	 *     _source_excludes?: list, // A list of fields to exclude from the returned _source field
+	 *     _source_includes?: list, // A list of fields to extract and return from the _source field
+	 *     version?: number, // Explicit version number for concurrency control
+	 *     version_type?: enum, // Specific version type
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -510,20 +510,20 @@ trait ClientEndpointsTrait
 	 * @param array{
 	 *     id: string, // (REQUIRED) The document ID
 	 *     index: string, // (REQUIRED) The name of the index
-	 *     preference: string, // Specify the node or shard the operation should be performed on (default: random)
-	 *     realtime: boolean, // Specify whether to perform the operation in realtime or search mode
-	 *     refresh: boolean, // Refresh the shard containing the document before performing the operation
-	 *     routing: string, // Specific routing value
-	 *     _source: list, // True or false to return the _source field or not, or a list of fields to return
-	 *     _source_excludes: list, // A list of fields to exclude from the returned _source field
-	 *     _source_includes: list, // A list of fields to extract and return from the _source field
-	 *     version: number, // Explicit version number for concurrency control
-	 *     version_type: enum, // Specific version type
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     preference?: string, // Specify the node or shard the operation should be performed on (default: random)
+	 *     realtime?: boolean, // Specify whether to perform the operation in realtime or search mode
+	 *     refresh?: boolean, // Refresh the shard containing the document before performing the operation
+	 *     routing?: string, // Specific routing value
+	 *     _source?: list, // True or false to return the _source field or not, or a list of fields to return
+	 *     _source_excludes?: list, // A list of fields to exclude from the returned _source field
+	 *     _source_includes?: list, // A list of fields to extract and return from the _source field
+	 *     version?: number, // Explicit version number for concurrency control
+	 *     version_type?: enum, // Specific version type
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -557,24 +557,24 @@ trait ClientEndpointsTrait
 	 * @param array{
 	 *     id: string, // (REQUIRED) The document ID
 	 *     index: string, // (REQUIRED) The name of the index
-	 *     analyze_wildcard: boolean, // Specify whether wildcards and prefix queries in the query string query should be analyzed (default: false)
-	 *     analyzer: string, // The analyzer for the query string query
-	 *     default_operator: enum, // The default operator for query string query (AND or OR)
-	 *     df: string, // The default field for query string query (default: _all)
-	 *     stored_fields: list, // A comma-separated list of stored fields to return in the response
-	 *     lenient: boolean, // Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
-	 *     preference: string, // Specify the node or shard the operation should be performed on (default: random)
-	 *     q: string, // Query in the Lucene query string syntax
-	 *     routing: string, // Specific routing value
-	 *     _source: list, // True or false to return the _source field or not, or a list of fields to return
-	 *     _source_excludes: list, // A list of fields to exclude from the returned _source field
-	 *     _source_includes: list, // A list of fields to extract and return from the _source field
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
-	 *     body: array, //  The query definition using the Query DSL
+	 *     analyze_wildcard?: boolean, // Specify whether wildcards and prefix queries in the query string query should be analyzed (default: false)
+	 *     analyzer?: string, // The analyzer for the query string query
+	 *     default_operator?: enum, // The default operator for query string query (AND or OR)
+	 *     df?: string, // The default field for query string query (default: _all)
+	 *     stored_fields?: list, // A comma-separated list of stored fields to return in the response
+	 *     lenient?: boolean, // Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
+	 *     preference?: string, // Specify the node or shard the operation should be performed on (default: random)
+	 *     q?: string, // Query in the Lucene query string syntax
+	 *     routing?: string, // Specific routing value
+	 *     _source?: list, // True or false to return the _source field or not, or a list of fields to return
+	 *     _source_excludes?: list, // A list of fields to exclude from the returned _source field
+	 *     _source_includes?: list, // A list of fields to extract and return from the _source field
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
+	 *     body?: array, //  The query definition using the Query DSL
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -607,21 +607,21 @@ trait ClientEndpointsTrait
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html
 	 *
 	 * @param array{
-	 *     index: list, //  A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
-	 *     fields: list, // A comma-separated list of field names
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     allow_no_indices: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-	 *     expand_wildcards: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
-	 *     include_unmapped: boolean, // Indicates whether unmapped fields should be included in the response.
-	 *     filters: list, // An optional set of filters: can include +metadata,-metadata,-nested,-multifield,-parent
-	 *     types: list, // Only return results for fields that have one of the types in the list
-	 *     include_empty_fields: boolean, // Include empty fields in result
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
-	 *     body: array, //  An index filter specified with the Query DSL
+	 *     index?: list, //  A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
+	 *     fields?: list, // A comma-separated list of field names
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     allow_no_indices?: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+	 *     expand_wildcards?: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
+	 *     include_unmapped?: boolean, // Indicates whether unmapped fields should be included in the response.
+	 *     filters?: list, // An optional set of filters: can include +metadata,-metadata,-nested,-multifield,-parent
+	 *     types?: list, // Only return results for fields that have one of the types in the list
+	 *     include_empty_fields?: boolean, // Include empty fields in result
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
+	 *     body?: array, //  An index filter specified with the Query DSL
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -658,22 +658,22 @@ trait ClientEndpointsTrait
 	 * @param array{
 	 *     id: string, // (REQUIRED) The document ID
 	 *     index: string, // (REQUIRED) The name of the index
-	 *     force_synthetic_source: boolean, // Should this request force synthetic _source? Use this to test if the mapping supports synthetic _source and to get a sense of the worst case performance. Fetches with this enabled will be slower the enabling synthetic source natively in the index.
-	 *     stored_fields: list, // A comma-separated list of stored fields to return in the response
-	 *     preference: string, // Specify the node or shard the operation should be performed on (default: random)
-	 *     realtime: boolean, // Specify whether to perform the operation in realtime or search mode
-	 *     refresh: boolean, // Refresh the shard containing the document before performing the operation
-	 *     routing: string, // Specific routing value
-	 *     _source: list, // True or false to return the _source field or not, or a list of fields to return
-	 *     _source_excludes: list, // A list of fields to exclude from the returned _source field
-	 *     _source_includes: list, // A list of fields to extract and return from the _source field
-	 *     version: number, // Explicit version number for concurrency control
-	 *     version_type: enum, // Specific version type
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     force_synthetic_source?: boolean, // Should this request force synthetic _source? Use this to test if the mapping supports synthetic _source and to get a sense of the worst case performance. Fetches with this enabled will be slower the enabling synthetic source natively in the index.
+	 *     stored_fields?: list, // A comma-separated list of stored fields to return in the response
+	 *     preference?: string, // Specify the node or shard the operation should be performed on (default: random)
+	 *     realtime?: boolean, // Specify whether to perform the operation in realtime or search mode
+	 *     refresh?: boolean, // Refresh the shard containing the document before performing the operation
+	 *     routing?: string, // Specific routing value
+	 *     _source?: list, // True or false to return the _source field or not, or a list of fields to return
+	 *     _source_excludes?: list, // A list of fields to exclude from the returned _source field
+	 *     _source_includes?: list, // A list of fields to extract and return from the _source field
+	 *     version?: number, // Explicit version number for concurrency control
+	 *     version_type?: enum, // Specific version type
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -706,12 +706,12 @@ trait ClientEndpointsTrait
 	 *
 	 * @param array{
 	 *     id: string, // (REQUIRED) Script ID
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -743,11 +743,11 @@ trait ClientEndpointsTrait
 	 * @see https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-contexts.html
 	 *
 	 * @param array{
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -777,11 +777,11 @@ trait ClientEndpointsTrait
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html
 	 *
 	 * @param array{
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -813,20 +813,20 @@ trait ClientEndpointsTrait
 	 * @param array{
 	 *     id: string, // (REQUIRED) The document ID
 	 *     index: string, // (REQUIRED) The name of the index
-	 *     preference: string, // Specify the node or shard the operation should be performed on (default: random)
-	 *     realtime: boolean, // Specify whether to perform the operation in realtime or search mode
-	 *     refresh: boolean, // Refresh the shard containing the document before performing the operation
-	 *     routing: string, // Specific routing value
-	 *     _source: list, // True or false to return the _source field or not, or a list of fields to return
-	 *     _source_excludes: list, // A list of fields to exclude from the returned _source field
-	 *     _source_includes: list, // A list of fields to extract and return from the _source field
-	 *     version: number, // Explicit version number for concurrency control
-	 *     version_type: enum, // Specific version type
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     preference?: string, // Specify the node or shard the operation should be performed on (default: random)
+	 *     realtime?: boolean, // Specify whether to perform the operation in realtime or search mode
+	 *     refresh?: boolean, // Refresh the shard containing the document before performing the operation
+	 *     routing?: string, // Specific routing value
+	 *     _source?: list, // True or false to return the _source field or not, or a list of fields to return
+	 *     _source_excludes?: list, // A list of fields to exclude from the returned _source field
+	 *     _source_includes?: list, // A list of fields to extract and return from the _source field
+	 *     version?: number, // Explicit version number for concurrency control
+	 *     version_type?: enum, // Specific version type
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -858,15 +858,15 @@ trait ClientEndpointsTrait
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/health-api.html
 	 *
 	 * @param array{
-	 *     feature: string, //  A feature of the cluster, as returned by the top-level health API
-	 *     timeout: time, // Explicit operation timeout
-	 *     verbose: boolean, // Opt in for more information about the health of the system
-	 *     size: int, // Limit the number of affected resources the health API returns
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     feature?: string, //  A feature of the cluster, as returned by the top-level health API
+	 *     timeout?: time, // Explicit operation timeout
+	 *     verbose?: boolean, // Opt in for more information about the health of the system
+	 *     size?: int, // Limit the number of affected resources the health API returns
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -900,25 +900,25 @@ trait ClientEndpointsTrait
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html
 	 *
 	 * @param array{
-	 *     id: string, //  Document ID
+	 *     id?: string, //  Document ID
 	 *     index: string, // (REQUIRED) The name of the index
-	 *     wait_for_active_shards: string, // Sets the number of shard copies that must be active before proceeding with the index operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
-	 *     op_type: enum, // Explicit operation type. Defaults to `index` for requests with an explicit document ID, and to `create`for requests without an explicit document ID
-	 *     refresh: enum, // If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes.
-	 *     routing: string, // Specific routing value
-	 *     timeout: time, // Explicit operation timeout
-	 *     version: number, // Explicit version number for concurrency control
-	 *     version_type: enum, // Specific version type
-	 *     if_seq_no: number, // only perform the index operation if the last operation that has changed the document has the specified sequence number
-	 *     if_primary_term: number, // only perform the index operation if the last operation that has changed the document has the specified primary term
-	 *     pipeline: string, // The pipeline id to preprocess incoming documents with
-	 *     require_alias: boolean, // When true, requires destination to be an alias. Default is false
-	 *     require_data_stream: boolean, // When true, requires the destination to be a data stream (existing or to-be-created). Default is false
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     wait_for_active_shards?: string, // Sets the number of shard copies that must be active before proceeding with the index operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
+	 *     op_type?: enum, // Explicit operation type. Defaults to `index` for requests with an explicit document ID, and to `create`for requests without an explicit document ID
+	 *     refresh?: enum, // If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes.
+	 *     routing?: string, // Specific routing value
+	 *     timeout?: time, // Explicit operation timeout
+	 *     version?: number, // Explicit version number for concurrency control
+	 *     version_type?: enum, // Specific version type
+	 *     if_seq_no?: number, // only perform the index operation if the last operation that has changed the document has the specified sequence number
+	 *     if_primary_term?: number, // only perform the index operation if the last operation that has changed the document has the specified primary term
+	 *     pipeline?: string, // The pipeline id to preprocess incoming documents with
+	 *     require_alias?: boolean, // When true, requires destination to be an alias. Default is false
+	 *     require_data_stream?: boolean, // When true, requires the destination to be a data stream (existing or to-be-created). Default is false
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 *     body: array, // (REQUIRED) The document
 	 * } $params
 	 *
@@ -956,11 +956,11 @@ trait ClientEndpointsTrait
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
 	 *
 	 * @param array{
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -992,13 +992,13 @@ trait ClientEndpointsTrait
 	 *
 	 * @param array{
 	 *     index: list, // (REQUIRED) A comma-separated list of index names to search; use `_all` to perform the operation on all indices
-	 *     routing: list, // A comma-separated list of specific routing values
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
-	 *     body: array, //  The search definition
+	 *     routing?: list, // A comma-separated list of specific routing values
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
+	 *     body?: array, //  The search definition
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -1031,21 +1031,21 @@ trait ClientEndpointsTrait
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html
 	 *
 	 * @param array{
-	 *     index: string, //  The name of the index
-	 *     force_synthetic_source: boolean, // Should this request force synthetic _source? Use this to test if the mapping supports synthetic _source and to get a sense of the worst case performance. Fetches with this enabled will be slower the enabling synthetic source natively in the index.
-	 *     stored_fields: list, // A comma-separated list of stored fields to return in the response
-	 *     preference: string, // Specify the node or shard the operation should be performed on (default: random)
-	 *     realtime: boolean, // Specify whether to perform the operation in realtime or search mode
-	 *     refresh: boolean, // Refresh the shard containing the document before performing the operation
-	 *     routing: string, // Specific routing value
-	 *     _source: list, // True or false to return the _source field or not, or a list of fields to return
-	 *     _source_excludes: list, // A list of fields to exclude from the returned _source field
-	 *     _source_includes: list, // A list of fields to extract and return from the _source field
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     index?: string, //  The name of the index
+	 *     force_synthetic_source?: boolean, // Should this request force synthetic _source? Use this to test if the mapping supports synthetic _source and to get a sense of the worst case performance. Fetches with this enabled will be slower the enabling synthetic source natively in the index.
+	 *     stored_fields?: list, // A comma-separated list of stored fields to return in the response
+	 *     preference?: string, // Specify the node or shard the operation should be performed on (default: random)
+	 *     realtime?: boolean, // Specify whether to perform the operation in realtime or search mode
+	 *     refresh?: boolean, // Refresh the shard containing the document before performing the operation
+	 *     routing?: string, // Specific routing value
+	 *     _source?: list, // True or false to return the _source field or not, or a list of fields to return
+	 *     _source_excludes?: list, // A list of fields to exclude from the returned _source field
+	 *     _source_includes?: list, // A list of fields to extract and return from the _source field
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 *     body: array, // (REQUIRED) Document identifiers; can be either `docs` (containing full document information) or `ids` (when index is provided in the URL.
 	 * } $params
 	 *
@@ -1082,19 +1082,19 @@ trait ClientEndpointsTrait
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html
 	 *
 	 * @param array{
-	 *     index: list, //  A comma-separated list of index names to use as default
-	 *     search_type: enum, // Search operation type
-	 *     max_concurrent_searches: number, // Controls the maximum number of concurrent searches the multi search api will execute
-	 *     typed_keys: boolean, // Specify whether aggregation and suggester names should be prefixed by their respective types in the response
-	 *     pre_filter_shard_size: number, // A threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method ie. if date filters are mandatory to match but the shard bounds and the query are disjoint.
-	 *     max_concurrent_shard_requests: number, // The number of concurrent shard requests each sub search executes concurrently per node. This value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests
-	 *     rest_total_hits_as_int: boolean, // Indicates whether hits.total should be rendered as an integer or an object in the rest search response
-	 *     ccs_minimize_roundtrips: boolean, // Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     index?: list, //  A comma-separated list of index names to use as default
+	 *     search_type?: enum, // Search operation type
+	 *     max_concurrent_searches?: number, // Controls the maximum number of concurrent searches the multi search api will execute
+	 *     typed_keys?: boolean, // Specify whether aggregation and suggester names should be prefixed by their respective types in the response
+	 *     pre_filter_shard_size?: number, // A threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method ie. if date filters are mandatory to match but the shard bounds and the query are disjoint.
+	 *     max_concurrent_shard_requests?: number, // The number of concurrent shard requests each sub search executes concurrently per node. This value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests
+	 *     rest_total_hits_as_int?: boolean, // Indicates whether hits.total should be rendered as an integer or an object in the rest search response
+	 *     ccs_minimize_roundtrips?: boolean, // Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 *     body: array, // (REQUIRED) The request definitions (metadata-search request definition pairs), separated by newlines
 	 * } $params
 	 *
@@ -1131,17 +1131,17 @@ trait ClientEndpointsTrait
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html
 	 *
 	 * @param array{
-	 *     index: list, //  A comma-separated list of index names to use as default
-	 *     search_type: enum, // Search operation type
-	 *     typed_keys: boolean, // Specify whether aggregation and suggester names should be prefixed by their respective types in the response
-	 *     max_concurrent_searches: number, // Controls the maximum number of concurrent searches the multi search api will execute
-	 *     rest_total_hits_as_int: boolean, // Indicates whether hits.total should be rendered as an integer or an object in the rest search response
-	 *     ccs_minimize_roundtrips: boolean, // Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     index?: list, //  A comma-separated list of index names to use as default
+	 *     search_type?: enum, // Search operation type
+	 *     typed_keys?: boolean, // Specify whether aggregation and suggester names should be prefixed by their respective types in the response
+	 *     max_concurrent_searches?: number, // Controls the maximum number of concurrent searches the multi search api will execute
+	 *     rest_total_hits_as_int?: boolean, // Indicates whether hits.total should be rendered as an integer or an object in the rest search response
+	 *     ccs_minimize_roundtrips?: boolean, // Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 *     body: array, // (REQUIRED) The request definitions (metadata-search request definition pairs), separated by newlines
 	 * } $params
 	 *
@@ -1178,25 +1178,25 @@ trait ClientEndpointsTrait
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html
 	 *
 	 * @param array{
-	 *     index: string, //  The index in which the document resides.
-	 *     ids: list, // A comma-separated list of documents ids. You must define ids as parameter or set "ids" or "docs" in the request body
-	 *     term_statistics: boolean, // Specifies if total term frequency and document frequency should be returned. Applies to all returned documents unless otherwise specified in body "params" or "docs".
-	 *     field_statistics: boolean, // Specifies if document count, sum of document frequencies and sum of total term frequencies should be returned. Applies to all returned documents unless otherwise specified in body "params" or "docs".
-	 *     fields: list, // A comma-separated list of fields to return. Applies to all returned documents unless otherwise specified in body "params" or "docs".
-	 *     offsets: boolean, // Specifies if term offsets should be returned. Applies to all returned documents unless otherwise specified in body "params" or "docs".
-	 *     positions: boolean, // Specifies if term positions should be returned. Applies to all returned documents unless otherwise specified in body "params" or "docs".
-	 *     payloads: boolean, // Specifies if term payloads should be returned. Applies to all returned documents unless otherwise specified in body "params" or "docs".
-	 *     preference: string, // Specify the node or shard the operation should be performed on (default: random) .Applies to all returned documents unless otherwise specified in body "params" or "docs".
-	 *     routing: string, // Specific routing value. Applies to all returned documents unless otherwise specified in body "params" or "docs".
-	 *     realtime: boolean, // Specifies if requests are real-time as opposed to near-real-time (default: true).
-	 *     version: number, // Explicit version number for concurrency control
-	 *     version_type: enum, // Specific version type
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
-	 *     body: array, //  Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.
+	 *     index?: string, //  The index in which the document resides.
+	 *     ids?: list, // A comma-separated list of documents ids. You must define ids as parameter or set "ids" or "docs" in the request body
+	 *     term_statistics?: boolean, // Specifies if total term frequency and document frequency should be returned. Applies to all returned documents unless otherwise specified in body "params" or "docs".
+	 *     field_statistics?: boolean, // Specifies if document count, sum of document frequencies and sum of total term frequencies should be returned. Applies to all returned documents unless otherwise specified in body "params" or "docs".
+	 *     fields?: list, // A comma-separated list of fields to return. Applies to all returned documents unless otherwise specified in body "params" or "docs".
+	 *     offsets?: boolean, // Specifies if term offsets should be returned. Applies to all returned documents unless otherwise specified in body "params" or "docs".
+	 *     positions?: boolean, // Specifies if term positions should be returned. Applies to all returned documents unless otherwise specified in body "params" or "docs".
+	 *     payloads?: boolean, // Specifies if term payloads should be returned. Applies to all returned documents unless otherwise specified in body "params" or "docs".
+	 *     preference?: string, // Specify the node or shard the operation should be performed on (default: random) .Applies to all returned documents unless otherwise specified in body "params" or "docs".
+	 *     routing?: string, // Specific routing value. Applies to all returned documents unless otherwise specified in body "params" or "docs".
+	 *     realtime?: boolean, // Specifies if requests are real-time as opposed to near-real-time (default: true).
+	 *     version?: number, // Explicit version number for concurrency control
+	 *     version_type?: enum, // Specific version type
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
+	 *     body?: array, //  Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -1232,18 +1232,18 @@ trait ClientEndpointsTrait
 	 *
 	 * @param array{
 	 *     index: list, // (REQUIRED) A comma-separated list of index names to open point in time; use `_all` or empty string to perform the operation on all indices
-	 *     preference: string, // Specify the node or shard the operation should be performed on (default: random)
-	 *     routing: string, // Specific routing value
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     expand_wildcards: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
-	 *     keep_alive: string, // Specific the time to live for the point in time
-	 *     allow_partial_search_results: boolean, // Specify whether to tolerate shards missing when creating the point-in-time, or otherwise throw an exception. (default: false)
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
-	 *     body: array, //  An index_filter specified with the Query DSL
+	 *     preference?: string, // Specify the node or shard the operation should be performed on (default: random)
+	 *     routing?: string, // Specific routing value
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     expand_wildcards?: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
+	 *     keep_alive?: string, // Specific the time to live for the point in time
+	 *     allow_partial_search_results?: boolean, // Specify whether to tolerate shards missing when creating the point-in-time, or otherwise throw an exception. (default: false)
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
+	 *     body?: array, //  An index_filter specified with the Query DSL
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -1276,11 +1276,11 @@ trait ClientEndpointsTrait
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
 	 *
 	 * @param array{
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -1311,14 +1311,14 @@ trait ClientEndpointsTrait
 	 *
 	 * @param array{
 	 *     id: string, // (REQUIRED) Script ID
-	 *     context: string, //  Script context
-	 *     timeout: time, // Explicit operation timeout
-	 *     master_timeout: time, // Specify timeout for connection to master
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     context?: string, //  Script context
+	 *     timeout?: time, // Explicit operation timeout
+	 *     master_timeout?: time, // Specify timeout for connection to master
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 *     body: array, // (REQUIRED) The document
 	 * } $params
 	 *
@@ -1356,16 +1356,16 @@ trait ClientEndpointsTrait
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/search-rank-eval.html
 	 *
 	 * @param array{
-	 *     index: list, //  A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     allow_no_indices: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-	 *     expand_wildcards: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
-	 *     search_type: enum, // Search operation type
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     index?: list, //  A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     allow_no_indices?: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+	 *     expand_wildcards?: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
+	 *     search_type?: enum, // Search operation type
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 *     body: array, // (REQUIRED) The ranking evaluation search definition, including search requests, document ratings and ranking metric definition.
 	 * } $params
 	 *
@@ -1404,19 +1404,19 @@ trait ClientEndpointsTrait
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html
 	 *
 	 * @param array{
-	 *     refresh: boolean, // Should the affected indexes be refreshed?
-	 *     timeout: time, // Time each individual bulk request should wait for shards that are unavailable.
-	 *     wait_for_active_shards: string, // Sets the number of shard copies that must be active before proceeding with the reindex operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
-	 *     wait_for_completion: boolean, // Should the request should block until the reindex is complete.
-	 *     requests_per_second: number, // The throttle to set on this request in sub-requests per second. -1 means no throttle.
-	 *     scroll: time, // Control how long to keep the search context alive
-	 *     slices: number|string, // The number of slices this task should be divided into. Defaults to 1, meaning the task isn't sliced into subtasks. Can be set to `auto`.
-	 *     max_docs: number, // Maximum number of documents to process (default: all documents)
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     refresh?: boolean, // Should the affected indexes be refreshed?
+	 *     timeout?: time, // Time each individual bulk request should wait for shards that are unavailable.
+	 *     wait_for_active_shards?: string, // Sets the number of shard copies that must be active before proceeding with the reindex operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
+	 *     wait_for_completion?: boolean, // Should the request should block until the reindex is complete.
+	 *     requests_per_second?: number, // The throttle to set on this request in sub-requests per second. -1 means no throttle.
+	 *     scroll?: time, // Control how long to keep the search context alive
+	 *     slices?: number|string, // The number of slices this task should be divided into. Defaults to 1, meaning the task isn't sliced into subtasks. Can be set to `auto`.
+	 *     max_docs?: number, // Maximum number of documents to process (default: all documents)
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 *     body: array, // (REQUIRED) The search definition using the Query DSL and the prototype for the index request.
 	 * } $params
 	 *
@@ -1450,12 +1450,12 @@ trait ClientEndpointsTrait
 	 *
 	 * @param array{
 	 *     task_id: string, // (REQUIRED) The task id to rethrottle
-	 *     requests_per_second: number, // The throttle to set on this request in floating sub-requests per second. -1 means set no throttle.
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     requests_per_second?: number, // The throttle to set on this request in floating sub-requests per second. -1 means set no throttle.
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -1487,13 +1487,13 @@ trait ClientEndpointsTrait
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/render-search-template-api.html
 	 *
 	 * @param array{
-	 *     id: string, //  The id of the stored search template
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
-	 *     body: array, //  The search definition template and its params
+	 *     id?: string, //  The id of the stored search template
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
+	 *     body?: array, //  The search definition template and its params
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -1529,12 +1529,12 @@ trait ClientEndpointsTrait
 	 * @internal This API is EXPERIMENTAL and may be changed or removed completely in a future release
 	 *
 	 * @param array{
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
-	 *     body: array, //  The script to execute
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
+	 *     body?: array, //  The script to execute
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -1565,15 +1565,15 @@ trait ClientEndpointsTrait
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#request-body-search-scroll
 	 *
 	 * @param array{
-	 *     scroll_id: string, //  The scroll ID
-	 *     scroll: time, // Specify how long a consistent view of the index should be maintained for scrolled search
-	 *     rest_total_hits_as_int: boolean, // Indicates whether hits.total should be rendered as an integer or an object in the rest search response
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
-	 *     body: array, //  The scroll ID if not passed by URL or query parameter.
+	 *     scroll_id?: string, //  The scroll ID
+	 *     scroll?: time, // Specify how long a consistent view of the index should be maintained for scrolled search
+	 *     rest_total_hits_as_int?: boolean, // Indicates whether hits.total should be rendered as an integer or an object in the rest search response
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
+	 *     body?: array, //  The scroll ID if not passed by URL or query parameter.
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -1608,58 +1608,58 @@ trait ClientEndpointsTrait
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html
 	 *
 	 * @param array{
-	 *     index: list, //  A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices
-	 *     analyzer: string, // The analyzer to use for the query string
-	 *     analyze_wildcard: boolean, // Specify whether wildcard and prefix queries should be analyzed (default: false)
-	 *     ccs_minimize_roundtrips: boolean, // Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution
-	 *     default_operator: enum, // The default operator for query string query (AND or OR)
-	 *     df: string, // The field to use as default where no field prefix is given in the query string
-	 *     explain: boolean, // Specify whether to return detailed information about score computation as part of a hit
-	 *     stored_fields: list, // A comma-separated list of stored fields to return as part of a hit
-	 *     docvalue_fields: list, // A comma-separated list of fields to return as the docvalue representation of a field for each hit
-	 *     from: number, // Starting offset (default: 0)
-	 *     force_synthetic_source: boolean, // Should this request force synthetic _source? Use this to test if the mapping supports synthetic _source and to get a sense of the worst case performance. Fetches with this enabled will be slower the enabling synthetic source natively in the index.
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     ignore_throttled: boolean, // Whether specified concrete, expanded or aliased indices should be ignored when throttled
-	 *     allow_no_indices: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-	 *     expand_wildcards: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
-	 *     lenient: boolean, // Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
-	 *     preference: string, // Specify the node or shard the operation should be performed on (default: random)
-	 *     q: string, // Query in the Lucene query string syntax
-	 *     routing: list, // A comma-separated list of specific routing values
-	 *     scroll: time, // Specify how long a consistent view of the index should be maintained for scrolled search
-	 *     search_type: enum, // Search operation type
-	 *     size: number, // Number of hits to return (default: 10)
-	 *     sort: list, // A comma-separated list of <field>:<direction> pairs
-	 *     _source: list, // True or false to return the _source field or not, or a list of fields to return
-	 *     _source_excludes: list, // A list of fields to exclude from the returned _source field
-	 *     _source_includes: list, // A list of fields to extract and return from the _source field
-	 *     terminate_after: number, // The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early.
-	 *     stats: list, // Specific 'tag' of the request for logging and statistical purposes
-	 *     suggest_field: string, // Specify which field to use for suggestions
-	 *     suggest_mode: enum, // Specify suggest mode
-	 *     suggest_size: number, // How many suggestions to return in response
-	 *     suggest_text: string, // The source text for which the suggestions should be returned
-	 *     timeout: time, // Explicit operation timeout
-	 *     track_scores: boolean, // Whether to calculate and return scores even if they are not used for sorting
-	 *     track_total_hits: boolean|long, // Indicate if the number of documents that match the query should be tracked. A number can also be specified, to accurately track the total hit count up to the number.
-	 *     allow_partial_search_results: boolean, // Indicate if an error should be returned if there is a partial search failure or timeout
-	 *     typed_keys: boolean, // Specify whether aggregation and suggester names should be prefixed by their respective types in the response
-	 *     version: boolean, // Specify whether to return document version as part of a hit
-	 *     seq_no_primary_term: boolean, // Specify whether to return sequence number and primary term of the last modification of each hit
-	 *     request_cache: boolean, // Specify if request cache should be used for this request or not, defaults to index level setting
-	 *     batched_reduce_size: number, // The number of shard results that should be reduced at once on the coordinating node. This value should be used as a protection mechanism to reduce the memory overhead per search request if the potential number of shards in the request can be large.
-	 *     max_concurrent_shard_requests: number, // The number of concurrent shard requests per node this search executes concurrently. This value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests
-	 *     pre_filter_shard_size: number, // A threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method ie. if date filters are mandatory to match but the shard bounds and the query are disjoint.
-	 *     rest_total_hits_as_int: boolean, // Indicates whether hits.total should be rendered as an integer or an object in the rest search response
-	 *     min_compatible_shard_node: string, // The minimum compatible version that all shards involved in search should have for this request to be successful
-	 *     include_named_queries_score: boolean, // Indicates whether hit.matched_queries should be rendered as a map that includes the name of the matched query associated with its score (true) or as an array containing the name of the matched queries (false)
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
-	 *     body: array, //  The search definition using the Query DSL
+	 *     index?: list, //  A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices
+	 *     analyzer?: string, // The analyzer to use for the query string
+	 *     analyze_wildcard?: boolean, // Specify whether wildcard and prefix queries should be analyzed (default: false)
+	 *     ccs_minimize_roundtrips?: boolean, // Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution
+	 *     default_operator?: enum, // The default operator for query string query (AND or OR)
+	 *     df?: string, // The field to use as default where no field prefix is given in the query string
+	 *     explain?: boolean, // Specify whether to return detailed information about score computation as part of a hit
+	 *     stored_fields?: list, // A comma-separated list of stored fields to return as part of a hit
+	 *     docvalue_fields?: list, // A comma-separated list of fields to return as the docvalue representation of a field for each hit
+	 *     from?: number, // Starting offset (default: 0)
+	 *     force_synthetic_source?: boolean, // Should this request force synthetic _source? Use this to test if the mapping supports synthetic _source and to get a sense of the worst case performance. Fetches with this enabled will be slower the enabling synthetic source natively in the index.
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     ignore_throttled?: boolean, // Whether specified concrete, expanded or aliased indices should be ignored when throttled
+	 *     allow_no_indices?: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+	 *     expand_wildcards?: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
+	 *     lenient?: boolean, // Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
+	 *     preference?: string, // Specify the node or shard the operation should be performed on (default: random)
+	 *     q?: string, // Query in the Lucene query string syntax
+	 *     routing?: list, // A comma-separated list of specific routing values
+	 *     scroll?: time, // Specify how long a consistent view of the index should be maintained for scrolled search
+	 *     search_type?: enum, // Search operation type
+	 *     size?: number, // Number of hits to return (default: 10)
+	 *     sort?: list, // A comma-separated list of <field>:<direction> pairs
+	 *     _source?: list, // True or false to return the _source field or not, or a list of fields to return
+	 *     _source_excludes?: list, // A list of fields to exclude from the returned _source field
+	 *     _source_includes?: list, // A list of fields to extract and return from the _source field
+	 *     terminate_after?: number, // The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early.
+	 *     stats?: list, // Specific 'tag' of the request for logging and statistical purposes
+	 *     suggest_field?: string, // Specify which field to use for suggestions
+	 *     suggest_mode?: enum, // Specify suggest mode
+	 *     suggest_size?: number, // How many suggestions to return in response
+	 *     suggest_text?: string, // The source text for which the suggestions should be returned
+	 *     timeout?: time, // Explicit operation timeout
+	 *     track_scores?: boolean, // Whether to calculate and return scores even if they are not used for sorting
+	 *     track_total_hits?: boolean|long, // Indicate if the number of documents that match the query should be tracked. A number can also be specified, to accurately track the total hit count up to the number.
+	 *     allow_partial_search_results?: boolean, // Indicate if an error should be returned if there is a partial search failure or timeout
+	 *     typed_keys?: boolean, // Specify whether aggregation and suggester names should be prefixed by their respective types in the response
+	 *     version?: boolean, // Specify whether to return document version as part of a hit
+	 *     seq_no_primary_term?: boolean, // Specify whether to return sequence number and primary term of the last modification of each hit
+	 *     request_cache?: boolean, // Specify if request cache should be used for this request or not, defaults to index level setting
+	 *     batched_reduce_size?: number, // The number of shard results that should be reduced at once on the coordinating node. This value should be used as a protection mechanism to reduce the memory overhead per search request if the potential number of shards in the request can be large.
+	 *     max_concurrent_shard_requests?: number, // The number of concurrent shard requests per node this search executes concurrently. This value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests
+	 *     pre_filter_shard_size?: number, // A threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method ie. if date filters are mandatory to match but the shard bounds and the query are disjoint.
+	 *     rest_total_hits_as_int?: boolean, // Indicates whether hits.total should be rendered as an integer or an object in the rest search response
+	 *     min_compatible_shard_node?: string, // The minimum compatible version that all shards involved in search should have for this request to be successful
+	 *     include_named_queries_score?: boolean, // Indicates whether hit.matched_queries should be rendered as a map that includes the name of the matched query associated with its score (true) or as an array containing the name of the matched queries (false)
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
+	 *     body?: array, //  The search definition using the Query DSL
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -1700,19 +1700,19 @@ trait ClientEndpointsTrait
 	 *     zoom: int, // (REQUIRED) Zoom level for the vector tile to search
 	 *     x: int, // (REQUIRED) X coordinate for the vector tile to search
 	 *     y: int, // (REQUIRED) Y coordinate for the vector tile to search
-	 *     exact_bounds: boolean, // If false, the meta layer's feature is the bounding box of the tile. If true, the meta layer's feature is a bounding box resulting from a `geo_bounds` aggregation.
-	 *     extent: int, // Size, in pixels, of a side of the vector tile.
-	 *     grid_precision: int, // Additional zoom levels available through the aggs layer. Accepts 0-8.
-	 *     grid_type: enum, // Determines the geometry type for features in the aggs layer.
-	 *     size: int, // Maximum number of features to return in the hits layer. Accepts 0-10000.
-	 *     track_total_hits: boolean|long, // Indicate if the number of documents that match the query should be tracked. A number can also be specified, to accurately track the total hit count up to the number.
-	 *     with_labels: boolean, // If true, the hits and aggs layers will contain additional point features with suggested label positions for the original features.
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
-	 *     body: array, //  Search request body.
+	 *     exact_bounds?: boolean, // If false, the meta layer's feature is the bounding box of the tile. If true, the meta layer's feature is a bounding box resulting from a `geo_bounds` aggregation.
+	 *     extent?: int, // Size, in pixels, of a side of the vector tile.
+	 *     grid_precision?: int, // Additional zoom levels available through the aggs layer. Accepts 0-8.
+	 *     grid_type?: enum, // Determines the geometry type for features in the aggs layer.
+	 *     size?: int, // Maximum number of features to return in the hits layer. Accepts 0-10000.
+	 *     track_total_hits?: boolean|long, // Indicate if the number of documents that match the query should be tracked. A number can also be specified, to accurately track the total hit count up to the number.
+	 *     with_labels?: boolean, // If true, the hits and aggs layers will contain additional point features with suggested label positions for the original features.
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
+	 *     body?: array, //  Search request body.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -1745,19 +1745,19 @@ trait ClientEndpointsTrait
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html
 	 *
 	 * @param array{
-	 *     index: list, //  A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices
-	 *     preference: string, // Specify the node or shard the operation should be performed on (default: random)
-	 *     routing: string, // Specific routing value
-	 *     local: boolean, // Return local information, do not retrieve the state from master node (default: false)
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     allow_no_indices: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-	 *     expand_wildcards: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
-	 *     master_timeout: time, // Explicit operation timeout for connection to master node
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     index?: list, //  A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices
+	 *     preference?: string, // Specify the node or shard the operation should be performed on (default: random)
+	 *     routing?: string, // Specific routing value
+	 *     local?: boolean, // Return local information, do not retrieve the state from master node (default: false)
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     allow_no_indices?: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+	 *     expand_wildcards?: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
+	 *     master_timeout?: time, // Explicit operation timeout for connection to master node
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws NoNodeAvailableException if all the hosts are offline
@@ -1791,25 +1791,25 @@ trait ClientEndpointsTrait
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html
 	 *
 	 * @param array{
-	 *     index: list, //  A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     ignore_throttled: boolean, // Whether specified concrete, expanded or aliased indices should be ignored when throttled
-	 *     allow_no_indices: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-	 *     expand_wildcards: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
-	 *     preference: string, // Specify the node or shard the operation should be performed on (default: random)
-	 *     routing: list, // A comma-separated list of specific routing values
-	 *     scroll: time, // Specify how long a consistent view of the index should be maintained for scrolled search
-	 *     search_type: enum, // Search operation type
-	 *     explain: boolean, // Specify whether to return detailed information about score computation as part of a hit
-	 *     profile: boolean, // Specify whether to profile the query execution
-	 *     typed_keys: boolean, // Specify whether aggregation and suggester names should be prefixed by their respective types in the response
-	 *     rest_total_hits_as_int: boolean, // Indicates whether hits.total should be rendered as an integer or an object in the rest search response
-	 *     ccs_minimize_roundtrips: boolean, // Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     index?: list, //  A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     ignore_throttled?: boolean, // Whether specified concrete, expanded or aliased indices should be ignored when throttled
+	 *     allow_no_indices?: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+	 *     expand_wildcards?: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
+	 *     preference?: string, // Specify the node or shard the operation should be performed on (default: random)
+	 *     routing?: list, // A comma-separated list of specific routing values
+	 *     scroll?: time, // Specify how long a consistent view of the index should be maintained for scrolled search
+	 *     search_type?: enum, // Search operation type
+	 *     explain?: boolean, // Specify whether to return detailed information about score computation as part of a hit
+	 *     profile?: boolean, // Specify whether to profile the query execution
+	 *     typed_keys?: boolean, // Specify whether aggregation and suggester names should be prefixed by their respective types in the response
+	 *     rest_total_hits_as_int?: boolean, // Indicates whether hits.total should be rendered as an integer or an object in the rest search response
+	 *     ccs_minimize_roundtrips?: boolean, // Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 *     body: array, // (REQUIRED) The search definition template and its params
 	 * } $params
 	 *
@@ -1847,12 +1847,12 @@ trait ClientEndpointsTrait
 	 *
 	 * @param array{
 	 *     index: list, // (REQUIRED) A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
-	 *     body: array, //  field name, string which is the prefix expected in matching terms, timeout and size for max number of results
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
+	 *     body?: array, //  field name, string which is the prefix expected in matching terms, timeout and size for max number of results
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -1886,24 +1886,24 @@ trait ClientEndpointsTrait
 	 *
 	 * @param array{
 	 *     index: string, // (REQUIRED) The index in which the document resides.
-	 *     id: string, //  The id of the document, when not specified a doc param should be supplied.
-	 *     term_statistics: boolean, // Specifies if total term frequency and document frequency should be returned.
-	 *     field_statistics: boolean, // Specifies if document count, sum of document frequencies and sum of total term frequencies should be returned.
-	 *     fields: list, // A comma-separated list of fields to return.
-	 *     offsets: boolean, // Specifies if term offsets should be returned.
-	 *     positions: boolean, // Specifies if term positions should be returned.
-	 *     payloads: boolean, // Specifies if term payloads should be returned.
-	 *     preference: string, // Specify the node or shard the operation should be performed on (default: random).
-	 *     routing: string, // Specific routing value.
-	 *     realtime: boolean, // Specifies if request is real-time as opposed to near-real-time (default: true).
-	 *     version: number, // Explicit version number for concurrency control
-	 *     version_type: enum, // Specific version type
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
-	 *     body: array, //  Define parameters and or supply a document to get termvectors for. See documentation.
+	 *     id?: string, //  The id of the document, when not specified a doc param should be supplied.
+	 *     term_statistics?: boolean, // Specifies if total term frequency and document frequency should be returned.
+	 *     field_statistics?: boolean, // Specifies if document count, sum of document frequencies and sum of total term frequencies should be returned.
+	 *     fields?: list, // A comma-separated list of fields to return.
+	 *     offsets?: boolean, // Specifies if term offsets should be returned.
+	 *     positions?: boolean, // Specifies if term positions should be returned.
+	 *     payloads?: boolean, // Specifies if term payloads should be returned.
+	 *     preference?: string, // Specify the node or shard the operation should be performed on (default: random).
+	 *     routing?: string, // Specific routing value.
+	 *     realtime?: boolean, // Specifies if request is real-time as opposed to near-real-time (default: true).
+	 *     version?: number, // Explicit version number for concurrency control
+	 *     version_type?: enum, // Specific version type
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
+	 *     body?: array, //  Define parameters and or supply a document to get termvectors for. See documentation.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -1942,23 +1942,23 @@ trait ClientEndpointsTrait
 	 * @param array{
 	 *     id: string, // (REQUIRED) Document ID
 	 *     index: string, // (REQUIRED) The name of the index
-	 *     wait_for_active_shards: string, // Sets the number of shard copies that must be active before proceeding with the update operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
-	 *     _source: list, // True or false to return the _source field or not, or a list of fields to return
-	 *     _source_excludes: list, // A list of fields to exclude from the returned _source field
-	 *     _source_includes: list, // A list of fields to extract and return from the _source field
-	 *     lang: string, // The script language (default: painless)
-	 *     refresh: enum, // If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes.
-	 *     retry_on_conflict: number, // Specify how many times should the operation be retried when a conflict occurs (default: 0)
-	 *     routing: string, // Specific routing value
-	 *     timeout: time, // Explicit operation timeout
-	 *     if_seq_no: number, // only perform the update operation if the last operation that has changed the document has the specified sequence number
-	 *     if_primary_term: number, // only perform the update operation if the last operation that has changed the document has the specified primary term
-	 *     require_alias: boolean, // When true, requires destination is an alias. Default is false
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     wait_for_active_shards?: string, // Sets the number of shard copies that must be active before proceeding with the update operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
+	 *     _source?: list, // True or false to return the _source field or not, or a list of fields to return
+	 *     _source_excludes?: list, // A list of fields to exclude from the returned _source field
+	 *     _source_includes?: list, // A list of fields to extract and return from the _source field
+	 *     lang?: string, // The script language (default: painless)
+	 *     refresh?: enum, // If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes.
+	 *     retry_on_conflict?: number, // Specify how many times should the operation be retried when a conflict occurs (default: 0)
+	 *     routing?: string, // Specific routing value
+	 *     timeout?: time, // Explicit operation timeout
+	 *     if_seq_no?: number, // only perform the update operation if the last operation that has changed the document has the specified sequence number
+	 *     if_primary_term?: number, // only perform the update operation if the last operation that has changed the document has the specified primary term
+	 *     require_alias?: boolean, // When true, requires destination is an alias. Default is false
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 *     body: array, // (REQUIRED) The request definition requires either `script` or partial `doc`
 	 * } $params
 	 *
@@ -1994,43 +1994,43 @@ trait ClientEndpointsTrait
 	 *
 	 * @param array{
 	 *     index: list, // (REQUIRED) A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices
-	 *     analyzer: string, // The analyzer to use for the query string
-	 *     analyze_wildcard: boolean, // Specify whether wildcard and prefix queries should be analyzed (default: false)
-	 *     default_operator: enum, // The default operator for query string query (AND or OR)
-	 *     df: string, // The field to use as default where no field prefix is given in the query string
-	 *     from: number, // Starting offset (default: 0)
-	 *     ignore_unavailable: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
-	 *     allow_no_indices: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-	 *     conflicts: enum, // What to do when the update by query hits version conflicts?
-	 *     expand_wildcards: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
-	 *     lenient: boolean, // Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
-	 *     pipeline: string, // Ingest pipeline to set on index requests made by this action. (default: none)
-	 *     preference: string, // Specify the node or shard the operation should be performed on (default: random)
-	 *     q: string, // Query in the Lucene query string syntax
-	 *     routing: list, // A comma-separated list of specific routing values
-	 *     scroll: time, // Specify how long a consistent view of the index should be maintained for scrolled search
-	 *     search_type: enum, // Search operation type
-	 *     search_timeout: time, // Explicit timeout for each search request. Defaults to no timeout.
-	 *     max_docs: number, // Maximum number of documents to process (default: all documents)
-	 *     sort: list, // A comma-separated list of <field>:<direction> pairs
-	 *     terminate_after: number, // The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early.
-	 *     stats: list, // Specific 'tag' of the request for logging and statistical purposes
-	 *     version: boolean, // Specify whether to return document version as part of a hit
-	 *     version_type: boolean, // Should the document increment the version number (internal) on hit or not (reindex)
-	 *     request_cache: boolean, // Specify if request cache should be used for this request or not, defaults to index level setting
-	 *     refresh: boolean, // Should the affected indexes be refreshed?
-	 *     timeout: time, // Time each individual bulk request should wait for shards that are unavailable.
-	 *     wait_for_active_shards: string, // Sets the number of shard copies that must be active before proceeding with the update by query operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
-	 *     scroll_size: number, // Size on the scroll request powering the update by query
-	 *     wait_for_completion: boolean, // Should the request should block until the update by query operation is complete.
-	 *     requests_per_second: number, // The throttle to set on this request in sub-requests per second. -1 means no throttle.
-	 *     slices: number|string, // The number of slices this task should be divided into. Defaults to 1, meaning the task isn't sliced into subtasks. Can be set to `auto`.
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
-	 *     body: array, //  The search definition using the Query DSL
+	 *     analyzer?: string, // The analyzer to use for the query string
+	 *     analyze_wildcard?: boolean, // Specify whether wildcard and prefix queries should be analyzed (default: false)
+	 *     default_operator?: enum, // The default operator for query string query (AND or OR)
+	 *     df?: string, // The field to use as default where no field prefix is given in the query string
+	 *     from?: number, // Starting offset (default: 0)
+	 *     ignore_unavailable?: boolean, // Whether specified concrete indices should be ignored when unavailable (missing or closed)
+	 *     allow_no_indices?: boolean, // Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+	 *     conflicts?: enum, // What to do when the update by query hits version conflicts?
+	 *     expand_wildcards?: enum, // Whether to expand wildcard expression to concrete indices that are open, closed or both.
+	 *     lenient?: boolean, // Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
+	 *     pipeline?: string, // Ingest pipeline to set on index requests made by this action. (default: none)
+	 *     preference?: string, // Specify the node or shard the operation should be performed on (default: random)
+	 *     q?: string, // Query in the Lucene query string syntax
+	 *     routing?: list, // A comma-separated list of specific routing values
+	 *     scroll?: time, // Specify how long a consistent view of the index should be maintained for scrolled search
+	 *     search_type?: enum, // Search operation type
+	 *     search_timeout?: time, // Explicit timeout for each search request. Defaults to no timeout.
+	 *     max_docs?: number, // Maximum number of documents to process (default: all documents)
+	 *     sort?: list, // A comma-separated list of <field>:<direction> pairs
+	 *     terminate_after?: number, // The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early.
+	 *     stats?: list, // Specific 'tag' of the request for logging and statistical purposes
+	 *     version?: boolean, // Specify whether to return document version as part of a hit
+	 *     version_type?: boolean, // Should the document increment the version number (internal) on hit or not (reindex)
+	 *     request_cache?: boolean, // Specify if request cache should be used for this request or not, defaults to index level setting
+	 *     refresh?: boolean, // Should the affected indexes be refreshed?
+	 *     timeout?: time, // Time each individual bulk request should wait for shards that are unavailable.
+	 *     wait_for_active_shards?: string, // Sets the number of shard copies that must be active before proceeding with the update by query operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
+	 *     scroll_size?: number, // Size on the scroll request powering the update by query
+	 *     wait_for_completion?: boolean, // Should the request should block until the update by query operation is complete.
+	 *     requests_per_second?: number, // The throttle to set on this request in sub-requests per second. -1 means no throttle.
+	 *     slices?: number|string, // The number of slices this task should be divided into. Defaults to 1, meaning the task isn't sliced into subtasks. Can be set to `auto`.
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
+	 *     body?: array, //  The search definition using the Query DSL
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing
@@ -2064,12 +2064,12 @@ trait ClientEndpointsTrait
 	 *
 	 * @param array{
 	 *     task_id: string, // (REQUIRED) The task id to rethrottle
-	 *     requests_per_second: number, // The throttle to set on this request in floating sub-requests per second. -1 means set no throttle.
-	 *     pretty: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
-	 *     human: boolean, // Return human readable values for statistics. (DEFAULT: true)
-	 *     error_trace: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
-	 *     source: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-	 *     filter_path: list, // A comma-separated list of filters used to reduce the response.
+	 *     requests_per_second?: number, // The throttle to set on this request in floating sub-requests per second. -1 means set no throttle.
+	 *     pretty?: boolean, // Pretty format the returned JSON response. (DEFAULT: false)
+	 *     human?: boolean, // Return human readable values for statistics. (DEFAULT: true)
+	 *     error_trace?: boolean, // Include the stack trace of returned errors. (DEFAULT: false)
+	 *     source?: string, // The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+	 *     filter_path?: list, // A comma-separated list of filters used to reduce the response.
 	 * } $params
 	 *
 	 * @throws MissingParameterException if a required parameter is missing


### PR DESCRIPTION
This fixes #1424 in `Indices` and `ClientEndpointsTrait`
