### PR TITLE
skip yaml tests that require feature flags

### DIFF
--- a/tests/BuildPHPUnitClass.php
+++ b/tests/BuildPHPUnitClass.php
@@ -33,7 +33,10 @@ class BuildPHPUnitClass
 {
     protected mixed $yaml;
 
-    public function __construct(private string $filename, private string $testGroup, private string $namespace)
+    /**
+     * @param array<int, string> $featureFlags
+     */
+    public function __construct(private string $filename, private string $testGroup, private string $namespace, private array $featureFlags)
     {
         // parse the YAML content
         $content = file_get_contents($filename);
@@ -57,6 +60,12 @@ class BuildPHPUnitClass
     public function build(): ?PhpNamespace
     {
         if (!$this->yaml[0]['requires'][$this->testGroup]) {
+            return null;
+        }
+        if (
+            isset($this->yaml[0]['requires']['feature_flag']) &&
+            !in_array($this->yaml[0]['requires']['feature_flag'], $this->featureFlags)
+        ) {
             return null;
         }
 

--- a/tests/build_es_tests.php
+++ b/tests/build_es_tests.php
@@ -98,7 +98,7 @@ foreach (new RecursiveIteratorIterator($it) as $file) {
         mkdir($unitTestFolder);
     }
     $namespace = $folderName === 'Tests' ? basename($outputFolder) : sprintf("%s\%s", basename($outputFolder), $folderName);
-    $test = new BuildPHPUnitClass($file->getPathname(), $testGroup, $namespace);
+    $test = new BuildPHPUnitClass($file->getPathname(), $testGroup, $namespace, []);
     $unitTest = $test->build();
     if (empty($unitTest)) {
         printf("Skipped (not %s): %s\n", $testGroup, $file->getPathname());


### PR DESCRIPTION
This change adds a `$featureFlags` option to the `BuildPHPUnitClass`, so that we can specify which feature flags are enabled in the server. This is used to filter out tests that require feature flags that are not enabled.

The default test runner for our CI indicates that no feature flags are enabled, to prevent errors when calling endpoints that are not generated in the client.