### PR TITLE
[Backport 8.19] ci: add x-access-token user to make.sh script

### DIFF
--- a/.github/make.sh
+++ b/.github/make.sh
@@ -202,7 +202,7 @@ if [[ "$CMD" == "codegen" ]]; then
       --rm -v $repo:/code/elasticsearch-php \
       $product \
       /bin/bash -x -c "cd /code && mkdir codegen && \
-      git clone https://$CLIENTS_GITHUB_TOKEN@github.com/elastic/elastic-client-generator-php.git && \
+      git clone https://x-access-token:$CLIENTS_GITHUB_TOKEN@github.com/elastic/elastic-client-generator-php.git && \
       cd /code/elastic-client-generator-php && composer install && \
       bin/elasticsearch9.php $ES_VERSION $BRANCH /code/codegen config/elasticsearch9.json && \
       cp /code/codegen/Elastic/Elasticsearch/Endpoints/* /code/elasticsearch-php/src/Endpoints/ && \


### PR DESCRIPTION
Codegen is failing since switching to ephemeral tokens with `fatal: could not read Password for 'https://***@github.com': No such device or address`

This is working for [elasticsearch-js](https://github.com/elastic/elasticsearch-js/blob/4b336837419c49d3faee6ac34dbf7e3f10e7df80/.github/make.sh#L179) which uses `https://x-access-token:$CLIENTS_GITHUB_TOKEN@github.com/elastic/elastic-client-generator-js.git`

(cherry picked from commit 5337e752b36c99e94abf0e62c449c8693b322c63)

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you signed [Contributor License Agreement](https://www.elastic.co/contributor-agreement)?
PR's (no matter how small) cannot be merged until the CLA has been signed.  It only needs to be signed once,
however.

- Have you read the [Contributing Guidelines](https://github.com/elastic/elasticsearch-php/blob/master/.github/CONTRIBUTING.md)?

If you answered yes to both, thanks for the PR and we'll get to it ASAP! :)

-->
