### PR TITLE
fix: add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,4 +1,9 @@
 name: Backport
+
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   pull_request_target:
     types:


### PR DESCRIPTION
InfoSec is changing GITHUB_TOKEN default permissions from read/write to read-only on July 15th. Adding explicit `permissions` blocks to all workflows that require write access.

## Changes
- `.github/workflows/backport.yml`: added `contents: write` and `pull-requests: write`