### PR TITLE
Added PHP 8.5 Support

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,6 +14,7 @@ steps:
         suite:
           - "platinum"
         php:
+          - "8.5-rc-cli"
           - "8.4-cli"
           - "8.3-cli"
           - "8.2-cli"

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [8.1, 8.2, 8.3, 8.4]
+        php-version: [8.1, 8.2, 8.3, 8.4, 8.5]
         os: [ubuntu-latest]
         es-version: [9.0.0-SNAPSHOT]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [8.1, 8.2, 8.3, 8.4]
+        php-version: [8.1, 8.2, 8.3, 8.4, 8.5]
         os: [ubuntu-latest]
         es-version: [9.0.0-SNAPSHOT]
 

--- a/.github/workflows/yaml_test.yml
+++ b/.github/workflows/yaml_test.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [8.1, 8.2, 8.3, 8.4]
+        php-version: [8.1, 8.2, 8.3, 8.4, 8.5]
         os: [ubuntu-latest]
         es-version: [9.0.0-SNAPSHOT]
         test-suite: [stack]


### PR DESCRIPTION
This MR introduces support for PHP 8.5. The changes ensure compatibility between the latest PHP features and the Elasticsearch client. Key updates include:

    Updated test to support PHP 8.5 runtime.
    Verified backward compatibility with PHP 8.4 and earlier versions.

These changes were thoroughly tested to maintain the stability and reliability of the integration while leveraging the latest PHP advancements.
