### PR TITLE
delete old endpoints before generating new ones

### DIFF
--- a/.github/make.sh
+++ b/.github/make.sh
@@ -191,6 +191,7 @@ if [[ "$CMD" == "codegen" ]]; then
       git clone https://$CLIENTS_GITHUB_TOKEN@github.com/elastic/elastic-client-generator-php.git && \
       cd /code/elastic-client-generator-php && composer install && \
       bin/elasticsearch9.php $ES_VERSION $BRANCH /code/codegen config/elasticsearch9.json && \
+      find /code/elasticsearch-php/src/Endpoints/ -name "*.php" -not -name AbstractEndpoint.php -exec rm {} \;
       cp /code/codegen/Elastic/Elasticsearch/Endpoints/* /code/elasticsearch-php/src/Endpoints/ && \
       cp /code/codegen/Elastic/Elasticsearch/Traits/* /code/elasticsearch-php/src/Traits/"
 fi


### PR DESCRIPTION
This PR adds a small change to the code generation action. The generated endpoints were copied directly on top of the current ones, which is normally fine, except when a namespace is deleted, which leaves an orphaned namespace source file. This change deletes the namespace source files before copying the ones from the generator, so that source files that are unused are removed.

I have found there is currently one such files in the repository in file ProjectRouting.php.