### PR TITLE
fix: Custom Guzzle/Client Configuration Has Been Overwritten

### DIFF
--- a/src/Transport/Adapter/Guzzle.php
+++ b/src/Transport/Adapter/Guzzle.php
@@ -15,6 +15,7 @@ declare(strict_types = 1);
 namespace Elastic\Elasticsearch\Transport\Adapter;
 
 use Elastic\Elasticsearch\Transport\RequestOptions;
+use GuzzleHttp\Client;
 use GuzzleHttp\RequestOptions As GuzzleOptions;
 use Psr\Http\Client\ClientInterface;
 
@@ -38,7 +39,10 @@ class Guzzle implements AdapterInterface
                     $guzzleConfig[GuzzleOptions::VERIFY] = $value;
             }
         }
+        /** @var Client $client */
+        $clientOptions = array_merge($clientOptions, $client->getConfig());
         $class = get_class($client);
+
         return new $class(array_merge($clientOptions, $guzzleConfig));
     }
 }

--- a/src/Transport/Adapter/Guzzle.php
+++ b/src/Transport/Adapter/Guzzle.php
@@ -40,7 +40,10 @@ class Guzzle implements AdapterInterface
             }
         }
         /** @var Client $client */
-        $clientOptions = array_merge($clientOptions, $client->getConfig());
+        if(method_exists($client, 'getConfig')){
+            $clientOptions = array_merge($clientOptions, $client->getConfig());
+        }
+
         $class = get_class($client);
 
         return new $class(array_merge($clientOptions, $guzzleConfig));

--- a/tests/Transport/Adapter/GuzzleTest.php
+++ b/tests/Transport/Adapter/GuzzleTest.php
@@ -17,6 +17,7 @@ namespace Elastic\Elasticsearch\Tests\Transport\Adapter;
 use Elastic\Elasticsearch\Transport\Adapter\Guzzle;
 use Elastic\Elasticsearch\Transport\RequestOptions;
 use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
 use GuzzleHttp\RequestOptions As GuzzleOptions;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientInterface;
@@ -64,5 +65,12 @@ class GuzzleTest extends TestCase
         $result = $this->guzzleAdapter->setConfig(new Client(), [ RequestOptions::SSL_CA => 'test'], []);
         $this->assertInstanceOf(Client::class, $result);
         $this->assertEquals('test', $result->getConfig(GuzzleOptions::VERIFY));
+    }
+
+    public function testSetConfigButNotOverwrittenClientOptions()
+    {
+        $result = $this->guzzleAdapter->setConfig(new Client(['base_uri' => 'http://localhost:12345']), [ RequestOptions::SSL_CA => 'test'], []);
+        $this->assertInstanceOf(Client::class, $result);
+        $this->assertEquals('http://localhost:12345', $result->getConfig('base_uri'));
     }
 }


### PR DESCRIPTION
<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you signed [Contributor License Agreement](https://www.elastic.co/contributor-agreement)?
PR's (no matter how small) cannot be merged until the CLA has been signed.  It only needs to be signed once,
however.

- Have you read the [Contributing Guidelines](https://github.com/elastic/elasticsearch-php/blob/master/.github/CONTRIBUTING.md)?

If you answered yes to both, thanks for the PR and we'll get to it ASAP! :)

-->

```php
        $builder = ClientBuilder::create();
        $client = new \GuzzleHttp\Client(['handler' => HandlerStack::create(new CoroutineHandler())]);

        $builder->setHttpClient($client);
        $this->client = $builder->setHosts(explode(',', config('elastic.endpoint')))
            ->setSSLVerification(false)
            ->build();
```

In the Hyperf framework, when using coroutine cURL and customizing the Handler as shown in the code above, the client set by $builder->setHttpClient($client) does not take effect after build.

(Translation by AI)


