### PR TITLE
Upgrade `ezimuel/ringphp` to 1.3.0 to support React Promise v3 for Elasticsearch 6.8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   "require": {
     "php": "^7.3 || ^8.0",
     "ext-json": ">=1.3.7",
-    "ezimuel/ringphp": "^1.1.2",
+    "ezimuel/ringphp": "^1.3.0",
     "psr/log": "^1|^2"
   },
   "require-dev": {


### PR DESCRIPTION
This PR upgrades the `ezimuel/ringphp` dependency from version `1.2.2` to `1.3.0`.

Changes: https://github.com/ezimuel/ringphp/commit/5e4ee1dfc7a323b87873b83f17c69c76ba047793

### Motivation
The current version of ringphp (1.2.2) enforces a dependency on React Promise ~2.0, which conflicts with projects using React Promise v3.

Thank you in advance!