### PR TITLE
[7.17] Added PHP 8.5 Support

### DIFF
--- a/.ci/test-matrix.yml
+++ b/.ci/test-matrix.yml
@@ -3,6 +3,7 @@ STACK_VERSION:
   - 7.17-SNAPSHOT
   
 PHP_VERSION:
+  - 8.5-cli
   - 8.4-cli
   - 8.3-cli
   - 8.2-cli

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
+        php-version: [7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5]
         os: [ubuntu-latest]
         es-version: [7.17-SNAPSHOT]
 


### PR DESCRIPTION
This MR introduces support for PHP 8.5 in conjunction with Elasticsearch 7.17. The changes ensure compatibility between the latest PHP features and the Elasticsearch client. Key updates include:

- Updated test to support PHP 8.5 runtime.
- Verified backward compatibility with PHP 8.4 and earlier versions.

These changes were thoroughly tested to maintain the stability and reliability of the integration while leveraging the latest PHP advancements.
