### PR TITLE
Remove deprecated 'php-http/message-factory' dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
     "nyholm/psr7": "^1.5",
     "php-http/mock-client": "^1.5",
     "symfony/http-client": "^5.0|^6.0|^7.0",
-    "psr/http-factory" : "^1.0",
-    "php-http/message-factory" : "^1.0"
+    "psr/http-factory" : "^1.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION

**Description:**

This PR closes #1441

Removed the dependency on `php-http/message-factory` from the `composer.json` file.

This update is aligned with the ongoing trend of deprecating `php-http/message-factory` in favor of `psr/http-factory` to ensure compatibility with modern libraries and to avoid using deprecated components.

**Evidence Collected from Other Package Changelogs:**

- `nyholm/psr7`

> Make dependency on php-http/message-factory optional.

- `php-http/message`

> Removed dependency on php-http/message-factory as it is abandoned and this package does not actually use it.

- `php-http/discovery`

> Dropped php-http/message-factory from composer requirements as it is deprecated in favor of PSR-17.

- `php-http/mock-client`

> Removed dependency on php-http/message-factory as the mock client does not use it.