### PR TITLE
Fix instance returned by MessageResponseTrait

### DIFF
--- a/src/Traits/MessageResponseTrait.php
+++ b/src/Traits/MessageResponseTrait.php
@@ -29,12 +29,11 @@ trait MessageResponseTrait
         return $this->response->getProtocolVersion();
     }
 
-    /**
-     * @return MessageInterface
-     */
     public function withProtocolVersion($version): MessageInterface
     {
-        return $this->response->withProtocolVersion($version);
+        $this->response->withProtocolVersion($version);
+
+        return $this;
     }
 
     public function getHeaders(): array
@@ -57,44 +56,37 @@ trait MessageResponseTrait
         return $this->response->getHeaderLine($name);
     }
 
-    /**
-     * @return MessageInterface
-     */
     public function withHeader(string $name, $value): MessageInterface
     {
-        return $this->response->withHeader($name, $value);
+        $this->response->withHeader($name, $value);
+
+        return $this;
     }
 
-    /**
-     * @return MessageInterface
-     */
     public function withAddedHeader(string $name, $value): MessageInterface
     {
-        return $this->response->withAddedHeader($name, $value);
+        $this->response->withAddedHeader($name, $value);
+
+        return $this;
     }
 
-    /**
-     * @return MessageInterface
-     */
     public function withoutHeader(string $name): MessageInterface
     {
-        return $this->response->withoutHeader($name);
+        $this->response->withoutHeader($name);
+
+        return $this;
     }
 
-    /**
-     * @return StreamInterface
-     */
     public function getBody(): StreamInterface
     {
         return $this->response->getBody();
     }
 
-    /**
-     * @return MessageInterface
-     */
     public function withBody(StreamInterface $body): MessageInterface
     {
-        return $this->response->withBody($body);
+        $this->response->withBody($body);
+
+        return $this;
     }
 
     public function getStatusCode(): int
@@ -102,12 +94,11 @@ trait MessageResponseTrait
         return $this->response->getStatusCode();
     }
 
-    /**
-     * @return ResponseInterface
-     */
     public function withStatus(int $code, string $reasonPhrase = ''): ResponseInterface
     {
-        return $this->response->withStatus($code, $reasonPhrase);
+        $this->response->withStatus($code, $reasonPhrase);
+
+        return $this;
     }
 
     public function getReasonPhrase(): string


### PR DESCRIPTION
The PSR-7 ResponseInterface states that the method here should return an instance of the same class as the method is being called on but the trait instead returned an instance of the underlying implementation. Simply returning `$this` resolves the issue and likely is also what is intended by the ResponseInterface having a return type of `static`.

*Note that the failing tests here are the same as on the main branch and not related to the changes*