### PR TITLE
Remove CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,0 @@
-# These owners will be the default owners for everything in
-# the repo.
-*       @elastic/devtools-team


### PR DESCRIPTION
There is no need to include the whole team as a reviewer. Removing the `CODEOWNERS` file will cut down on notifications sent to team members. None of the other dynamic languages have this file.