### PR TITLE
[docs] Clean up cross-repo links

### DIFF
--- a/docs/reference/iterators.md
+++ b/docs/reference/iterators.md
@@ -9,7 +9,7 @@ The PHP client includes helpers for iterating through results by page or by hits
 
 ## Search response iterator [search-response-iterator]
 
-Use the `SearchResponseIterator` to iterate page by page in a search result using [pagination](elasticsearch://docs/reference/elasticsearch/rest-apis/paginate-search-results.md).
+Use the `SearchResponseIterator` to iterate page by page in a search result using [pagination](elasticsearch://reference/elasticsearch/rest-apis/paginate-search-results.md).
 
 Here’s an example:
 
@@ -40,7 +40,7 @@ foreach($pages as $page) {
 
 ### Search hit iterator [search-hit-iterator]
 
-Use the `SearchHitIterator` to iterate in a `SearchResponseIterator` without worrying about [pagination](elasticsearch://docs/reference/elasticsearch/rest-apis/paginate-search-results.md).
+Use the `SearchHitIterator` to iterate in a `SearchResponseIterator` without worrying about [pagination](elasticsearch://reference/elasticsearch/rest-apis/paginate-search-results.md).
 
 Here’s an example:
 

--- a/docs/reference/search_operations.md
+++ b/docs/reference/search_operations.md
@@ -221,7 +221,7 @@ The scrolling functionality of {{es}} is used to paginate over many documents in
 
 Scrolling works by maintaining a "point in time" snapshot of the index which is then used to page over. This window allows consistent paging even if there is background indexing/updating/deleting. First, you execute a search request with `scroll` enabled. This returns a "page" of documents, and a `scroll_id` which is used to continue paginating through the hits.
 
-More details about scrolling can be found in the [reference documentation](elasticsearch://docs/reference/elasticsearch/rest-apis/paginate-search-results.md#scroll-search-results).
+More details about scrolling can be found in the [reference documentation](elasticsearch://reference/elasticsearch/rest-apis/paginate-search-results.md#scroll-search-results).
 
 This is an example which can be used as a template for more advanced operations:
 


### PR DESCRIPTION
Follow up to #1432 

When using cross-repo links, the path should be relative to the `docset.yml` not the full path within the repo ([updated docs-builder docs](https://elastic.github.io/docs-builder/syntax/links/#cross-repository-links)).