### PR TITLE
Allow guzzlehttp/guzzle 8.0 in dev-dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "nyholm/psr7": "^1.8",
     "php-http/mock-client": "^1.6",
     "psr/http-factory" : "^1.0",
-    "guzzlehttp/guzzle": "^7.0",
+    "guzzlehttp/guzzle": "^7.0|^8.0",
     "symfony/http-client": "^6.0|^7.0",
     "nette/php-generator": "^4.0"
   },


### PR DESCRIPTION
<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you signed [Contributor License Agreement](https://www.elastic.co/contributor-agreement)?
PR's (no matter how small) cannot be merged until the CLA has been signed.  It only needs to be signed once,
however.

- Have you read the [Contributing Guidelines](https://github.com/elastic/elasticsearch-php/blob/master/.github/CONTRIBUTING.md)?

If you answered yes to both, thanks for the PR and we'll get to it ASAP! :)

-->

Allow guzzlehttp/guzzle 8.0 to unblock upgrades of other packages.