### PR TITLE
Move PHPStan settings to it's config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "PHP Client for Elasticsearch",
   "keywords": [
     "search",
-    "client", 
+    "client",
     "elasticsearch",
     "elastic"
   ],
@@ -52,7 +52,7 @@
       "vendor/bin/phpunit --testdox -c phpunit-integration-cloud-tests.xml"
     ],
     "phpstan": [
-      "phpstan analyse src --level 2 --no-progress --memory-limit 256M"
+      "phpstan analyse --no-progress --memory-limit 256M"
     ]
   },
   "config": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,6 @@
 parameters:
+    level: 2
+    paths:
+        - src
     ignoreErrors:
         - '#PHPDoc tag @param has invalid value#'


### PR DESCRIPTION
This makes it so that developers can simply run `vendor/bin/phpstan` and that IDEs can correctly integrate with it for the project.

Also please share you fax number so that I may send you any notices permitted to be given by the CLA.