### PR TITLE
ESQL query builder prototype

### DIFF
--- a/src/Helper/Esql.php
+++ b/src/Helper/Esql.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Elasticsearch PHP Client
+ *
+ * @link      https://github.com/elastic/elasticsearch-php
+ * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
+ * @license   https://opensource.org/licenses/MIT MIT License
+ *
+ * Licensed to Elasticsearch B.V under one or more agreements.
+ * Elasticsearch B.V licenses this file to you under the MIT License.
+ * See the LICENSE file in the project root for more information.
+ */
+declare(strict_types = 1);
+
+namespace Elastic\Elasticsearch\Helper;
+
+abstract class ESQL {
+    public static function from(string ...$indices): From
+    {
+        return new From($indices);
+    }
+}
+
+abstract class ESQLBase {
+    private ?ESQLBase $parent = null;
+
+    public function render(): string
+    {
+        $query = "";
+        if ($this->parent) {
+            $query .= $this->parent->render() . "\n| ";
+        }
+        $query .= $this->render_internal();
+        return $query;
+    }
+
+    protected abstract function render_internal(): string;
+
+    public function __construct(ESQLBase $parent)
+    {
+        $this->parent = $parent;
+    }
+
+    public function __toString(): string
+    {
+        return $this->render();
+    }
+
+   public function where(string ...$expressions): Where
+    {
+        return new Where($this, $expressions);
+    }
+}
+
+class From extends ESQLBase {
+    private array $indices;
+
+    public function __construct(array $indices)
+    {
+        $this->indices = $indices;
+    }
+
+    protected function render_internal(): string
+    {
+        return "FROM " . implode(", ", $this->indices);
+    }
+}
+
+class Where extends ESQLBase {
+    private array $expressions;
+
+    public function __construct(ESQLBase $parent, array $expressions)
+    {
+        parent::__construct($parent);
+        $this->expressions = $expressions;
+    }
+
+    protected function render_internal(): string
+    {
+        return "WHERE " . implode(" AND ", $this->expressions);
+    }
+}


### PR DESCRIPTION
This PR contains a prototype of an ES|QL query builder feature for the PHP client.

Example usage:

```php
<?php

require(__DIR__ . "/vendor/autoload.php");

use Elastic\Elasticsearch\ClientBuilder;
use Elastic\Elasticsearch\Helper\ESQL;

$client = ClientBuilder::create()
    ->setHosts([getenv("ELASTICSEARCH_URL")])
    ->setApiKey(getenv("ELASTIC_API_KEY"))
    ->build();

$query = ESQL::from("books", "books*")
    ->where('author == "King"', 'year == 1982');
echo $query;

$result = $client->esql()->query([
    'body' => ['query' => $query->__toString()]
]);
```

The output of `echo $query` for the code above is:

```
FROM books, books*
| WHERE author == "King" AND year == 1982
```