### PR TITLE
[docs] Fix image paths for docs-assembler

### DIFF
--- a/docs/reference/connecting.md
+++ b/docs/reference/connecting.md
@@ -22,27 +22,19 @@ Where <cloud-id> and <api-key> can be retrieved using the Elastic Cloud web UI.
 
 You can get the `Cloud ID` from the `My deployment` page of your dashboard (see the red rectangle reported in the screenshot).
 
-:::{image} images/cloud_id.png
-:alt: Elastic Cloud ID
-:::
+![Elastic Cloud ID](images/cloud_id.png)
 
 You can generate an `API key` in the `Management` page under the section `Security`.
 
-:::{image} images/create_api_key.png
-:alt: Create API key
-:::
+![Create API key](images/create_api_key.png)
 
 When you click on `Create API key` button you can choose a name and set the other options (eg. restrict privileges, expire after time, etc).
 
-:::{image} images/api_key_name.png
-:alt: Choose an API name
-:::
+![Choose an API name](images/api_key_name.png)
 
 After this step you will get the `API key`in the API keys page.
 
-:::{image} images/cloud_api_key.png
-:alt: Cloud API key
-:::
+![Cloud API key](images/cloud_api_key.png)
 
 ***IMPORTANT***: you need to copy and store the `API key`in a secure place, since you will not be able to view it again in Elastic Cloud.
 

--- a/docs/reference/getting-started.md
+++ b/docs/reference/getting-started.md
@@ -53,15 +53,11 @@ $client = ClientBuilder::create()
 
 Your Elasticsearch endpoint can be found on the ***My deployment*** page of your deployment:
 
-:::{image} images/es_endpoint.jpg
-:alt: Finding Elasticsearch endpoint
-:::
+![Finding Elasticsearch endpoint](images/es_endpoint.jpg)
 
 You can generate an API key on the ***Management*** page under Security.
 
-:::{image} images/create_api_key.png
-:alt: Create API key
-:::
+![Create API key](images/create_api_key.png)
 
 For other connection options, refer to the [*Connecting*](/reference/connecting.md) section.
 


### PR DESCRIPTION
Fixes image paths to work with docs-assembler.

Notes for the reviewer:
* I was not able to get images in reference, extend, or release-notes to work using the `:::{image}` syntax because it seems to resolve differently than the Markdown `![]()` syntax. We should address this in docs-builder, but in order to get images working as soon as possible, I've used Markdown syntax and left us a `TO DO` in a code comment to add back the `screenshot` class where applicable. 
* Can you please add the appropriate labels needed for backporting?