### PR TITLE
Stop running builds on buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,20 +4,21 @@ steps:
   - label: ":elasticsearch: :php: ES PHP ({{ matrix.php }}) Test Suite: {{ matrix.suite }}"
     agents:
       provider: "gcp"
-    env:
-      PHP_VERSION: "{{ matrix.php }}"
-      TEST_SUITE: "{{ matrix.suite }}"
-      STACK_VERSION: 9.3.0-SNAPSHOT
-      BRANCH_CLIENT_TESTS: 9.2
-    matrix:
-      setup:
-        suite:
-          - "platinum"
-        php:
-          - "8.5-cli"
-          - "8.4-cli"
-          - "8.3-cli"
-          - "8.2-cli"
-          - "8.1-cli"
-    command: ./.buildkite/run-tests
-    artifact_paths: "*.xml"
+    # env:
+    #   PHP_VERSION: "{{ matrix.php }}"
+    #   TEST_SUITE: "{{ matrix.suite }}"
+    #   STACK_VERSION: 9.3.0-SNAPSHOT
+    #   BRANCH_CLIENT_TESTS: 9.2
+    # matrix:
+    #   setup:
+    #     suite:
+    #       - "platinum"
+    #     php:
+    #       - "8.5-cli"
+    #       - "8.4-cli"
+    #       - "8.3-cli"
+    #       - "8.2-cli"
+    #       - "8.1-cli"
+    # command: ./.buildkite/run-tests
+    # artifact_paths: "*.xml"
+    command: echo Not used


### PR DESCRIPTION
I'm commenting out the buildkite builds, since we currently run all the integration tests on GitHub Actions.